### PR TITLE
Enable EKS Pod Identity Agent in Terraform EKS module

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -26,6 +26,9 @@ module "eks" {
     vpc-cni = {
       most_recent = true
     }
+    eks-pod-identity-agent = {
+      most_recent = true
+    }
   }
 
   manage_aws_auth_configmap = true


### PR DESCRIPTION
## Type
Enhancement

___
## Description
This PR introduces the following changes:
- Enables the EKS Pod Identity Agent in the Terraform EKS module. This is done by adding a new addon `eks-pod-identity-agent` in the module configuration.

___
## PR changes summary

| | Relevant Files &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; |
|-----------|-------------|
| **configuration changes** | <details><summary>files:</summary><ul><details><summary>**main.tf** <sup>[ ( +3/-0 )](https://github.com/Smana/demo-secured-eks/pull/22/files#diff-417ec24690b4cefab94c36369121105f6a398a3640e69aab37f04c36bd48840d)</sup></summary><ul>Changes summary:<br>**Added a new addon `eks-pod-identity-agent` in the EKS module <br>configuration.**</ul></details></ul></details>|
