### PR TITLE
fix(app-composition): strip PR-preview pin to 0.2.0 after SPEC-007 merge

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.2.0-pr1580
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.2.0
 
         - step: ready
           functionRef:


### PR DESCRIPTION
#1580 merged with the App module pinned at crossplane-app:0.2.0-pr1580 (a PR preview tag). Point at the released 0.2.0 tag published on merge to main — matches kcl.mod version, keeps validate-composition-versions green, and avoids Flux pulling a preview tag that may be garbage-collected. Verified 0.2.0 is anonymously pullable. Mirrors #1576.