### PR TITLE
chore(runlore): bump to 0.6.1

### DIFF
--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # Pinned to the v0.6.0 release commit (main HEAD), in lockstep with the
-  # multi-arch release image ghcr.io/smana/runlore:0.6.0. runlore now ships
+  # Pinned to the v0.6.1 release commit (main HEAD), in lockstep with the
+  # multi-arch release image ghcr.io/smana/runlore:0.6.1. runlore now ships
   # semver release images (release-please + goreleaser) instead of per-commit
   # sha-<short> tags. The chart lives at deploy/helm/runlore.
   ref:
     branch: main
-    commit: b2f43040a7138783ad25a4c1eb2740bc96e4a085  # pragma: allowlist secret
+    commit: 9f5f75edd862b9fc2e32e76dbde55a45e2cecd36  # pragma: allowlist secret

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     # require an RWX volume (EFS) so the standby can mount the same data — deferred.
     replicaCount: 1
     image:
-      tag: "0.6.0"
+      tag: "0.6.1"
     serviceAccount:
       create: true
       # Must match the SA bound by the xplane-runlore EKS Pod Identity (security/base/epis/runlore.yaml).


### PR DESCRIPTION
Bumps RunLore `0.6.0 → 0.6.1` on the Flux-reconciled branch.

- `observability/base/runlore/helmrelease.yaml`: `image.tag` → `0.6.1`
- `flux/sources/gitrepo-runlore.yaml`: pinned commit → `9f5f75e` (v0.6.1 release)

**What's in 0.6.1:** fixes `what_changed` missing the diff on Flux health-check failures ([Smana/runlore#239](https://github.com/Smana/runlore/issues/239) / [#240](https://github.com/Smana/runlore/pull/240)) — investigations now recover the real change (last commit touching the resource's path) instead of emitting a bare/wrong revert target.