### PR TITLE
feat(app-wizard): enable LLM assists — GLM 5.2 via Z.ai's Anthropic-compatible endpoint

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -158,13 +158,21 @@ spec:
     # LLM assists (Phase 3, optional). Assists become AVAILABLE when either
     # LLM_API_KEY (secret, via envFrom) OR LLM_BASE_URL is set; otherwise the UI
     # hides the assist affordances via /api/assist/status. LLM_MODEL is
-    # non-secret and defaults to "claude-opus-4-8" in the binary — override here
-    # if needed. Neither key nor base URL is set below, so assists ship OFF.
-    # - name: LLM_MODEL
-    #   value: "claude-opus-4-8"
-    # Optional: point at the in-cluster AI Gateway instead of a public endpoint.
-    # - name: LLM_BASE_URL
-    #   value: "http://ai-gateway.llm-platform.svc/v1"
+    # non-secret and defaults to "claude-opus-4-8" in the binary.
+    #
+    # Assists run on GLM 5.2 through Z.ai's Anthropic-compatible endpoint — the
+    # backend speaks the Anthropic Messages API (forced tool_use for structured
+    # output), which this endpoint implements. The API key is a copy of
+    # runlore's GLM key, held in the wizard's own blob (apps/app-wizard/llm).
+    #
+    # LLM_MODEL is set explicitly: the endpoint also accepts Anthropic model
+    # ids as aliases, but maps claude-opus-4-8 → glm-4.7 (verified live), an
+    # OLDER model than glm-5.2 — relying on the binary's default would silently
+    # downgrade the assists.
+    - name: LLM_MODEL
+      value: "glm-5.2"
+    - name: LLM_BASE_URL
+      value: "https://api.z.ai/api/anthropic"
 
   # ---------------------------------------------------------------------------
   # OAuth app credentials + session key from AWS Secrets Manager.
@@ -182,16 +190,26 @@ spec:
   #   SESSION_KEY            — signs the session cookie (required in all modes)
   #   ZITADEL_CLIENT_ID      — Zitadel OIDC app creds (only used when
   #   ZITADEL_CLIENT_SECRET    AUTH_MODE=zitadel; PKCE app secret may be empty)
-  #   LLM_API_KEY           — LLM assists (optional; omit to keep assists off)
   # Missing keys simply don't materialize as env vars; a mode that doesn't need
   # a key is unaffected. Populating them is a human step (T003).
+  #
+  # The LLM assist key lives in its OWN blob (apps/app-wizard/llm, key
+  # LLM_API_KEY) rather than the oauth blob: it is a copy of runlore's GLM key
+  # and rotates on that key's lifecycle, not the OAuth apps'. Remove the blob
+  # (or the entry below) to switch assists off.
   externalSecrets:
     - name: app-wizard-oauth
       remoteRef: apps/app-wizard/oauth
       refreshInterval: 1h
+    - name: app-wizard-llm
+      remoteRef: apps/app-wizard/llm
+      refreshInterval: 1h
   envFrom:
     - secretRef:
         name: app-wizard-oauth
+        optional: true
+    - secretRef:
+        name: app-wizard-llm
         optional: true
 
   # ---------------------------------------------------------------------------

--- a/container-images/app-wizard/README.md
+++ b/container-images/app-wizard/README.md
@@ -85,14 +85,20 @@ Non-secret (set via `env` in the App claim):
 | `ZITADEL_REDIRECT_URL` | OIDC callback (default `.../api/auth/callback`) |
 | `ZITADEL_REQUIRED_ROLE` | project role a user must hold, e.g. `app-wizard:user` (empty ⇒ any authenticated user) |
 | `OAUTH_REDIRECT_URL` | GitHub OAuth / GitHub-link callback |
-| `LLM_MODEL` | assist model id (default `claude-opus-4-8`) |
-| `LLM_BASE_URL` | optional; point assists at the in-cluster AI Gateway |
+| `LLM_MODEL` | assist model id (default `claude-opus-4-8`; deployed as `glm-5.2` — see below) |
+| `LLM_BASE_URL` | optional Anthropic-API-compatible endpoint (deployed: `https://api.z.ai/api/anthropic`; can also target the in-cluster AI Gateway) |
 
-Secret (via `envFrom` from the ESO-materialized `app-wizard-oauth` Secret;
-source blob `apps/app-wizard/oauth` in AWS Secrets Manager):
+Secret (via `envFrom` from two ESO-materialized Secrets):
 
-`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `SESSION_KEY`,
-`ZITADEL_CLIENT_ID`, `ZITADEL_CLIENT_SECRET`, `LLM_API_KEY`.
+- `app-wizard-oauth` (source blob `apps/app-wizard/oauth`): `GITHUB_CLIENT_ID`,
+  `GITHUB_CLIENT_SECRET`, `SESSION_KEY`, `ZITADEL_CLIENT_ID`, `ZITADEL_CLIENT_SECRET`.
+- `app-wizard-llm` (source blob `apps/app-wizard/llm`): `LLM_API_KEY` — a copy of
+  runlore's Z.ai GLM key in a wizard-owned blob (own rotation lifecycle).
+
+The deployed assists run on **GLM 5.2 via Z.ai's Anthropic-compatible endpoint**
+(the assist backend speaks the Anthropic Messages API with forced tool use, which
+that endpoint implements). `LLM_MODEL=glm-5.2` is set explicitly because the
+endpoint maps the Anthropic alias `claude-opus-4-8` to the older `glm-4.7`.
 
 Switching a deployment to `zitadel` requires registering the Zitadel app
 (Web / OIDC / PKCE) and its role, plus populating the `ZITADEL_*` secret keys


### PR DESCRIPTION
## What

Turns ON the Phase-3 LLM assists (describe-to-prefill + network-policy suggester) that shipped dark: the deployed claim set neither `LLM_API_KEY` nor `LLM_BASE_URL`, so `/api/assist/status` reported unavailable and the UI hid the assist affordances.

## How — config only, zero backend code

The assist backend speaks the Anthropic Messages API with forced `tool_use` for structured output. Z.ai exposes an Anthropic-compatible endpoint that implements exactly that, so:

- `LLM_BASE_URL=https://api.z.ai/api/anthropic`, `LLM_MODEL=glm-5.2` on the claim.
- **glm-5.2 is pinned explicitly**: the endpoint accepts Anthropic model ids as aliases but maps `claude-opus-4-8` → the *older* `glm-4.7` (verified live) — relying on the binary default would silently downgrade.
- API key: copy of runlore's GLM key in a **wizard-owned** Secrets Manager blob `apps/app-wizard/llm` (created), materialized via its own ExternalSecret + `envFrom`. No dependency on `runlore/credentials`, own rotation lifecycle.
- Egress: already covered by the claim's CNP (`toEntities: world` on 443 — same rationale as GitHub egress, see in-file TRAP notes).

## Evidence

Ran the binary locally with the exact deployed env (key fetched from the new blob):

- `GET /api/assist/status` → `{"available": true}`
- `POST /api/assist/prefill` with *"a Python API on port 8000 with a small postgres database, private access only"* → schema-valid partial spec: `type: web`, `service.port: 8000`, `sqlInstance: {enabled, size: small}`, `route: {enabled, internetFacing: false}`

`./scripts/validate-manifests.sh`: renders clean (`failed=0`); Gate 1 reports **one pre-existing violation unrelated to this diff** (`EC2NodeClass/gpu-l4`: `amiSelectorTerms[0].ssmParameter not allowed` — latent issue caught by the freshly regenerated catalog, tracked separately).

## Post-merge

Flux reconciles the claim → pod restarts with the new env → the prefill panel appears in the create form. Verify: `curl https://app-wizard.priv.cloud.ogenki.io/api/assist/status` → `{"available": true}`.