### PR TITLE
feat(runlore): deploy v0.2.0 (auth, integrations, model)

### DIFF
--- a/observability/base/runlore/externalsecret-webhook.yaml
+++ b/observability/base/runlore/externalsecret-webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: runlore-webhook
+spec:
+  # Shared bearer token guarding the alert webhook. v0.2.0 fails closed
+  # (internal/app/config.go RequireWebhookAuth): once a model is configured the
+  # /webhook/alertmanager endpoint must be authenticated, since alert
+  # labels/annotations flow verbatim into the LLM prompt and bill the model.
+  # The SAME token is mounted into Alertmanager (observability ns) so its runlore
+  # receiver posts with `Authorization: Bearer <token>` (see
+  # externalsecret-runlore-webhook-token.yaml + the vm-common AM config).
+  data:
+    - secretKey: WEBHOOK_TOKEN  # pragma: allowlist secret
+      remoteRef:
+        key: runlore/webhook
+        property: token
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: clustersecretstore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: runlore-webhook

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     # require an RWX volume (EFS) so the standby can mount the same data — deferred.
     replicaCount: 1
     image:
-      tag: sha-9b9195b
+      tag: sha-2519d2b
     serviceAccount:
       create: true
       # Must match the SA bound by the xplane-runlore EKS Pod Identity (security/base/epis/runlore.yaml).
@@ -87,15 +87,23 @@ spec:
     config:
       gitops:
         engine: flux
+      # v0.2.0 extensible-source schema: a key under `sources.<name>` ENABLES that
+      # source (presence = enablement); `triggers.*` now holds only match/dedup/
+      # debounce POLICY. The agent strict-parses (KnownFields), so the old
+      # `triggers.incidents.enabled` / `triggers.gitops_failures.enabled` keys are
+      # rejected and were removed.
+      sources:
+        alertmanager: {}            # mount the Alertmanager/VMAlert incident webhook
+        gitops:
+          enabled: true             # also react to Flux Ready=False
       triggers:
         incidents:
-          enabled: true
           match:
             severity: [critical]
           dedup:
             window: 30m
         gitops_failures:
-          enabled: true
+          debounce: 60s
       leader_election:
         enabled: true
         name: runlore-leader

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -88,7 +88,10 @@ spec:
               protocol: TCP
             - port: 9428
               protocol: TCP
-        # Hubble Relay gRPC :80 (network-flow tool) in kube-system.
+        # Hubble Relay (network-flow tool) in kube-system. runlore dials the
+        # Service on :80, but with a podSelector the policy is enforced on the
+        # post-DNAT backend port — the relay container's gRPC port 4245 (the
+        # Service's targetPort), NOT 80. Using 80 here silently times out.
         - to:
             - namespaceSelector:
                 matchLabels:
@@ -97,7 +100,7 @@ spec:
                 matchLabels:
                   k8s-app: hubble-relay
           ports:
-            - port: 80
+            - port: 4245
               protocol: TCP
     vmServiceScrape:
       enabled: true

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -150,7 +150,11 @@ spec:
         metrics_enabled: true
       model:
         provider: gemini
-        model: gemini-2.5-flash
+        # gemini-2.5-pro: flash was inconsistent on real investigations (went
+        # inconclusive on an obvious IAM-quota case, low-confidence on a subtle
+        # Pod-Identity race). pro's stronger reasoning yields confident, correct
+        # RCAs — worth the per-investigation cost for an SRE agent.
+        model: gemini-2.5-pro
         api_key_env: GEMINI_API_KEY  # pragma: allowlist secret
       catalog:
         dir: /var/lib/runlore/catalog

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -83,6 +83,8 @@ spec:
           name: runlore-credentials
       - secretRef:
           name: runlore-slack
+      - secretRef:
+          name: runlore-webhook
     # Rendered verbatim into /etc/runlore/runlore.yaml (strict-parsed by the agent).
     config:
       gitops:
@@ -165,6 +167,12 @@ spec:
         cluster_name: mycluster-0
       # actions: omitted -> mode "off" (fully read-only on the cluster; only
       # writes are KB PRs/issues on Smana/runlore-kb via the GitHub App).
-      # server.webhook_token_env: omitted — the Alertmanager runlore receiver
-      # posts unauthenticated in-cluster (observability/.../vm-common-helm-values-configmap.yaml).
+      # v0.2.0 fails closed (RequireWebhookAuth): with a model configured the
+      # alert webhook MUST be authenticated, since alert labels/annotations flow
+      # into the LLM prompt and bill the model. The bearer token comes from the
+      # runlore-webhook ExternalSecret (envFrom above); the Alertmanager runlore
+      # receiver posts it via authorization.credentials_file
+      # (observability/.../vm-common-helm-values-configmap.yaml).
+      server:
+        webhook_token_env: WEBHOOK_TOKEN  # pragma: allowlist secret
       # network / metrics.url / logs.url: deferred to a fast-follow once the base deploy is green.

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     # require an RWX volume (EFS) so the standby can mount the same data — deferred.
     replicaCount: 1
     image:
-      tag: sha-d9c4584
+      tag: 0.2.0
     serviceAccount:
       create: true
       # Must match the SA bound by the xplane-runlore EKS Pod Identity (security/base/epis/runlore.yaml).

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -72,6 +72,33 @@ spec:
       # Renders a CiliumNetworkPolicy allowing egress to the EKS Pod Identity
       # credential endpoint (169.254.170.23:80, host entity) — required on Cilium.
       awsPodIdentity: true
+      # Integration egress (v0.2.0 data sources). The baseline policy only opens
+      # DNS + 443 + 6443; the in-cluster observability backends listen on
+      # non-standard ports, so the investigation tools need explicit allow rules
+      # or every query silently times out (default-deny).
+      extraEgress:
+        # VictoriaMetrics :8428 (query_metrics / query_metrics_range) and
+        # VictoriaLogs :9428 (query_logs) — both in the observability namespace.
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: observability
+          ports:
+            - port: 8428
+              protocol: TCP
+            - port: 9428
+              protocol: TCP
+        # Hubble Relay gRPC :80 (network-flow tool) in kube-system.
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: hubble-relay
+          ports:
+            - port: 80
+              protocol: TCP
     vmServiceScrape:
       enabled: true
       interval: 30s
@@ -161,6 +188,20 @@ spec:
           app_id: 4106804
           installation_id: 141652301
           private_key_env: GITHUB_APP_PRIVATE_KEY  # pragma: allowlist secret
+      # Investigation data sources (v0.2.0). Each tool dials the base URL and
+      # appends its own API path: metrics -> /api/v1/query[_range] (PromQL),
+      # logs -> /select/logsql/query (LogsQL). Hubble Relay has server TLS
+      # disabled in this cluster, and the agent's hubble client dials plaintext,
+      # so the relay is reached on :80. Egress for all three is opened in
+      # networkPolicy.extraEgress above.
+      metrics:
+        url: http://vmsingle-victoria-metrics-k8s-stack.observability.svc:8428
+      logs:
+        url: http://victoria-logs-victoria-logs-single-server.observability.svc:9428
+      network:
+        provider: hubble
+        hubble:
+          url: hubble-relay.kube-system:80
       cloud:
         provider: aws
         region: eu-west-3

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     # require an RWX volume (EFS) so the standby can mount the same data — deferred.
     replicaCount: 1
     image:
-      tag: sha-2519d2b
+      tag: sha-d9c4584
     serviceAccount:
       create: true
       # Must match the SA bound by the xplane-runlore EKS Pod Identity (security/base/epis/runlore.yaml).

--- a/observability/base/runlore/kustomization.yaml
+++ b/observability/base/runlore/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: runlore
 resources:
   - externalsecret-credentials.yaml
   - externalsecret-slack.yaml
+  - externalsecret-webhook.yaml
   - helmrelease.yaml

--- a/observability/base/victoria-metrics-k8s-stack/externalsecret-runlore-webhook-token.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/externalsecret-runlore-webhook-token.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: runlore-webhook-token
+  namespace: observability
+spec:
+  # Same bearer token as the runlore agent's runlore-webhook secret (AWS SM
+  # runlore/webhook). Mounted into Alertmanager via spec.secrets and referenced by
+  # the runlore receiver's http_config.authorization.credentials_file, so AM posts
+  # `Authorization: Bearer <token>` to /webhook/alertmanager — which v0.2.0
+  # requires (fail-closed RequireWebhookAuth once a model is configured).
+  data:
+    - secretKey: token  # pragma: allowlist secret
+      remoteRef:
+        key: runlore/webhook
+        property: token
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: clustersecretstore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: runlore-webhook-token

--- a/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - externalsecret-alertmanager-slack-app.yaml
+  - externalsecret-runlore-webhook-token.yaml
   - externalsecret-grafana-envvars.yaml
 
   # HttpRoutes

--- a/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vm-common-helm-values-configmap.yaml
@@ -31,6 +31,7 @@ data:
         externalURL: "https://vmalertmanager-${cluster_name}.${private_domain_name}"
         secrets:
           - "victoria-metrics-k8s-stack-alertmanager-slack-app"
+          - "runlore-webhook-token"
       config:
         global:
           slack_api_url: "https://slack.com/api/chat.postMessage"
@@ -65,6 +66,13 @@ data:
             webhook_configs:
               - url: "http://runlore.runlore.svc:8080/webhook/alertmanager"
                 send_resolved: true
+                # v0.2.0 fails closed: the runlore agent requires a bearer token on
+                # /webhook/alertmanager once a model is configured. Per-receiver
+                # http_config overrides the global (Slack) one; the token is mounted
+                # from the runlore-webhook-token secret (spec.secrets above).
+                http_config:
+                  authorization:
+                    credentials_file: /etc/vm/secrets/runlore-webhook-token/token
           - name: "slack-monitoring"
             slack_configs:
               - channel: "#alerts"


### PR DESCRIPTION
Deploys and configures RunLore **v0.2.0** on mycluster-0. Validated end-to-end on a live cluster this session.

## Changes (all under `observability/base/runlore/` + vmstack webhook wiring)
- **Image → `0.2.0`** (release tag); config migrated to the v0.2.0 `sources:` schema (source enablement moved out of `triggers.*.enabled`; strict-parsed).
- **Fail-closed webhook auth** (new v0.2.0 hardening): shared bearer token in AWS SM `runlore/webhook` → ESO into `runlore-webhook` (runlore ns, env `WEBHOOK_TOKEN`) and `runlore-webhook-token` (observability ns); Alertmanager runlore receiver authenticates via `http_config.authorization.credentials_file`. Verified: **202 with token / 401 without**.
- **Data-source integrations**: `metrics` → VictoriaMetrics, `logs` → VictoriaLogs, `network` → Hubble Relay; `networkPolicy.extraEgress` for VM :8428 / VL :9428 / Hubble **:4245** (backend port, not Service :80 — a NetworkPolicy podSelector enforces the post-DNAT port).
- **Model → `gemini-2.5-pro`** (flash was inconsistent on real investigations).

## Validation (live)
Sources + auth gate · trigger filtering · per-incident logs · slack delivery · pod_logs · query_metrics_range · query_logs · network_drops · AWS cloud_resource_health/cloud_what_changed (Pod Identity) · adversarial verify · recall (hit→downgraded + reject) · #164 coalesce-surface-cause · gitops-failure source · outcome ledger · telemetry. Showcase RCA → runlore-kb#72 (merged). Worked example: runlore docs/examples/harbor-registry-down.md.

## ⚠️ Merge footgun
The live FluxInstance tracks `refs/heads/feat/sre-agent-v0.2.0`. If this PR is squash-merged **and the head branch auto-deleted**, the cluster's `flux-system` Git source 404s. Before merging: either cut the FluxInstance over to `main` first, or restore the branch post-merge (`git push origin <branch>:<branch>` + `flux reconcile source git flux-system`).