### PR TITLE
security(epis): read-only EKS Pod Identity for the RunLore SRE agent

### DIFF
--- a/security/base/epis/kustomization.yaml
+++ b/security/base/epis/kustomization.yaml
@@ -13,4 +13,5 @@ resources:
   - harbor.yaml
   - load-balancer-controller.yaml
   - openbao-snapshot.yaml
+  - runlore.yaml
   - victoriametrics.yaml

--- a/security/base/epis/runlore.yaml
+++ b/security/base/epis/runlore.yaml
@@ -1,0 +1,43 @@
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: EPI
+metadata:
+    name: xplane-runlore
+    namespace: runlore
+spec:
+    clusters:
+        - name: "mycluster-0"
+          region: "eu-west-3"
+    serviceAccount:
+        name: runlore
+        namespace: runlore
+    # Read-only AWS access for the RunLore SRE agent's cloud provider:
+    # CloudTrail "what changed" + EC2/ASG/EKS resource health. No mutating actions.
+    policyDocument: |
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "CloudTrailWhatChanged",
+                    "Effect": "Allow",
+                    "Action": [
+                        "cloudtrail:LookupEvents"
+                    ],
+                    "Resource": "*"
+                },
+                {
+                    "Sid": "NodeAndCapacityHealth",
+                    "Effect": "Allow",
+                    "Action": [
+                        "ec2:DescribeInstances",
+                        "ec2:DescribeInstanceStatus",
+                        "ec2:DescribeTags",
+                        "autoscaling:DescribeAutoScalingGroups",
+                        "autoscaling:DescribeScalingActivities",
+                        "eks:DescribeCluster",
+                        "eks:DescribeNodegroup",
+                        "eks:ListNodegroups"
+                    ],
+                    "Resource": "*"
+                }
+            ]
+        }


### PR DESCRIPTION
Grants `runlore/runlore` read-only AWS access for RunLore's new cloud provider (PR Smana/runlore#55):

- **`cloudtrail:LookupEvents`** — the AWS 'what changed' lens.
- **EC2/ASG/EKS describe** (`ec2:DescribeInstances/InstanceStatus/Tags`, `autoscaling:DescribeAutoScalingGroups/ScalingActivities`, `eks:DescribeCluster/Nodegroup`, `eks:ListNodegroups`) — node/capacity health.

**Read-only — no mutating actions** (RunLore is read-only on the cloud too). Scoped to `mycluster-0`/`eu-west-3` via the existing EPI composition. Once applied, deploy RunLore with `cloud.provider: aws` and it authenticates via Pod Identity (no static keys). Base `feat/sre-agent`.