### PR TITLE
observability: route a copy of alerts to the RunLore SRE agent

### DIFF
--- a/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
@@ -51,8 +51,20 @@ data:
             - matchers:
                 - alertname =~ "InfoInhibitor|Watchdog|KubeCPUOvercommit"
               receiver: "blackhole"
+            # Send a copy of every non-blackholed alert to the RunLore SRE agent,
+            # then continue so Slack still receives it. RunLore's own trigger policy
+            # decides which alerts it actually investigates.
+            - receiver: "runlore"
+              continue: true
+            # Explicit Slack catch-all (required because the route above matches all
+            # with continue: true, so the root receiver no longer fires on its own).
+            - receiver: "slack-monitoring"
         receivers:
           - name: "blackhole"
+          - name: "runlore"
+            webhook_configs:
+              - url: "http://runlore.runlore.svc:8080/webhook/alertmanager"
+                send_resolved: true
           - name: "slack-monitoring"
             slack_configs:
               - channel: "#alerts"


### PR DESCRIPTION
Wires Alertmanager → RunLore so real alerts reach the agent (today nothing does — RunLore only got manual test webhooks).

- Adds a `runlore` webhook receiver → `http://runlore.runlore.svc:8080/webhook/alertmanager`.
- Adds a `continue: true` route so every non-blackholed alert is **also** sent to RunLore, with an explicit `slack-monitoring` catch-all so Slack still receives everything (the continue route otherwise suppresses the root receiver).
- Blackholed alerts (InfoInhibitor/Watchdog/KubeCPUOvercommit) are unaffected.

RunLore's own trigger policy (now severity in [critical,warning]) decides what it actually investigates; dedup prevents storms.

Base is `feat/sre-agent` (the branch this cluster's Flux tracks).