### PR TITLE
fix(ci): drop the impossible 'latest' tag push, and strip the -pr1574 pin

### DIFF
--- a/.github/workflows/crossplane-modules.yml
+++ b/.github/workflows/crossplane-modules.yml
@@ -283,11 +283,25 @@ jobs:
 
           echo "✅ Successfully published ${MODULE_NAME}:${PUBLISH_VERSION}"
 
-          if [ "$IS_PR" = "false" ]; then
-            echo "🚀 Publishing 'latest' tag for release version"
-            kcl mod push "oci://${FULL_MODULE_NAME}:latest"
-            echo "✅ Successfully published ${MODULE_NAME}:latest"
-          fi
+          # NOTE: there is deliberately no 'latest' tag push here.
+          #
+          # `kcl mod push` IGNORES the tag in the OCI URL and publishes under the
+          # `version` field in kcl.mod (the same trap that forces the sed rewrite
+          # above for PR builds). So `kcl mod push oci://...:latest` did not
+          # publish `latest` at all — it re-pushed the release version, hit
+          # "package version 'X' already exists", and exited 1.
+          #
+          # That step could never succeed, and it failed EVERY push to main. Worse,
+          # `validate-composition-versions` declares `needs: [publish]`, so a failed
+          # publish SKIPPED the pin audit — which is why a dangling `-pr<N>` pin
+          # could sit on main undetected (crossplane-app:0.1.10-pr1434 did, from
+          # May until July). Two bugs, the first one hiding the second.
+          #
+          # Nothing consumes a `:latest` module tag — compositions pin an explicit
+          # version, as they must for reproducible renders — and `latest` has never
+          # existed for any module in this registry. So the fix is to delete the
+          # step, not to repair it. If a floating tag is ever wanted, alias it with
+          # `oras tag` (which does respect the URL) rather than `kcl mod push`.
 
       - name: Generate publication summary
         env:

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -8,7 +8,7 @@ It is **off by default.** Two independent gates must both be released — see [T
 A default `terramate script run deploy` plus a default Flux reconcile leaves the cluster LLM-free.
 
 > **Scope of this document.** It describes what the code in this repository actually does, as of the
-> composition module `crossplane-inference-service:0.8.2`. Where a capability is implemented but switched
+> composition module `crossplane-inference-service:0.9.0`. Where a capability is implemented but switched
 > on nowhere, it says so. Where something is a known gap, it is listed in [Known gaps](#known-gaps) rather
 > than quietly omitted.
 

--- a/infrastructure/base/crossplane/configuration/inference-service-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/inference-service-composition.yaml
@@ -51,22 +51,13 @@ spec:
                   # annotation, falling back to metadata.name), so the other rendered
                   # resources keep their identities and are not recreated.
                   target: Default
-                  # PR-preview tag. This MUST be `<kcl.mod version>-pr<PR number>` while
-                  # the PR is open and `<kcl.mod version>` on main — the
-                  # `validate-composition-versions` job in crossplane-modules.yml enforces
-                  # exactly that, keying on `github.event_name`. Pinning the release tag
-                  # early fails the PR; leaving the -pr tag fails main.
-                  #
-                  # >>> STRIP THE `-pr1574` SUFFIX IN A FOLLOW-UP COMMIT ON MAIN. <<<
-                  #
-                  # This is not a nicety. On push to main the same job expects the bare
-                  # `0.8.2`, so main goes red until it is stripped — and main is left
-                  # pointing at a mutable PR-preview artifact. That follow-up is
-                  # demonstrably easy to forget: main still carries
-                  # `crossplane-app:0.1.10-pr1434`, and carried
-                  # `crossplane-inference-service:0.6.0-pr1434` until this branch
-                  # overwrote it. Two PRs, two promises, zero follow-ups.
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-inference-service:0.9.0-pr1574
+                  # Must be `<kcl.mod version>-pr<N>` while a PR is open, and the bare
+                  # `<kcl.mod version>` on main. `validate-composition-versions` in
+                  # crossplane-modules.yml enforces exactly that, keying on
+                  # `github.event_name` — so pinning the release tag early fails the PR,
+                  # and leaving the `-pr` tag fails main. Strip the suffix in a follow-up
+                  # commit as soon as the PR merges; that audit is what catches you.
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-inference-service:0.9.0
 
         - step: ready
           functionRef:


### PR DESCRIPTION
## What

Two changes. The first explains why every push to `main` has failed since May.

### 1. The `latest` tag push could never have worked

`kcl mod push` **ignores the tag in the OCI URL** and publishes under the `version` field in `kcl.mod`. That's a known trap — it's why the PR path already `sed`-rewrites `kcl.mod` before pushing, and it's documented in `.claude/rules/kcl-crossplane.md` rule 5.

The release path then did:

```bash
kcl mod push "oci://${FULL_MODULE_NAME}:latest"
```

which did **not** publish `latest`. It re-pushed the release version, hit `package version '0.9.0' already exists`, and exited 1 — on every push to `main`.

Evidence:
- `latest` has **never existed** for `crossplane-inference-service`, `crossplane-app`, or `crossplane-eks-pod-identity` (checked against the registry).
- Nothing in the repo references a `:latest` module tag.

**The compounding bug:** `validate-composition-versions` declares `needs: [publish]`. A failed publish **skips the pin audit** — so the guard that exists specifically to catch a dangling `-pr<N>` pin on `main` was disarmed by the step running right before it. That is exactly how `crossplane-app:0.1.10-pr1434` has sat on `main` since May with nothing going red.

Two bugs, the first one hiding the second.

Deleted rather than repaired: nothing consumes a floating module tag, and compositions must pin explicit versions for reproducible renders. If one is ever wanted, `oras tag` respects the URL — `kcl mod push` does not.

### 2. Strip the composition pin `0.9.0-pr1574` → `0.9.0`

The release tag was published by the #1574 merge (verified anonymously pullable, the same way `function-kcl` pulls it). `main` was pointing at a PR-preview artifact.

## Not fixed here, deliberately

`app-composition.yaml` still pins `crossplane-app:0.1.10-pr1434`. The release tag `0.1.10` exists, and the digest difference is now fully explained (the PR build rewrites `kcl.mod`'s version before pushing, so the content differs by that string). But it's a production composition I can't exercise without a cluster, and it isn't what this PR is about. Separate change, separate evidence.