### PR TITLE
chore(gateway-api): realign CRD pin to v1.6.1

### DIFF
--- a/opentofu/eks/configure/variables.tf
+++ b/opentofu/eks/configure/variables.tf
@@ -56,7 +56,7 @@ variable "env" {
 variable "gateway_api_version" {
   description = "Gateway API CRDs version — must match flux/sources/gitrepo-gateway-api.yaml ref"
   type        = string
-  default     = "v1.6.0"
+  default     = "v1.6.1"
 }
 
 variable "private_domain_name" {


### PR DESCRIPTION
## What

Realign the Gateway API CRD pin `v1.6.0` → `v1.6.1` (`opentofu/eks/configure/variables.tf` `gateway_api_version` default).

## Why

The Flux source (`flux/sources/gitrepo-gateway-api.yaml`) already tracks `tag: v1.6.1`, while the OpenTofu default was still `v1.6.0` — violating the repo's own stated lockstep invariant ("must match `flux/sources/gitrepo-gateway-api.yaml` ref"). `v1.6.1` is a conformance/test-only release with zero CRD schema change, so practical impact is nil; this fixes the intra-repo drift so a fresh bootstrap installs the same version Flux reconciles.

Cluster is not live — validation deferred to the next bootstrap.
