### PR TITLE
🔧 chore: increase Karpenter CPU limit from 20 to 21

### DIFF
--- a/opentofu/eks/variables.tfvars
+++ b/opentofu/eks/variables.tfvars
@@ -14,7 +14,7 @@ cert_manager_approle_secret_name = "openbao/cloud-native-ref/approles/cert-manag
 
 karpenter_limits = {
   "default" = {
-    cpu    = "20"
+    cpu    = "21"
     memory = "64Gi"
   }
   "io" = {


### PR DESCRIPTION
### **User description**
Adjust default Karpenter resource limits to accommodate additional workload capacity.


___

### **PR Type**
Enhancement


___

### **Description**
- Increased Karpenter CPU limit.

- Improved workload capacity.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[variables.tfvars] --> B{Increased CPU limit from 20 to 21};
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tfvars</strong><dd><code>Increased Karpenter CPU Limit in `variables.tfvars`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

opentofu/eks/variables.tfvars

<ul><li>Increased the CPU limit in the <code>karpenter_limits</code> block from 20 to 21 <br>for the <code>default</code> profile.<br> <li> No changes were made to the <code>io</code> profile's CPU limit, which remains at <br>20.<br> <li> The memory limit for the <code>default</code> profile remains unchanged at 64Gi.</ul>


</details>


  </td>
  <td><a href="https://github.com/Smana/cloud-native-ref/pull/1081/files#diff-7f81dd492857d60ad3d57285bad906949a0d832433b91707321f41a846d66f5e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

