### PR TITLE
fix(dns): enable sync mode and improve gateway access control

### DIFF
--- a/docs/tailscale-gateway-api.md
+++ b/docs/tailscale-gateway-api.md
@@ -3,8 +3,8 @@
 This platform uses Gateway API with Tailscale to provide secure, custom domain access to private services (`*.priv.cloud.ogenki.io`) without exposing them to the internet.
 
 **Access Segregation**: The platform uses **two separate Gateways** with different Tailscale tags to enforce access control via ACLs:
-- **General Gateway** (`tag:k8s`): Accessible to all Tailscale members
-- **Admin Gateway** (`tag:admin`): Restricted to `group:admin` only
+- **General Gateway** (`tag:k8s`): Accessible to all users in the tailnet (not public)
+- **Admin Gateway** (`tag:admin`): Restricted to specific allowed people in `group:admin`
 
 ## Architecture Overview
 
@@ -23,12 +23,12 @@ flowchart TB
         externaldns["🔄 ExternalDNS<br/>Watches HTTPRoutes<br/>Creates Route53 records"]
 
         subgraph gateways["🚪 Gateways"]
-            general["General Gateway<br/>tag:k8s<br/>8 services"]
-            adminGW["Admin Gateway<br/>tag:admin<br/>5 services"]
+            general["General Gateway<br/>tag:k8s<br/>10 services"]
+            adminGW["Admin Gateway<br/>tag:admin<br/>3 services"]
         end
 
-        generalSvc["🎯 General Services<br/>Harbor, Grafana, etc"]
-        adminSvc["🔒 Admin Services<br/>Hubble UI, VictoriaLogs, OnCall"]
+        generalSvc["🎯 General Services<br/>Harbor, Grafana, VictoriaLogs, etc"]
+        adminSvc["🔒 Admin Services<br/>Hubble UI, Grafana OnCall"]
     end
 
     admin -->|"✅ Full Access"| route53
@@ -62,15 +62,15 @@ flowchart TB
 ### Choose the Right Gateway
 
 **General Gateway** (`platform-tailscale-general`) - Use for:
-- Public-facing platform tools (Harbor, Headlamp, Homepage)
+- Platform tools (Harbor, Headlamp, Homepage)
 - Monitoring dashboards (Grafana, VictoriaMetrics)
-- Services accessible to all team members
+- Log aggregation (VictoriaLogs)
+- Services accessible to all users in the tailnet
 
 **Admin Gateway** (`platform-tailscale-admin`) - Use for:
 - Infrastructure observability (Hubble UI)
-- Log aggregation (VictoriaLogs)
 - Incident management (Grafana OnCall)
-- Sensitive operational services
+- Highly sensitive operational services
 
 ### Create HTTPRoute
 
@@ -177,8 +177,8 @@ acls = [
 ```
 
 **Service Distribution**:
-- **General Gateway** (8 services): Harbor, Headlamp, Homepage, Grafana, VictoriaMetrics (vmagent, vmalertmanager, vmsingle, vmcluster)
-- **Admin Gateway** (5 services): Hubble UI, VictoriaLogs (vlsingle, vlcluster), Grafana OnCall, OnCall RabbitMQ
+- **General Gateway** (10 services): Harbor, Headlamp, Homepage, Grafana, VictoriaMetrics (vmagent, vmalertmanager, vmsingle, vmcluster), VictoriaLogs (vlsingle, vlcluster)
+- **Admin Gateway** (3 services): Hubble UI, Grafana OnCall, OnCall RabbitMQ
 
 ## How It Works
 

--- a/infrastructure/base/external-dns/helmrelease.yaml
+++ b/infrastructure/base/external-dns/helmrelease.yaml
@@ -37,11 +37,16 @@ spec:
     logFormat: json
     txtOwnerId: "${cluster_name}"
 
+    # Sync mode: automatically cleanup stale DNS records
+    policy: sync
+
     # Extra arguments for Gateway filtering
     extraArgs:
       # Watch HTTPRoutes from platform-tailscale Gateway
       - --gateway-namespace=infrastructure
       - --gateway-label-filter=external-dns=enabled
+      # Prevent rapid deletions during temporary issues
+      - --min-event-sync-interval=30s
     resources:
       limits:
         memory: 100Mi

--- a/observability/base/victoria-logs/httproute-vlcluster.yaml
+++ b/observability/base/victoria-logs/httproute-vlcluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: observability
 spec:
   parentRefs:
-    - name: platform-tailscale-admin
+    - name: platform-tailscale-general
       namespace: infrastructure
   hostnames:
     - "vl.priv.${domain_name}"

--- a/observability/base/victoria-logs/httproute-vlsingle.yaml
+++ b/observability/base/victoria-logs/httproute-vlsingle.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: observability
 spec:
   parentRefs:
-    - name: platform-tailscale-admin
+    - name: platform-tailscale-general
       namespace: infrastructure
   hostnames:
     - "vl.priv.${domain_name}"


### PR DESCRIPTION
## 🔍 Type: fix

## 📝 Summary

This PR resolves DNS stale record issues by enabling external-dns sync mode and improves Tailscale Gateway API access control by moving VictoriaLogs to the general gateway. The sync policy ensures automatic cleanup of orphaned DNS records during cluster recreations, preventing connectivity failures like the recent `home.priv.cloud.ogenki.io` incident.

## 🎯 Key Changes

- Enable external-dns `policy: sync` to automatically delete stale DNS records
- Add `--min-event-sync-interval=30s` safeguard to prevent rapid deletions during temporary issues
- Move VictoriaLogs HTTPRoutes from admin gateway to general gateway (broader team access)
- Update Tailscale Gateway API documentation to clarify access model (tailnet-wide vs admin-only)
- Fix service count distribution in diagrams (General: 8→10, Admin: 5→3)

## 📊 Architecture Changes

```mermaid
flowchart LR
    extdns["external-dns"]:::changed
    general["General Gateway<br/>10 services"]:::changed
    admin["Admin Gateway<br/>3 services"]:::changed
    vl["VictoriaLogs"]:::moved
    
    extdns -- "sync policy<br/>auto-cleanup" --> route53["Route53 DNS"]
    vl -. "moved from" .-> admin
    vl -- "now on" --> general
    
    classDef changed fill:#1e3a8a,stroke:#3b82f6,stroke-width:3px,color:#fff
    classDef moved fill:#059669,stroke:#10b981,stroke-width:3px,color:#fff
```

## 🗂️ Files Changed

| File | Type | Description |
|------|------|-------------|
| `infrastructure/base/external-dns/helmrelease.yaml` | fix | Enable sync policy and min-event-sync-interval |
| `observability/base/victoria-logs/httproute-vlcluster.yaml` | refactor | Move to general gateway |
| `observability/base/victoria-logs/httproute-vlsingle.yaml` | refactor | Move to general gateway |
| `docs/tailscale-gateway-api.md` | docs | Update access model and service distribution |

<details>
<summary>📋 Detailed Changes</summary>

### infrastructure/base/external-dns/helmrelease.yaml
- **Added**: `policy: sync` to enable automatic stale record cleanup
- **Added**: `--min-event-sync-interval=30s` to prevent rapid deletions during Flux issues
- **Impact**: Prevents orphaned DNS records after cluster recreation (fixes home.priv.cloud.ogenki.io issue)

### observability/base/victoria-logs/httproute-vlcluster.yaml
- **Changed**: `parentRefs.name` from `platform-tailscale-admin` to `platform-tailscale-general`
- **Impact**: VictoriaLogs accessible to all tailnet users (not just admins)

### observability/base/victoria-logs/httproute-vlsingle.yaml
- **Changed**: `parentRefs.name` from `platform-tailscale-admin` to `platform-tailscale-general`
- **Impact**: VictoriaLogs accessible to all tailnet users (not just admins)

### docs/tailscale-gateway-api.md
- **Clarified**: General Gateway is "accessible to all users in the tailnet (not public)"
- **Updated**: Service distribution counts (General: 8→10, Admin: 5→3)
- **Updated**: Mermaid diagram to reflect VictoriaLogs on general gateway
- **Updated**: Gateway selection guidance to include VictoriaLogs under general services

</details>

## 🐛 Problem Solved

**Issue**: After cluster recreation, `home.priv.cloud.ogenki.io` was unreachable because:
1. Old DNS record pointed to stale Tailscale IP (100.103.159.24)
2. New gateway got different IP (100.99.218.96)
3. external-dns (with `upsert-only` policy) refused to update orphaned records without TXT ownership

**Root Cause**: DNS records from previous cluster had no TXT ownership markers, so external-dns ignored them.

**Solution**: `policy: sync` makes external-dns delete records not matching current sources, automatically cleaning up stale entries.

## ✅ Testing

After deployment, verify:
```bash
# Watch external-dns cleanup stale records
kubectl logs -n kube-system -l app.kubernetes.io/name=external-dns -f | grep -i delete

# Should see cleanup of:
# - image-gallery.priv.cloud.ogenki.io (100.103.159.24)
# - podinfo.priv.cloud.ogenki.io (100.103.159.24)
# - Old CNAME records for deleted gateways

# Verify VictoriaLogs on general gateway
kubectl get httproute -n observability victoria-logs -o yaml | grep -A 3 "parentRefs:"
```

## 🏷️ Labels

`fix`, `dns`, `external-dns`, `observability`, `gateway-api`, `tailscale`, `documentation`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
