### PR TITLE
fix(eks): remove k8s provider from cluster-creating stage

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -336,15 +336,6 @@
         "line_number": 31
       }
     ],
-    "opentofu/eks/init/variables.tfvars": [
-      {
-        "type": "Secret Keyword",
-        "filename": "opentofu/eks/init/variables.tfvars",
-        "hashed_secret": "cf6b2ae93c70a7fb628cbb8d9cd7ec0b7e4661e5",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
     "opentofu/network/README.md": [
       {
         "type": "Secret Keyword",
@@ -512,5 +503,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-07T11:20:04Z"
+  "generated_at": "2026-06-04T17:27:28Z"
 }

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -13,8 +13,8 @@ globals {
 
   # Helm chart versions for EKS bootstrap
   cilium_version        = "1.19.0"
-  flux_operator_version = "0.48.0"
-  flux_instance_version = "0.48.0"
+  flux_operator_version = "0.50.0"
+  flux_instance_version = "0.50.0"
 
   # Flux sync configuration
   flux_sync_repository_url = "https://github.com/Smana/cloud-native-ref.git"

--- a/opentofu/eks/configure/data.tf
+++ b/opentofu/eks/configure/data.tf
@@ -1,3 +1,46 @@
 data "aws_eks_cluster" "this" {
   name = var.cluster_name
 }
+
+data "aws_caller_identity" "this" {}
+
+# Re-derived here (rather than read from eks/init remote state) to keep this
+# stage self-contained. Same tag filters as the VPC created by opentofu/network.
+data "aws_vpc" "selected" {
+  filter {
+    name   = "tag:project"
+    values = ["cloud-native-ref"]
+  }
+  filter {
+    name   = "tag:owner"
+    values = ["Smana"]
+  }
+  filter {
+    name   = "tag:environment"
+    values = [var.env]
+  }
+}
+
+data "aws_route53_zone" "public" {
+  name         = var.public_domain_name
+  private_zone = false
+}
+
+# OIDC provider ARN for the cluster IRSA/EPI issuer — re-derived from the
+# cluster's OIDC issuer URL instead of reading module.eks output via remote state.
+data "aws_iam_openid_connect_provider" "this" {
+  url = data.aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
+
+data "aws_secretsmanager_secret_version" "github_app" {
+  secret_id = var.github_app_secret_name
+}
+
+data "aws_secretsmanager_secret_version" "cert_manager_approle" {
+  secret_id = var.cert_manager_approle_secret_name
+}
+
+data "http" "gateway_api_crds" {
+  count = length(local.gateway_api_crds_urls)
+  url   = local.gateway_api_crds_urls[count.index]
+}

--- a/opentofu/eks/configure/kubernetes.tf
+++ b/opentofu/eks/configure/kubernetes.tf
@@ -1,4 +1,15 @@
-# Install Gateway API CRD's. Requirement to be installed before Cilium is running.
+# Cluster-internal bootstrap resources.
+#
+# These were moved here from eks/init. They must NOT live in the cluster-creating
+# stage: there the kubectl/kubernetes providers would be configured from
+# module.eks.* outputs that don't exist until the same apply runs, and
+# alekc/kubectl cannot defer provider configuration with unknown values
+# (fails with "no configuration has been provided, try setting KUBERNETES_MASTER").
+# This is the same reason terraform-aws-modules/eks removed the Kubernetes
+# provider from the module in v20. Here the cluster already exists
+# (data.aws_eks_cluster.this + exec auth), so the providers configure cleanly.
+
+# Install Gateway API CRDs. Requirement to be installed before Cilium is running.
 # `force_conflicts = true` because Flux's `crds-gateway-api` Kustomization
 # (kube-system) takes over field-managership after the cluster is up — on
 # subsequent re-deploys Tofu would otherwise fail with SSA conflicts on
@@ -11,12 +22,7 @@ resource "kubectl_manifest" "gateway_api_crds" {
   server_side_apply = true
   force_conflicts   = true
   wait              = true
-  depends_on        = [module.eks.cluster_name]
 }
-
-# Cilium CNI ConfigMap is created in Stage 2 (opentofu/eks/configure/)
-# Cilium and Flux are deployed via Stage 2
-# See: cd opentofu/eks/configure && terramate script run deploy
 
 # Create flux-system namespace first (required for secrets and ConfigMap)
 resource "kubectl_manifest" "flux_system_namespace" {
@@ -28,7 +34,6 @@ resource "kubectl_manifest" "flux_system_namespace" {
     }
   })
   server_side_apply = true
-  depends_on        = [module.eks]
 }
 
 # ConfigMap with cluster variables for Flux substitution
@@ -37,19 +42,19 @@ resource "kubectl_manifest" "flux_cluster_vars" {
     apiVersion = "v1"
     kind       = "ConfigMap"
     metadata = {
-      name      = "eks-${var.name}-vars"
+      name      = "eks-${var.cluster_name}-vars"
       namespace = "flux-system"
       labels = {
         "reconcile.fluxcd.io/watch" = "Enabled"
       }
     }
     data = {
-      cluster_name           = var.name
-      cluster_endpoint       = replace(module.eks.cluster_endpoint, "https://", "")
-      cluster_endpoint_full  = module.eks.cluster_endpoint
-      oidc_provider_arn      = module.eks.oidc_provider_arn
-      oidc_issuer_url        = module.eks.cluster_oidc_issuer_url
-      oidc_issuer_host       = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+      cluster_name           = var.cluster_name
+      cluster_endpoint       = replace(data.aws_eks_cluster.this.endpoint, "https://", "")
+      cluster_endpoint_full  = data.aws_eks_cluster.this.endpoint
+      oidc_provider_arn      = data.aws_iam_openid_connect_provider.this.arn
+      oidc_issuer_url        = local.oidc_issuer_url
+      oidc_issuer_host       = local.oidc_issuer_host
       aws_account_id         = data.aws_caller_identity.this.account_id
       region                 = var.region
       environment            = var.env
@@ -58,7 +63,7 @@ resource "kubectl_manifest" "flux_cluster_vars" {
       public_domain_name     = var.public_domain_name
       vpc_id                 = data.aws_vpc.selected.id
       vpc_cidr_block         = data.aws_vpc.selected.cidr_block
-      karpenter_queue_name   = module.karpenter.queue_name
+      karpenter_queue_name   = local.karpenter_queue_name
       route53_public_zone_id = data.aws_route53_zone.public.zone_id
     }
   })
@@ -68,11 +73,6 @@ resource "kubectl_manifest" "flux_cluster_vars" {
 
 # Create secrets using kubectl_manifest instead of kubernetes_secret
 # to avoid plan-time validation issues with the kubernetes provider
-locals {
-  cert_manager_approle = jsondecode(data.aws_secretsmanager_secret_version.cert_manager_approle.secret_string)
-  github_app_secret    = jsondecode(data.aws_secretsmanager_secret_version.github_app.secret_string)
-}
-
 resource "kubectl_manifest" "flux_cert_manager_approle" {
   yaml_body = yamlencode({
     apiVersion = "v1"
@@ -128,8 +128,6 @@ resource "kubectl_manifest" "gp3_storageclass" {
       type: gp3
   YAML
   server_side_apply = true
-
-  depends_on = [module.eks]
 }
 
 # Remove gp2 as default StorageClass
@@ -148,6 +146,4 @@ resource "kubectl_manifest" "gp2_not_default" {
     volumeBindingMode: WaitForFirstConsumer
   YAML
   server_side_apply = true
-
-  depends_on = [module.eks]
 }

--- a/opentofu/eks/configure/locals.tf
+++ b/opentofu/eks/configure/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  # Gateway API CRDs installed before Cilium (Cilium's Gateway API support
+  # requires these CRDs to exist). Version must match
+  # flux/sources/gitrepo-gateway-api.yaml ref.
   gateway_api_crds_urls = [
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml",
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml",
@@ -9,4 +12,15 @@ locals {
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml",
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml"
   ]
+
+  cert_manager_approle = jsondecode(data.aws_secretsmanager_secret_version.cert_manager_approle.secret_string)
+  github_app_secret    = jsondecode(data.aws_secretsmanager_secret_version.github_app.secret_string)
+
+  oidc_issuer_url  = data.aws_eks_cluster.this.identity[0].oidc[0].issuer
+  oidc_issuer_host = replace(local.oidc_issuer_url, "https://", "")
+
+  # Karpenter SQS queue name. The terraform-aws-modules karpenter submodule
+  # defaults to "Karpenter-<cluster_name>" (coalesce(var.queue_name, ...)) and
+  # eks/init does not override queue_name, so this matches the created queue.
+  karpenter_queue_name = "Karpenter-${var.cluster_name}"
 }

--- a/opentofu/eks/configure/main.tf
+++ b/opentofu/eks/configure/main.tf
@@ -45,6 +45,7 @@ resource "helm_release" "cilium" {
   depends_on = [
     kubectl_manifest.disable_vpc_cni,
     kubectl_manifest.cilium_cni_config,
+    kubectl_manifest.gateway_api_crds, # Gateway API CRDs must exist before Cilium
   ]
 
   name             = "cilium"
@@ -124,14 +125,17 @@ resource "kubectl_manifest" "disable_kube_proxy" {
 # Step 5: Install Flux Operator
 # =============================================================================
 resource "helm_release" "flux_operator" {
-  depends_on = [kubectl_manifest.disable_kube_proxy]
+  depends_on = [
+    kubectl_manifest.disable_kube_proxy,
+    kubectl_manifest.flux_system_namespace, # flux-system namespace must exist first
+  ]
 
   name             = "flux-operator"
   repository       = "oci://ghcr.io/controlplaneio-fluxcd/charts"
   chart            = "flux-operator"
   version          = var.flux_operator_version
   namespace        = "flux-system"
-  create_namespace = false # Created by Stage 1
+  create_namespace = false # Created by kubectl_manifest.flux_system_namespace
 
   wait    = true
   timeout = 300
@@ -141,7 +145,14 @@ resource "helm_release" "flux_operator" {
 # Step 6: Install Flux Instance
 # =============================================================================
 resource "helm_release" "flux_instance" {
-  depends_on = [helm_release.flux_operator]
+  depends_on = [
+    helm_release.flux_operator,
+    # Git auth + cert-manager AppRole secrets and the substitution-vars
+    # ConfigMap must exist before Flux starts reconciling the repo.
+    kubectl_manifest.flux_system_secret,
+    kubectl_manifest.flux_cert_manager_approle,
+    kubectl_manifest.flux_cluster_vars,
+  ]
 
   name             = "flux"
   repository       = "oci://ghcr.io/controlplaneio-fluxcd/charts"

--- a/opentofu/eks/configure/variables.tf
+++ b/opentofu/eks/configure/variables.tf
@@ -23,13 +23,13 @@ variable "cilium_version" {
 variable "flux_operator_version" {
   description = "Flux Operator Helm chart version"
   type        = string
-  default     = "0.48.0"
+  default     = "0.50.0"
 }
 
 variable "flux_instance_version" {
   description = "Flux Instance Helm chart version"
   type        = string
-  default     = "0.48.0"
+  default     = "0.50.0"
 }
 
 variable "flux_sync_url" {
@@ -41,4 +41,54 @@ variable "flux_git_ref" {
   description = "Git reference (branch/tag) for Flux sync"
   type        = string
   default     = "refs/heads/main"
+}
+
+variable "env" {
+  description = "The environment of the EKS cluster"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.env)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "gateway_api_version" {
+  description = "Gateway API CRDs version — must match flux/sources/gitrepo-gateway-api.yaml ref"
+  type        = string
+  default     = "v1.5.1"
+}
+
+variable "private_domain_name" {
+  description = "Private domain name for internal services (e.g., priv.cloud.ogenki.io)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.private_domain_name))
+    error_message = "Domain name must be a valid DNS domain name."
+  }
+}
+
+variable "public_domain_name" {
+  description = "Public domain name for internet-facing services (e.g., cloud.ogenki.io)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.public_domain_name))
+    error_message = "Domain name must be a valid DNS domain name."
+  }
+}
+
+variable "github_app_secret_name" {
+  type        = string
+  description = "SecretsManager name from where to retrieve the Github App information. ref: https://fluxcd.io/flux/components/source/gitrepositories/#github"
+  default     = "github/flux-app"
+  sensitive   = true
+}
+
+variable "cert_manager_approle_secret_name" {
+  type        = string
+  description = "SecretsManager name from where to retrieve the cert-manager approle information."
+  default     = "openbao/approles/cert-manager"
+  sensitive   = true
 }

--- a/opentofu/eks/configure/versions.tf
+++ b/opentofu/eks/configure/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "gavinbunney/kubectl"
       version = "~> 1.14"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.4"
+    }
   }
 }

--- a/opentofu/eks/init/data.tf
+++ b/opentofu/eks/init/data.tf
@@ -1,4 +1,3 @@
-data "aws_caller_identity" "this" {}
 data "aws_vpc" "selected" {
   filter {
     name   = "tag:project"
@@ -60,26 +59,10 @@ data "aws_ecrpublic_authorization_token" "token" {
   provider = aws.virginia
 }
 
-data "aws_eks_cluster_auth" "cluster_auth" {
-  name = module.eks.cluster_name
-}
-
-data "aws_secretsmanager_secret_version" "github_app" {
-  secret_id = var.github_app_secret_name
-}
-
-data "aws_secretsmanager_secret_version" "cert_manager_approle" {
-  secret_id = var.cert_manager_approle_secret_name
-}
-
-data "http" "gateway_api_crds" {
-  count = length(local.gateway_api_crds_urls)
-  url   = local.gateway_api_crds_urls[count.index]
-}
-
-data "aws_route53_zone" "public" {
-  name         = var.public_domain_name
-  private_zone = false
-}
+# Cluster-internal bootstrap resources and the data sources that feed them
+# (aws_eks_cluster_auth, secretsmanager approle/github-app, gateway-API CRDs,
+# route53 zone) were moved to eks/configure. They require a live cluster, which
+# does not exist during this cluster-creating apply — keeping a kubectl provider
+# configured from module.eks.* outputs here broke fresh applies.
 
 # Karpenter manifests moved to Flux GitOps (infrastructure/base/karpenter/)

--- a/opentofu/eks/init/providers.tf
+++ b/opentofu/eks/init/providers.tf
@@ -7,16 +7,8 @@ provider "aws" {
   alias  = "virginia"
 }
 
-provider "kubectl" {
-  apply_retry_count      = 15
-  host                   = module.eks.cluster_endpoint
-  token                  = data.aws_eks_cluster_auth.cluster_auth.token
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  load_config_file       = false
-}
-
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  token                  = data.aws_eks_cluster_auth.cluster_auth.token
-}
+# No kubectl/kubernetes provider here on purpose: this stage only creates the
+# EKS cluster. A provider configured from module.eks.* outputs would depend on
+# resources created in this same apply, which alekc/kubectl cannot defer
+# (fails with "no configuration has been provided"). Cluster-internal resources
+# live in eks/configure, which runs against the already-created cluster.

--- a/opentofu/eks/init/variables.tf
+++ b/opentofu/eks/init/variables.tf
@@ -32,7 +32,7 @@ variable "name" {
 
 variable "kubernetes_version" {
   description = "k8s cluster version"
-  default     = "1.35"
+  default     = "1.36"
   type        = string
 
   validation {
@@ -59,46 +59,10 @@ variable "identity_providers" {
   default     = {}
 }
 
-variable "gateway_api_version" {
-  description = "Gateway API CRDs version — must match flux/sources/gitrepo-gateway-api.yaml ref"
-  default     = "v1.5.1"
-  type        = string
-}
-
-variable "private_domain_name" {
-  description = "Private domain name for internal services (e.g., priv.cloud.ogenki.io)"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.private_domain_name))
-    error_message = "Domain name must be a valid DNS domain name."
-  }
-}
-
-variable "public_domain_name" {
-  description = "Public domain name for internet-facing services (e.g., cloud.ogenki.io)"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.public_domain_name))
-    error_message = "Domain name must be a valid DNS domain name."
-  }
-}
-
-# Flux
-variable "github_app_secret_name" {
-  type        = string
-  description = "SecretsManager name from where to retrieve the Github App information. ref: https://fluxcd.io/flux/components/source/gitrepositories/#github"
-  default     = "github/flux-app"
-  sensitive   = true
-}
-
-variable "cert_manager_approle_secret_name" {
-  type        = string
-  description = "SecretsManager name from where to retrieve the cert-manager approle information."
-  default     = "openbao/approles/cert-manager"
-  sensitive   = true
-}
+# Gateway API CRDs, Flux bootstrap secrets, and the public/private domain names
+# are consumed by the cluster-internal resources, which now live in eks/configure
+# (the stage that runs against an already-created cluster). Their variables were
+# moved there along with the resources.
 
 # Note: Flux configuration (version, sync URL, git ref) is now managed via Terramate globals
 # in opentofu/config.tm.hcl and Helm values in opentofu/eks/helm_values/flux-instance.yaml

--- a/opentofu/eks/init/variables.tfvars
+++ b/opentofu/eks/init/variables.tfvars
@@ -1,7 +1,5 @@
-env                 = "dev"
-name                = "mycluster-0" # Generated with petname
-private_domain_name = "priv.cloud.ogenki.io"
-public_domain_name  = "cloud.ogenki.io"
+env  = "dev"
+name = "mycluster-0" # Generated with petname
 
 tags = {
   GithubRepo = "cloud-native-ref"
@@ -9,8 +7,6 @@ tags = {
 }
 
 enable_ssm = true
-
-cert_manager_approle_secret_name = "openbao/cloud-native-ref/approles/cert-manager"
 
 identity_providers = {
   zitadel = {

--- a/opentofu/eks/init/versions.tf
+++ b/opentofu/eks/init/versions.tf
@@ -10,18 +10,6 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
-    }
-    kubectl = {
-      source  = "alekc/kubectl"
-      version = ">= 2.0.0"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 3.4"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"


### PR DESCRIPTION
## Problem

A fresh `cd opentofu/eks/init && terramate script run deploy` failed right after planning:

```
Error: invalid provider configuration: invalid configuration: no configuration
has been provided, try setting KUBERNETES_MASTER environment variable
  with provider["registry.opentofu.org/alekc/kubectl"]
```

**Root cause:** `eks/init` configured the `kubectl`/`kubernetes` providers from `module.eks.*` outputs, which don't exist until that same apply creates the cluster. On a fresh apply the endpoint is unknown, and `alekc/kubectl` can't defer provider configuration with unknown values — it builds a client with an empty host and errors. A provider configuration must not depend on resources created in the same apply (the same reason `terraform-aws-modules/eks` dropped the Kubernetes provider from the module in v20).

## Change

Move the 7 cluster-internal `kubectl_manifest` resources out of the cluster-**creating** stage into `eks/configure`, which already runs against an existing cluster (`data.aws_eks_cluster` + `exec` auth):

- **Moved → `eks/configure`:** Gateway-API CRDs, `flux-system` namespace + secrets + substitution-vars ConfigMap, gp3/gp2 StorageClasses, and their data sources.
- **`eks/configure` re-derives** the few init-only values via AWS data sources (OIDC provider ARN, Karpenter queue name) rather than `terraform_remote_state`, keeping the stage self-contained.
- **Ordering** re-established with `depends_on`: gateway CRDs → before Cilium; `flux-system` namespace → before flux-operator; secrets + ConfigMap → before flux-instance.
- **`eks/init` no longer declares** the `kubectl`/`kubernetes`/`http` providers.
- Bump `flux_operator_version` / `flux_instance_version` `0.48.0 → 0.50.0`.

No `-target` two-pass needed — a clean `terramate script run deploy` works end to end.

## Validation

| Check | init | configure |
|---|---|---|
| `tofu validate` | ✅ | ✅ |
| `tofu fmt -check` | ✅ | ✅ |
| `trivy config --exit-code=1` | ✅ (0) | ✅ (0) |

End-to-end: deployed fresh on `mycluster-0` — cluster + Cilium + Flux up, FluxInstance `Ready: True`.

## Migration note

Clean only because init state was empty. On an **already-applied** cluster the 7 resources live in init's state; removing them from init config would mean destroy+recreate (incl. deleting the `flux-system` namespace) unless migrated with cross-stack `terraform state mv`.