### PR TITLE
fix(flux-schema): generate Karpenter CRD schemas from the deployed OCI pin

### DIFF
--- a/scripts/flux-schema/gen-catalog.sh
+++ b/scripts/flux-schema/gen-catalog.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # Build the local JSON-Schema catalog consumed by `flux schema validate`.
 #
-# Two sources (SPEC-007 FR-002):
+# Three sources (SPEC-007 FR-002):
 #   1. The repo's own Crossplane XRDs  -> cloud.ogenki.io/*
 #   2. Envoy AI Gateway CRDs           -> aigateway.envoyproxy.io/*
 #      (absent from the hosted ecosystem catalog)
+#   3. Karpenter CRDs                  -> karpenter.k8s.aws/*, karpenter.sh/*
+#      (PRESENT in the hosted ecosystem catalog but STALE: it pins an older
+#      provider release that predates fields we use — e.g. EC2NodeClass
+#      amiSelectorTerms[].ssmParameter, required for the Bottlerocket NVIDIA
+#      variant. Generating them here from the same OCI pin Flux installs makes
+#      the local catalog win over the stale ecosystem entry, matching the
+#      deployed CRD exactly.)
 #
 # The catalog is generated, never committed, so it cannot drift from the XRDs.
 #
@@ -52,6 +59,24 @@ if [[ -z "${AI_GATEWAY_VERSION}" ]]; then
   exit 1
 fi
 
+# Same single-source-of-truth approach for Karpenter: chart URL + version come
+# from the OCIRepository Flux installs. NOTE the version key differs from the AI
+# Gateway source — Karpenter's OCIRepository pins `ref.semver:`, not `ref.tag:`
+# — so this regex reads `semver:` (a bare version or a range like ">=1.0.0"; the
+# leading token is enough for `helm template --version`).
+KARPENTER_SOURCE="flux/sources/ocirepo-karpenter.yaml"
+KARPENTER_CHART="$(sed -nE 's#^[[:space:]]*url:[[:space:]]*"?(oci://[^"[:space:]]+)"?[[:space:]]*$#\1#p' "${KARPENTER_SOURCE}" | head -n1 || true)"
+KARPENTER_VERSION="$(sed -nE 's/^[[:space:]]*semver:[[:space:]]*"?(v?[0-9][^"[:space:]]*)"?[[:space:]]*$/\1/p' "${KARPENTER_SOURCE}" | head -n1 || true)"
+
+if [[ -z "${KARPENTER_CHART}" ]]; then
+  echo "error: could not read the Karpenter chart url from ${KARPENTER_SOURCE}" >&2
+  exit 1
+fi
+if [[ -z "${KARPENTER_VERSION}" ]]; then
+  echo "error: could not read the Karpenter chart version from ${KARPENTER_SOURCE}" >&2
+  exit 1
+fi
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 
@@ -70,9 +95,21 @@ echo "==> Rendering Envoy AI Gateway CRDs (chart ${AI_GATEWAY_VERSION})"
 "${HELM_BIN}" template aigw-crds "${AI_GATEWAY_CHART}" --version "${AI_GATEWAY_VERSION}" --include-crds \
   > "${tmp}/aigateway-crds.yaml"
 
+echo "==> Rendering Karpenter CRDs (chart ${KARPENTER_VERSION})"
+# The pinned OCIRepository is the FULL karpenter chart (controller + CRDs), not
+# a dedicated CRD chart, so `helm template` also renders the controller
+# templates — and the Deployment template hard-fails without settings.clusterName
+# ("Chart cannot be installed without a valid settings.clusterName!"). The value
+# is render-only: `flux schema extract crd` below picks out ONLY the CRDs, so
+# this throwaway name never reaches the catalog.
+"${HELM_BIN}" template karpenter "${KARPENTER_CHART}" --version "${KARPENTER_VERSION}" --include-crds \
+  --set settings.clusterName=catalog \
+  > "${tmp}/karpenter-crds.yaml"
+
 echo "==> Extracting JSON Schemas into ${build_dir}/"
 "${FLUX_BIN}" schema extract crd "${tmp}/xrd-crds.yaml" -d "${build_dir}"
 "${FLUX_BIN}" schema extract crd "${tmp}/aigateway-crds.yaml" -d "${build_dir}"
+"${FLUX_BIN}" schema extract crd "${tmp}/karpenter-crds.yaml" -d "${build_dir}"
 
 echo "==> Verifying the catalog is complete"
 for kind in app sqlinstance inferenceservice epi; do
@@ -85,6 +122,14 @@ done
 
 if ! compgen -G "${build_dir}/aigateway.envoyproxy.io/*.json" >/dev/null; then
   echo "error: catalog build produced zero aigateway.envoyproxy.io schemas (chart ${AI_GATEWAY_VERSION} rendered no CRDs?)" >&2
+  exit 1
+fi
+
+# EC2NodeClass is the schema this source exists to fix (the stale ecosystem
+# entry lacks ssmParameter); assert it specifically, not just "some karpenter
+# schema landed".
+if [[ ! -s "${build_dir}/karpenter.k8s.aws/ec2nodeclass_v1.json" ]]; then
+  echo "error: catalog build produced no karpenter.k8s.aws/ec2nodeclass_v1.json (chart ${KARPENTER_VERSION} rendered no CRDs?)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

`flux schema validate` (Gate 1 of `validate-manifests.sh`, SPEC-007) fails on **every PR whose CI regenerates the catalog**:

```
EC2NodeClass/karpenter/gpu-l4 is invalid: schema violation
  - /spec/amiSelectorTerms/0: additional properties 'ssmParameter' not allowed
Summary: ... Valid: 1218, Invalid: 1, Skipped: 0
```

This currently blocks unrelated PRs (e.g. #1628).

## The manifest is correct — the schema was stale

The deployed **karpenter v1.13.0** CRD (`flux/sources/ocirepo-karpenter.yaml`, `ref.semver: 1.13.0`) explicitly defines `amiSelectorTerms[].ssmParameter`, with the CEL rule:

```
self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))
```

`ssmParameter` is the **only** supported AMI selector for the **Bottlerocket NVIDIA** variant the `gpu-l4` NodePool needs — v1 `alias` does not cover it (see the in-file comment).

**Root cause:** that schema was coming from the hosted **`ecosystem`** catalog, pinned to an older provider release (**v1.2.8**) that predates `ssmParameter`. The local **`.schemas`** catalog — which wins in the `schemaLocation` order (`./.schemas` → `default` → `ecosystem`) — only carried the repo XRDs and the Envoy AI Gateway CRDs, so karpenter fell through to the stale entry.

## Fix

Extend `gen-catalog.sh` to extract the Karpenter CRD schemas into the local catalog **from the same OCIRepository pin Flux installs** — mirroring the existing AI Gateway CRD pattern. The local schema then matches the deployed CRD exactly and cannot drift: Renovate bumps the pin, the catalog follows.

- Reads chart URL + version from `flux/sources/ocirepo-karpenter.yaml` (note: `ref.semver:`, not `ref.tag:` like the AI Gateway source — handled with a distinct regex).
- The pinned chart is the **full** karpenter chart (controller + CRDs), whose Deployment template hard-fails without `settings.clusterName`; supplied as a **throwaway** `--set` value. `flux schema extract crd` pulls out **only** the CRDs, so it never reaches the catalog.
- Adds a completeness assertion for `karpenter.k8s.aws/ec2nodeclass_v1.json` (the schema this change exists to fix).

Produces: `karpenter.k8s.aws/ec2nodeclass_v1.json` (+ `karpenter.sh/{nodepool,nodeclaim,nodeoverlay}`).

## Evidence

```
$ ./scripts/validate-manifests.sh
...
Summary: 1219 resources found in 181 files - Valid: 1219, Invalid: 0, Skipped: 0
==> All gates passed
```

(was `Valid: 1218, Invalid: 1`.) `shellcheck` clean; `.schemas/` stays gitignored (generated per run).