### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Cloud Native Platform Reference
 
+[![Run in Smithery](https://smithery.ai/badge/skills/smana)](https://smithery.ai/skills?ns=smana&utm_source=github&utm_medium=badge)
+
+
 **_An opinionated, production-ready Kubernetes platform using GitOps principles._**
 
 This repository demonstrates how to build and operate a secure, scalable cloud-native platform. It showcases modern cloud-native technologies, GitOps workflows, and platform engineering best practices.


### PR DESCRIPTION
## Add skill discoverability badge

Your 2 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/Smana)](https://smithery.ai/skills?ns=Smana&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.