### PR TITLE
chore(runlore): bump to 0.6.0

### DIFF
--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # Pinned to the v0.5.0 release commit (main HEAD), in lockstep with the
-  # multi-arch release image ghcr.io/smana/runlore:0.5.0. runlore now ships
+  # Pinned to the v0.6.0 release commit (main HEAD), in lockstep with the
+  # multi-arch release image ghcr.io/smana/runlore:0.6.0. runlore now ships
   # semver release images (release-please + goreleaser) instead of per-commit
   # sha-<short> tags. The chart lives at deploy/helm/runlore.
   ref:
     branch: main
-    commit: f57ce7ce311cc8066c766986329e8556d2668bf3  # pragma: allowlist secret
+    commit: b2f43040a7138783ad25a4c1eb2740bc96e4a085  # pragma: allowlist secret

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     # require an RWX volume (EFS) so the standby can mount the same data — deferred.
     replicaCount: 1
     image:
-      tag: "0.5.0"
+      tag: "0.6.0"
     serviceAccount:
       create: true
       # Must match the SA bound by the xplane-runlore EKS Pod Identity (security/base/epis/runlore.yaml).


### PR DESCRIPTION
Bumps RunLore `0.5.0 → 0.6.0` on the Flux-reconciled branch.

- `observability/base/runlore/helmrelease.yaml`: `image.tag` → `0.6.0`
- `flux/sources/gitrepo-runlore.yaml`: pinned commit → `b2f4304` (v0.6.0 release; chart at `deploy/helm/runlore`)

**What's in 0.6.0:** removes the 👍/👎 verdict-feedback buttons ([Smana/runlore#237](https://github.com/Smana/runlore/pull/237)) — the feedback was write-only (no consumer read the ledger events). This deployment is read-only (`actions.mode` off), so it needs no Slack Interactivity endpoint.

Multi-arch image `ghcr.io/smana/runlore:0.6.0` verified published.