### PR TITLE
chore(app-wizard): bump image pin to main-119c516

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -25,12 +25,11 @@ spec:
     # platform's config.
     #
     # Immutable <branch>-<short-sha> tag from Smana/app-wizard's build workflow.
-    # main-018a625 is the first published post-refactor image: it understands
-    # wizard.yaml (config-file layer), derives the claim GVK from the XRD, and
-    # ships github+dev auth only. Bump to the newest main-<short-sha> when the
-    # upstream wizard changes.
+    # It understands wizard.yaml (config-file layer), derives the claim GVK from
+    # the XRD, and ships github+dev auth only. Bump to the newest main-<short-sha>
+    # when the upstream wizard changes.
     repository: ghcr.io/smana/app-wizard
-    tag: "main-018a625"
+    tag: "main-119c516"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions


### PR DESCRIPTION
Bumps the deployed wizard to `ghcr.io/smana/app-wizard:main-119c516`, which carries:
- the `/simplify` cleanup (parse XRD once, drop dead `env()`, layout guard)
- the dark-mode warning-alert readability fix
- the README AI-assist section + light-mode hero screenshot
- the commit-author correction (all history now under the Smana identity)

Verified with the published image against this repo + `wizard.yaml` → `/api/schema` gvk `cloud.ogenki.io/v1alpha1` `App`, stacks `[platform demo]`. `./scripts/validate-manifests.sh` → `Valid: 1219, Invalid: 0, Skipped: 0`.