### PR TITLE
Switch Harbor storage from S3 to filesystem

### DIFF
--- a/tooling/base/harbor/harbor-helmrelease.yaml
+++ b/tooling/base/harbor/harbor-helmrelease.yaml
@@ -32,10 +32,12 @@ spec:
       imageChartStorage:
         # An issue prevents from using IRSA: https://github.com/goharbor/harbor/pull/18686
         # Currently this is not possible to push to S3 bucket
-        type: s3
-        s3:
-          region: ${region}
-          bucket: ${region}-ogenki-harbor
+        # type: s3
+        # s3:
+        #   region: ${region}
+        #   bucket: ${region}-ogenki-harbor
+        # Use PVC while waiting for the above issue to be solved
+        type: filesystem
 
     existingSecretAdminPassword: harbor-admin-password
     existingSecretAdminPasswordKey: password


### PR DESCRIPTION
## Type
Refactoring

___
## Description
This PR modifies the Harbor Helm release configuration to use a Persistent Volume Claim (PVC) for storing Helm charts and Docker images, instead of an S3 bucket. This change is temporary and due to an issue that prevents the use of IRSA with S3. Once the issue is resolved, the storage type will be switched back to S3.

___
## Main files walkthrough
<details> <summary>files:</summary>

- `tooling/base/harbor/harbor-helmrelease.yaml`: The storage type for imageChartStorage has been changed from 's3' to 'filesystem'. The configuration for the 's3' type has been commented out and will be reinstated once the issue with IRSA is resolved.
</details>
