### PR TITLE
chore(flux): bump operator + instance to 0.55.0

### DIFF
--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -13,8 +13,8 @@ globals {
 
   # Helm chart versions for EKS bootstrap
   cilium_version        = "1.19.6"
-  flux_operator_version = "0.53.0"
-  flux_instance_version = "0.53.0"
+  flux_operator_version = "0.55.0"
+  flux_instance_version = "0.55.0"
 
   # Flux sync configuration
   flux_sync_repository_url = "https://github.com/Smana/cloud-native-ref.git"


### PR DESCRIPTION
## What

Bump the Flux Operator and Flux Instance charts `0.53.0` → `0.55.0` (`opentofu/config.tm.hcl`).

## Why

`0.54.1` fixes a patch-version election bug where a floating `distribution.version: "2.x"` could stay pinned at Flux 2.9.0 and never roll forward to 2.9.2 — which carries the fix that stops postBuild variable substitution from corrupting CRD schemas containing `${...}`. Given this repo's heavy use of postBuild substitution, reaching ≥ 2.9.1 matters.

Non-breaking: no CRD/API changes in 0.54/0.55, and the 2.9.0-line breaking change (`image`/`notification` `v1beta2` API removal) does not affect this repo — notifications are on `v1beta3` and no image-automation controllers are enabled.

Cluster is not live — validation deferred to the next bootstrap.
