### PR TITLE
feat(cilium): gateway access logs + bump to 1.19.6

### DIFF
--- a/infrastructure/base/gapi/tailscale-gatewayclass-config.yaml
+++ b/infrastructure/base/gapi/tailscale-gatewayclass-config.yaml
@@ -9,3 +9,13 @@ spec:
     type: LoadBalancer
     loadBalancerClass: tailscale
     externalTrafficPolicy: Cluster
+  # Envoy L7 access logs for both Tailscale gateways (admin + general) using this
+  # GatewayClass. JSON format so VictoriaLogs' `unpack_json` can parse fields
+  # (log.method, log.path, log.response_code, log.duration, ...). Requires Cilium
+  # >= 1.19.6 (spec.telemetry.accessLogs on CiliumGatewayClassConfig). The default
+  # `json` field map (method/path/response_code/duration/upstream_host/...) applies
+  # unless overridden. Logs emit on the cilium-envoy DaemonSet stdout -> VictoriaLogs.
+  telemetry:
+    accessLogs:
+      - format: JSON
+        targets: ["HTTP"]

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -12,7 +12,7 @@ globals {
   cert_manager_approle             = "cert-manager"
 
   # Helm chart versions for EKS bootstrap
-  cilium_version        = "1.19.5"
+  cilium_version        = "1.19.6"
   flux_operator_version = "0.53.0"
   flux_instance_version = "0.53.0"
 


### PR DESCRIPTION
## What

- Bump Cilium `1.19.5` → `1.19.6` (`opentofu/config.tm.hcl`).
- Enable Envoy L7 access logs on the shared Tailscale `CiliumGatewayClassConfig` via `spec.telemetry.accessLogs` (JSON), covering both the admin and general Tailscale gateways.

## Why

`1.19.6` (2026-07-16) is a same-minor patch carrying fixes on this repo's Cilium surface: L7 proxy ports resolved per-frontend (multi-Gateway + `CiliumEnvoyConfig`), CNP established-connections no longer dropped on agent restart, and Gateway API multi-listener namespace/kind fixes. The `spec.telemetry.accessLogs` field requires Cilium ≥ 1.19.6, so the bump and the feature ship together.

JSON format feeds VictoriaLogs' `unpack_json` pipeline (`log.method`, `log.path`, `log.response_code`, `log.duration`, ...); logs emit on the `cilium-envoy` DaemonSet stdout → VictoriaLogs. The default `json` field map applies unless overridden.

## Validation

Verified against the v1.19.6 `CiliumGatewayClassConfig` CRD schema; `kubectl kustomize infrastructure/base/gapi` renders clean. The cluster is not live — full end-to-end validation is deferred to the next cluster bootstrap.
