### PR TITLE
chore(openbao): bump to 2.6.0

### DIFF
--- a/opentofu/openbao/cluster/variables.tf
+++ b/opentofu/openbao/cluster/variables.tf
@@ -22,7 +22,7 @@ variable "mode" {
 variable "openbao_version" {
   description = "OpenBao version to install"
   type        = string
-  default     = "2.5.5"
+  default     = "2.6.0"
 }
 
 variable "openbao_data_path" {


### PR DESCRIPTION
## What

Bump the self-hosted OpenBao version `2.5.5` → `2.6.0` (`opentofu/openbao/cluster/variables.tf` default).

## Why

`2.6.0` (2026-07-14) is the latest OpenBao. The cluster initializes fresh (not a rolling upgrade), so this is a clean-start version pick with no unseal/migration concern. Pre-checks that apply to this deployment pass:

- PKI roles use explicit `allowed_domains` + `allow_subdomains` — no `*` glob templates (which 2.6.0 now rejects by default without `allow_globs_in_identity_templates`).
- Auto-unseal stays on `seal "awskms"` (still supported in 2.6.0).

No CVE forces the jump — 2.5.5 was already a clean security baseline (it carries every windowed fix).

**Future note**: OpenBao 2.7.0 will remove the built-in `awskms` auto-unseal in favor of an external KMS plugin — a genuine breaking migration for this deployment. Do not skip past 2.6.0 without planning that. (2.7.0 does not exist yet.)

Cluster is not live — validation deferred to the next bootstrap.
