### PR TITLE
spec(SPEC-010): migrate SQLInstance backups to Barman Cloud plugin

### DIFF
--- a/docs/specs/010-cnpg-barman-cloud-plugin/clarifications.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/clarifications.md
@@ -1,0 +1,37 @@
+# Clarifications Log — Migrate SQLInstance backups to the Barman Cloud CNPG-I plugin
+
+**Spec**: [SPEC-010](spec.md)
+
+> **Append-only.** Never rewrite earlier entries. Every entry has a stable ID (`CL-1`, `CL-2`, ...) so `spec.md` and `plan.md` can reference the decision by ID. This is the durable "why did we pick option A?" audit trail.
+
+---
+
+## CL-1 — 2026-07-18 — Migrate to the plugin, or stay on in-tree Barman Cloud?
+
+**Asked by**: Spec author
+**Context**: In-tree `barmanObjectStore` is deprecated (CNPG 1.26) and removed in operator **1.31.0**. The cluster runs operator 1.30.0 today, so backups still work — the question is whether to migrate proactively or defer until forced.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | Migrate to the Barman Cloud CNPG-I plugin now | Unblocks the 1.31.0 bump; migration is documented as seamless/zero-data-loss; done on our schedule | New plugin install (greenfield); two render sites to change |
+| B | Stay on in-tree until forced | No work now | Blocks any operator bump past 1.30.x; forced migration under time pressure later |
+
+**Decision**: A — migrate to the plugin now.
+**Rationale**: In-tree removal in 1.31.0 is a hard upstream deadline; the CNPG project documents the plugin migration as seamless. Doing it proactively (while the cluster is not live, per this session's context) removes the operator-upgrade blocker with zero migration risk. Matches the constitution's "prefer the sanctioned upstream mechanism".
+**Decided by**: Recency-assessment session, 2026-07-18 (user-approved as a Tier-1 adoption).
+**References**: <https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/>; SPEC-010 spec.md Problem.
+
+---
+
+<!-- Remaining open questions (plugin delivery mechanism, exact ScheduledBackup plugin API,
+     inheritFromIAMRole support, plugin securityContext/CNP) are tracked in spec.md
+     "Open questions" and will be appended here as CL-2..CL-N once resolved via /clarify. -->
+
+---
+
+## Related
+
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- ADRs: [docs/decisions/](../../decisions/) — ADR-0002 (EKS Pod Identity over IRSA) governs the credential model

--- a/docs/specs/010-cnpg-barman-cloud-plugin/clarifications.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/clarifications.md
@@ -25,9 +25,81 @@
 
 ---
 
-<!-- Remaining open questions (plugin delivery mechanism, exact ScheduledBackup plugin API,
-     inheritFromIAMRole support, plugin securityContext/CNP) are tracked in spec.md
-     "Open questions" and will be appended here as CL-2..CL-N once resolved via /clarify. -->
+## CL-2 — 2026-07-18 — Plugin delivery mechanism: HelmRelease vs raw manifests?
+
+**Asked by**: Spec author (/clarify)
+**Context**: The barman-cloud plugin (controller Deployment + `ObjectStore` CRD) must be installed cluster-wide — greenfield, nothing exists today. Flux can deliver it as a `HelmRelease` from the official chart or as vendored raw manifests; the choice sets version management and how much of the securityContext/CNP the repo owns.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | `HelmRelease` from the official `plugin-barman-cloud` chart | Matches constitution "prefer HelmRelease when an upstream chart exists" + the CNPG-operator install pattern; Flux-native version pin + clean upgrades; Renovate-trackable | Must confirm the chart exposes PSS-restricted `securityContext` + resource knobs |
+| B | Raw manifests vendored under `infrastructure/base/` + CRDs under `crds/base/` | Full control over securityContext / CNP / resources | Manual version bumps; drifts from upstream release manifest; against the prefer-HelmRelease default |
+
+**Decision**: A — `HelmRelease` from the official `plugin-barman-cloud` chart.
+**Rationale**: The plugin ships an official chart, so the constitution's GitOps rule ("prefer `HelmRelease` over raw manifests when an upstream chart exists") applies; mirrors `infrastructure/base/cloudnative-pg/helmrelease.yaml`. Version pin + upgrades stay Flux-native and Renovate-trackable.
+**Decided by**: user via /clarify, 2026-07-18
+**References**: constitution GitOps section; `infrastructure/base/cloudnative-pg/helmrelease.yaml`; [[CL-1]]
+
+## CL-3 — 2026-07-18 — Exact `ScheduledBackup` + `Cluster.spec.plugins` + recovery API shape?
+
+**Asked by**: Spec author (/clarify)
+**Context**: The composition renders `ScheduledBackup`, `Cluster.spec.plugins`, and the recovery `externalClusters`. The plugin API shape had to be confirmed against the real docs/CRD rather than guessed (this marker was a verification, not a design choice).
+
+**Resolution (verified from upstream docs — `plugin-barman-cloud`)**:
+- `ScheduledBackup`: `spec.method: plugin` + `spec.pluginConfiguration.name: barman-cloud.cloudnative-pg.io`.
+- `Cluster`: `spec.plugins: [{name: barman-cloud.cloudnative-pg.io, isWALArchiver: true, parameters: {barmanObjectName: <ObjectStore name>}}]`.
+- Recovery: `Cluster.spec.externalClusters[].plugin: {name: barman-cloud.cloudnative-pg.io, parameters: {barmanObjectName: <recovery ObjectStore>, serverName: <source cluster>}}` — note singular `plugin:` (not `plugins:`) — with `spec.bootstrap.recovery.source: <externalCluster name>`.
+
+**Decision**: Adopt the plugin's documented API verbatim — it is the plugin's only interface, no alternative. Confirms the plan.md FR-003/FR-004 sketch and removes the T001 "verify exact shape" guess.
+**Rationale**: Verified factual answer against canonical upstream docs.
+**Decided by**: verification via upstream docs (/clarify), 2026-07-18
+**References**: <https://github.com/cloudnative-pg/plugin-barman-cloud> (`migration.md`, `usage.md`); [[CL-1]]
+
+## CL-4 — 2026-07-18 — Credential model: credential-less IAM (Pod Identity), access-key Secret, or both?
+
+**Asked by**: Spec author (/clarify)
+**Context**: The plugin's `ObjectStore` supports credential-less IAM on EKS (recommended) or access keys in a Secret. The repo defaults to EKS Pod Identity (existing `PodIdentityAssociation` for SA `<name>-cnpg-cluster`, `main.k:744-761`). FR-006 originally required "no new Secret".
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | Credential-less IAM via Pod Identity (omit `s3Credentials`; ambient creds) | Constitution-aligned; no static creds; reuses IAM bundle | Only works where ambient IAM is available (EKS + Pod Identity) |
+| B | Access-key Secret via ESO (S3 keys in OpenBao → `ExternalSecret` → `ObjectStore.s3Credentials`) | Works for any S3-compatible / cross-account store | Static credential; extra ESO wiring; adds an XRD field |
+
+**Decision**: **Both — A as the default, B as an opt-in alternative.**
+- **Default** (no opt-in): credential-less IAM via Pod Identity — the `ObjectStore` omits explicit `s3Credentials`; the plugin sidecar (in the CNPG instance pods, SA `<name>-cnpg-cluster`) inherits ambient credentials from the existing `PodIdentityAssociation`. No new Secret.
+- **Opt-in**: a claim may select access-key mode, wiring an ESO-backed Secret (keys sourced from OpenBao) into `ObjectStore.s3Credentials`.
+
+**Rationale**: A keeps the default posture constitutional (EKS Pod Identity, never IRSA, no static creds) and satisfies FR-006 for the common path; B adds flexibility for non-Pod-Identity / non-AWS / cross-account object stores without compromising the default. Reconciliations: **FR-006** "no new Secret" now scopes to the default path; the opt-in access-key path uses an ESO-managed Secret (never hardcoded). **Non-Goal #2** (XRD API unchanged) gains a carve-out for one optional, default-off access-key field. Residual for the default path: T001 must confirm the `ObjectStore` accepts an omitted `s3Credentials` block (the plugin docs show IRSA-annotation + access-keys explicitly; the repo must NOT use the IRSA `eks.amazonaws.com/role-arn` annotation — Pod Identity supplies ambient creds via the AWS SDK default chain).
+**Decided by**: user via /clarify, 2026-07-18
+**References**: plugin `ObjectStore` auth docs (IRSA/ambient + access-keys); constitution (Pod Identity; no hardcoded creds → ESO); FR-006; Non-Goal #2; `main.k:744-761`; [[CL-3]]
+
+## CL-5 — 2026-07-18 — Plugin securityContext + resource limits + CNP egress shape?
+
+**Asked by**: Spec author (/clarify)
+**Context**: The plugin controller Deployment + injected backup sidecar must comply with PSS-restricted securityContext (constitution) and need a `CiliumNetworkPolicy` for S3 egress. securityContext + limits are constitution-mandated; the real choice was the CNP egress model (`toFQDNs` vs `toEntities: world`). Both the workload's long-lived nature (CNP rule #4) and the CL-4 ambient-credential path (needs the Pod Identity Agent, CNP rule #3) constrain it.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | `toFQDNs` for S3 + DNS L7 + `toEntities: ["host"]` TCP 80 (Pod Identity Agent) | Precise default-deny; constitution-aligned for long-lived; makes CL-4 ambient creds work | S3 FQDN set to maintain (`matchPattern` subdomain-depth care) |
+| B | `toEntities: world` on TCP 443 | Simpler | Disallowed by CNP rule #4 for long-lived workloads; `world` excludes `host`, so it breaks CL-4's Pod Identity Agent reach (rule #3) regardless |
+
+**Decision**: **A — `toFQDNs`.**
+- **securityContext** (PSS-restricted, both controller and — where configurable — the injected sidecar): `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`. Resource requests + limits set.
+- **CiliumNetworkPolicy** (default-deny + explicit allow) egress:
+  - kube-dns with L7 `rules.dns matchPattern: "*"` — mandatory or `toFQDNs` silently fails (rule #1);
+  - `toFQDNs` for the S3 endpoints (`s3.<region>.amazonaws.com` + regional/bucket variants; watch `matchPattern` subdomain depth — rule #2);
+  - `toEntities: ["host"]` on TCP 80 for the Pod Identity Agent (`169.254.170.23`) — required for CL-4 ambient creds (rule #3);
+  - egress to the CNPG cluster/instances as needed.
+
+**Rationale**: Compliant with CNP rule #4 (no `world:443` on a long-lived workload) and rule #3 (host entity for the Pod Identity Agent); satisfies the constitution's zero-trust default-deny + PSS-restricted mandates. B was rejected: it violates rule #4 and, because `world` excludes the `host` entity, would break CL-4's credential path regardless.
+**Decided by**: user via /clarify, 2026-07-18
+**References**: `.claude/rules/cilium-network-policies.md` (rules #1–#4); constitution security defaults; [[CL-4]] (Pod Identity Agent dependency)
 
 ---
 

--- a/docs/specs/010-cnpg-barman-cloud-plugin/clarifications.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/clarifications.md
@@ -103,6 +103,33 @@
 
 ---
 
+## CL-6 — 2026-07-18 — CORRECTION: no Helm chart exists → GitRepository + Flux Kustomization (supersedes CL-2)
+
+**Asked by**: Implementation (verification before build)
+**Context**: CL-2 chose `HelmRelease` delivery on the premise that the plugin ships an official chart. **Verification during implementation found this premise false**: the Barman Cloud plugin supports only manifest/Kustomize installation — a Helm chart is an open upstream feature request (issue #351). The `plugin-barman-cloud-v0.7.0` "chart" referenced in CL-2 is a *manifest release*, not a Helm chart.
+
+**Options considered** (both raw-manifest — no chart exists):
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A′ | Flux `Kustomization` from a `GitRepository` at the plugin release tag, with kustomize patches (namespace, securityContext, CNP) | Mirrors the repo's existing CNPG-CRD + gateway-api-CRD install pattern; versioned by tag; Renovate-trackable; minimal vendored YAML | Patching a multi-resource upstream manifest |
+| B′ | Vendor the release `manifest.yaml` into the repo | Fully explicit | Large static blob; manual version bumps |
+
+**Decision**: **A′ — Flux `Kustomization` from a `GitRepository`** at the plugin release tag. **Supersedes CL-2.**
+- `ObjectStore` CRD under `crds/base/` (mirrors `crds/base/kustomization-cloudnative-pg.yaml`).
+- Plugin workload under `infrastructure/base/cloudnative-pg-barman-plugin/` via a Flux Kustomization from `flux/sources/gitrepo-barman-cloud-plugin.yaml` (tag), with kustomize patches: **namespace = `infrastructure`** (MUST match the CNPG operator, not the docs' default `cnpg-system`), PSS-restricted securityContext, resource limits, + an added `CiliumNetworkPolicy` (CL-5).
+- Requires **cert-manager** (already in the repo) for plugin↔operator TLS.
+
+**Side-findings (same verification):**
+1. **cert-manager is a hard requirement** for the plugin↔operator mTLS — satisfied (repo already runs cert-manager).
+2. **CL-4 credential mechanism refined**: `ObjectStore.spec.configuration` is the *same* `BarmanObjectStoreConfiguration` type as the in-tree field, so the default path sets `s3Credentials.inheritFromIAMRole: true` (a verbatim carry-over of `main.k:277`) — **not** an omitted block. Ambient Pod Identity still supplies creds via the AWS SDK default chain; the CL-5 host:80 CNP rule is still required. This *strengthens* CL-4 (direct carry-over, no "omit-and-verify" residual).
+
+**Rationale**: No chart exists, so CL-2's `HelmRelease` is impossible. A′ matches the repo's established CRD-install pattern (GitRepository + Flux Kustomization), keeps upgrades to a tag bump, and lets the namespace/securityContext/CNP patches layer on cleanly.
+**Decided by**: user via /clarify (correction), 2026-07-18
+**References**: upstream issue #351 (Helm chart requested); plugin installation docs (manifest/Kustomize; same-namespace-as-operator; cert-manager required); `crds/base/kustomization-cloudnative-pg.yaml`; `flux/sources/gitrepo-cloudnative-pg.yaml`; supersedes [[CL-2]]
+
+---
+
 ## Related
 
 - Constitution: [docs/specs/constitution.md](../constitution.md)

--- a/docs/specs/010-cnpg-barman-cloud-plugin/plan.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/plan.md
@@ -25,9 +25,11 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://<bucketName>
-    # DEFAULT (CL-4): no s3Credentials block → plugin sidecar uses ambient creds from the
-    # existing PodIdentityAssociation. OPT-IN access-key mode adds s3Credentials referencing
-    # an ESO-backed Secret. The IRSA `eks.amazonaws.com/role-arn` annotation is NOT used.
+    s3Credentials:
+      inheritFromIAMRole: true        # DEFAULT (CL-4, refined by CL-6): same barman-cloud API as
+                                      # the in-tree field (main.k:277); ambient Pod Identity via the
+                                      # AWS SDK default chain. OPT-IN access-key mode swaps in
+                                      # accessKeyId/secretAccessKey (ESO Secret). No IRSA annotation.
     wal: { compression: bzip2 }
     data: { compression: bzip2 }
   retentionPolicy: <retentionPolicy>  # moved off Cluster.spec.backup (CL-3)
@@ -79,23 +81,24 @@ spec:
 | `ScheduledBackup` (`method: plugin`) | When `spec.backup.schedule` set | Was in-tree default |
 | `ExternalSecret` (access-key) | When opt-in access-key mode (CL-4 B) | Keys from OpenBao → Secret referenced in `ObjectStore.s3Credentials` |
 | RBAC `objectstores` grant | Always (one-time) | Added to `additional-rbac.yaml` aggregate ClusterRole |
-| barman-cloud plugin (HelmRelease → Deployment + CRD + CNP) | Always (one-time, cluster-wide) | Greenfield install via HelmRelease (CL-2) |
+| barman-cloud plugin (GitRepository + Flux Kustomization → CRD + Deployment + RBAC + Service + cert-manager certs + CNP) | Always (one-time, cluster-wide) | Greenfield install, patched to ns `infrastructure` (CL-6) |
 
 ### Key Entities
 
 - **`ObjectStore`** (`barmancloud.cnpg.io`): per-claim S3 backup destination, named `xplane-<claim>-cnpg-objectstore`.
-- **barman-cloud plugin controller**: cluster-wide Deployment (installed via HelmRelease, CL-2) reconciling `ObjectStore` + injecting the WAL-archiver/backup sidecar into instance pods (runs under the existing SA `<claim>-cnpg-cluster` → existing Pod Identity carries over).
+- **barman-cloud plugin controller**: cluster-wide Deployment in ns `infrastructure` (installed via Flux Kustomization from a GitRepository, CL-6) reconciling `ObjectStore` + injecting the WAL-archiver/backup sidecar into instance pods (runs under the existing SA `<claim>-cnpg-cluster` → existing Pod Identity carries over).
 
 ### Dependencies
 
-- [ ] barman-cloud CNPG-I plugin installed cluster-wide via **HelmRelease** (Deployment + `ObjectStore` CRD + CNP) — greenfield, nothing exists today (CL-2).
+- [ ] barman-cloud CNPG-I plugin installed cluster-wide via **Flux Kustomization from a GitRepository** at the release tag (CRD + Deployment + RBAC + Service + cert-manager certs + CNP), patched to ns `infrastructure` — greenfield, nothing exists today (CL-6).
+- [ ] cert-manager present (plugin↔operator mTLS) — already in the repo.
 - [ ] `objectstores` added to the Crossplane aggregate ClusterRole (`additional-rbac.yaml:13`).
 - [ ] Verify the `ObjectStore` accepts an omitted `s3Credentials` block → ambient Pod Identity auth (CL-4 default; T001).
 - [ ] Target the migration to land **before** any operator `1.31.0` bump (in-tree removed there).
 
 ### Alternatives considered
 
-Keep in-tree `barmanObjectStore` — rejected: removed in operator 1.31.0, blocks the CNPG upgrade path. Switch backup tooling entirely (e.g. off Barman) — rejected: out of scope, plugin is the sanctioned CNPG path. Raw-manifest plugin delivery — rejected (CL-2): constitution prefers `HelmRelease` when an upstream chart exists.
+Keep in-tree `barmanObjectStore` — rejected: removed in operator 1.31.0, blocks the CNPG upgrade path. Switch backup tooling entirely (e.g. off Barman) — rejected: out of scope, plugin is the sanctioned CNPG path. `HelmRelease` delivery — not possible (CL-6): the plugin ships no Helm chart (upstream #351); vendoring the raw manifest — rejected (CL-6) in favour of a GitRepository + Flux Kustomization (matches the repo's CRD-install pattern, tag-versioned).
 
 ---
 
@@ -118,8 +121,9 @@ infrastructure/base/crossplane/configuration/kcl/cloudnativepg/
 ├── main_test.k       # + ObjectStore count / method=plugin / spec.plugins assertions
 └── settings-example.yaml
 infrastructure/base/crossplane/providers/additional-rbac.yaml   # + objectstores
-infrastructure/base/cloudnative-pg-barman-plugin/               # HelmRelease + source + CNP (CL-2)
-crds/base/                                                      # ObjectStore CRD (if not chart-managed)
+infrastructure/base/cloudnative-pg-barman-plugin/               # Flux Kustomization + kustomize patches (ns/securityContext/CNP) (CL-6)
+flux/sources/gitrepo-barman-cloud-plugin.yaml                   # GitRepository @ release tag (CL-6)
+crds/base/kustomization-barman-cloud-plugin.yaml                # ObjectStore CRD, mirrors kustomization-cloudnative-pg.yaml
 ```
 
 ### Validation path
@@ -135,12 +139,12 @@ crds/base/                                                      # ObjectStore CR
 
 > Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../.claude/rules/process.md)).
 
-> **Requirements coverage**: FR-001 → T004; FR-002 → T005; FR-003 → T006 (CL-3); FR-004 → T007; FR-005 → T004; FR-006 → T004 (default: omit `s3Credentials`) / T012 (opt-in access-key, CL-4); FR-007 → T001/T002 (CL-2); FR-008 → T003; FR-009 → T008.
+> **Requirements coverage**: FR-001 → T004; FR-002 → T005; FR-003 → T006 (CL-3); FR-004 → T007; FR-005 → T004; FR-006 → T004 (default: omit `s3Credentials`) / T012 (opt-in access-key, CL-4); FR-007 → T001/T002 (CL-6); FR-008 → T003; FR-009 → T008.
 
 ### Phase 1: Prerequisites
 
 - [ ] **T001**: Verify the `ObjectStore` CRD apiVersion/kind and that omitting `s3Credentials` yields ambient IAM (Pod Identity) auth, against `plugin-barman-cloud` v0.7.0. (The `ScheduledBackup` / `Cluster.spec.plugins` / `externalClusters[].plugin` shapes are confirmed in CL-3.)
-- [ ] **T002**: Install the plugin via **HelmRelease** from the `plugin-barman-cloud` chart (CL-2) — HelmRepository/OCIRepository source + HelmRelease + `ObjectStore` CRD; PSS-restricted securityContext + resource limits (CL-5); default-deny `CiliumNetworkPolicy` per CL-5 (kube-dns L7 + `toFQDNs` S3 + `toEntities: host` TCP 80 Pod Identity Agent).
+- [ ] **T002**: Install the plugin via a **Flux Kustomization from a GitRepository** at the plugin release tag (CL-6): `ObjectStore` CRD under `crds/base/`; Deployment/RBAC/Service/cert-manager certs applied via `infrastructure/base/cloudnative-pg-barman-plugin/` with kustomize patches — **namespace → `infrastructure`** (match the CNPG operator), PSS-restricted securityContext + resource limits (CL-5), and a default-deny `CiliumNetworkPolicy` (kube-dns L7 + `toFQDNs` S3 + `toEntities: host` TCP 80 Pod Identity Agent).
 - [ ] **T003**: Add `objectstores` to the Crossplane aggregate ClusterRole (`additional-rbac.yaml:13`).
 
 ### Phase 2: Implementation

--- a/docs/specs/010-cnpg-barman-cloud-plugin/plan.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/plan.md
@@ -4,7 +4,7 @@
 **Status**: draft
 **Last updated**: 2026-07-18
 
-> The **plan** covers *HOW* to deliver the spec. It may evolve during implementation. Append-only `clarifications.md` is where decisions are durable.
+> The **plan** covers *HOW* to deliver the spec. It may evolve during implementation. Append-only `clarifications.md` is where decisions are durable. Reconciled with CL-2…CL-5 on 2026-07-18.
 
 ---
 
@@ -12,10 +12,12 @@
 
 ### API / Interface
 
-User-facing XRD API is **unchanged**. Internal rendering changes from in-tree to plugin. New rendered `ObjectStore` (per claim with backup):
+User-facing XRD API is unchanged **except** one optional, default-off access-key field (CL-4). Internal rendering changes from in-tree to plugin. Plugin API shapes below are verified in [CL-3](clarifications.md); credential model is [CL-4](clarifications.md).
+
+New rendered `ObjectStore` (per claim with backup) — **default omits `s3Credentials`** (ambient Pod Identity, CL-4):
 
 ```yaml
-apiVersion: barmancloud.cnpg.io/v1   # confirm group/version against plugin-barman-cloud v0.7.0 CRD
+apiVersion: barmancloud.cnpg.io/v1   # verify ObjectStore group/version against plugin v0.7.0 CRD (T001)
 kind: ObjectStore
 metadata:
   name: xplane-<claim>-cnpg-objectstore
@@ -23,14 +25,15 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://<bucketName>
-    s3Credentials:
-      inheritFromIAMRole: true        # reuse existing Pod Identity — FR-006 (verify support)
+    # DEFAULT (CL-4): no s3Credentials block → plugin sidecar uses ambient creds from the
+    # existing PodIdentityAssociation. OPT-IN access-key mode adds s3Credentials referencing
+    # an ESO-backed Secret. The IRSA `eks.amazonaws.com/role-arn` annotation is NOT used.
     wal: { compression: bzip2 }
     data: { compression: bzip2 }
-  retentionPolicy: <retentionPolicy>  # moved off Cluster.spec.backup
+  retentionPolicy: <retentionPolicy>  # moved off Cluster.spec.backup (CL-3)
 ```
 
-`Cluster` gains the plugin ref and drops `spec.backup.barmanObjectStore`:
+`Cluster` gains the plugin ref and drops `spec.backup.barmanObjectStore` (CL-3):
 
 ```yaml
 spec:
@@ -41,41 +44,58 @@ spec:
         barmanObjectName: xplane-<claim>-cnpg-objectstore
 ```
 
-`ScheduledBackup` gains the plugin method:
+`ScheduledBackup` gains the plugin method (CL-3, verified):
 
 ```yaml
 spec:
   method: plugin
-  pluginConfiguration:               # confirm exact field name against plugin CRD
+  pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
+```
+
+Recovery (CL-3) — `Cluster.spec.externalClusters[].plugin` (singular) + `bootstrap.recovery.source`:
+
+```yaml
+spec:
+  bootstrap:
+    recovery:
+      source: <recovery-source-name>
+  externalClusters:
+    - name: <recovery-source-name>
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: xplane-<claim>-cnpg-objectstore-recovery
+          serverName: <source cluster>
 ```
 
 ### Resources Created
 
 | Resource | Condition | Notes |
 |----------|-----------|-------|
-| `ObjectStore` (barman-cloud) | When `spec.backup` set | Replaces in-tree backup config; holds destination + retention + compression |
-| `ObjectStore` (recovery) | When `spec.objectStoreRecovery` set | Feeds `externalClusters` plugin recovery |
+| `ObjectStore` (barman-cloud) | When `spec.backup` set | Replaces in-tree backup config; destination + retention + compression; no `s3Credentials` by default (CL-4) |
+| `ObjectStore` (recovery) | When `spec.objectStoreRecovery` set | Feeds `externalClusters[].plugin` recovery (CL-3) |
 | `Cluster.spec.plugins` entry | When backup set | `isWALArchiver: true` |
 | `ScheduledBackup` (`method: plugin`) | When `spec.backup.schedule` set | Was in-tree default |
+| `ExternalSecret` (access-key) | When opt-in access-key mode (CL-4 B) | Keys from OpenBao → Secret referenced in `ObjectStore.s3Credentials` |
 | RBAC `objectstores` grant | Always (one-time) | Added to `additional-rbac.yaml` aggregate ClusterRole |
-| barman-cloud plugin (Deployment + CRD) | Always (one-time, cluster-wide) | Greenfield install |
+| barman-cloud plugin (HelmRelease → Deployment + CRD + CNP) | Always (one-time, cluster-wide) | Greenfield install via HelmRelease (CL-2) |
 
 ### Key Entities
 
 - **`ObjectStore`** (`barmancloud.cnpg.io`): per-claim S3 backup destination, named `xplane-<claim>-cnpg-objectstore`.
-- **barman-cloud plugin controller**: cluster-wide Deployment reconciling `ObjectStore` + injecting the WAL-archiver/backup sidecar into instance pods (runs under the existing SA `<claim>-cnpg-cluster` → existing Pod Identity carries over).
+- **barman-cloud plugin controller**: cluster-wide Deployment (installed via HelmRelease, CL-2) reconciling `ObjectStore` + injecting the WAL-archiver/backup sidecar into instance pods (runs under the existing SA `<claim>-cnpg-cluster` → existing Pod Identity carries over).
 
 ### Dependencies
 
-- [ ] barman-cloud CNPG-I plugin installed cluster-wide (Deployment + `ObjectStore` CRD) — **greenfield**, nothing exists today.
+- [ ] barman-cloud CNPG-I plugin installed cluster-wide via **HelmRelease** (Deployment + `ObjectStore` CRD + CNP) — greenfield, nothing exists today (CL-2).
 - [ ] `objectstores` added to the Crossplane aggregate ClusterRole (`additional-rbac.yaml:13`).
-- [ ] Plugin `s3Credentials.inheritFromIAMRole` support confirmed (else the IAM/Pod-Identity model changes — see spec Open questions).
+- [ ] Verify the `ObjectStore` accepts an omitted `s3Credentials` block → ambient Pod Identity auth (CL-4 default; T001).
 - [ ] Target the migration to land **before** any operator `1.31.0` bump (in-tree removed there).
 
 ### Alternatives considered
 
-Keep in-tree `barmanObjectStore` — rejected: removed in operator 1.31.0, blocks the CNPG upgrade path. Switch backup tooling entirely (e.g. off Barman) — rejected: out of scope, plugin is the sanctioned CNPG path.
+Keep in-tree `barmanObjectStore` — rejected: removed in operator 1.31.0, blocks the CNPG upgrade path. Switch backup tooling entirely (e.g. off Barman) — rejected: out of scope, plugin is the sanctioned CNPG path. Raw-manifest plugin delivery — rejected (CL-2): constitution prefers `HelmRelease` when an upstream chart exists.
 
 ---
 
@@ -83,9 +103,12 @@ Keep in-tree `barmanObjectStore` — rejected: removed in operator 1.31.0, block
 
 - **Two render sites** must both change: backup (`main.k:273-288`) and recovery `externalClusters` (`main.k:325-339`, bootstrap source `main.k:248-253`). Don't migrate one and miss the other.
 - **No KCL dict mutation** (function-kcl #285) — build the `ObjectStore` and the `spec.plugins` list with inline conditionals, single-line list comprehensions.
-- **IAM bundle is unchanged** if `inheritFromIAMRole` is supported: the plugin sidecar runs in the instance pods under SA `<claim>-cnpg-cluster`, which already has the `PodIdentityAssociation` + IAM role/policy (`main.k:671-761`). No new EPI, no ExternalSecret.
-- **ActivationPolicy needs NO change** — `ObjectStore` is a CNPG-ecosystem CRD, not an `m.upbound.io` managed resource (activation policy only gates Upbound provider CRDs).
+- **Credential model (CL-4)**: default omits `s3Credentials` → the plugin sidecar (in the instance pods under SA `<claim>-cnpg-cluster`) inherits ambient creds from the existing `PodIdentityAssociation` + IAM role/policy (`main.k:671-761`). No new EPI. Opt-in access-key mode adds an `ExternalSecret` (OpenBao-sourced) referenced in `ObjectStore.s3Credentials`.
+- **CNP (CL-5)** — default-deny + explicit allow egress on the plugin controller/sidecar: kube-dns with L7 `rules.dns matchPattern: "*"` (mandatory, rule #1); `toFQDNs` for the S3 endpoints (`s3.<region>.amazonaws.com` + variants; `matchPattern` subdomain-depth care, rule #2); `toEntities: ["host"]` TCP 80 for the Pod Identity Agent `169.254.170.23` (required for the ambient-cred default, rule #3); egress to the CNPG cluster/instances as needed. **Not** `toEntities: world` — long-lived workload (rule #4).
+- **securityContext (CL-5)**: PSS-restricted — `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault` — on the controller and, where configurable, the injected sidecar. Requests + limits set.
+- **ActivationPolicy needs NO change** — `ObjectStore` is a CNPG-ecosystem CRD, not an `m.upbound.io` managed resource.
 - Retention field relocates: delete from `Cluster.spec.backup.retentionPolicy`, add to `ObjectStore.spec.retentionPolicy`.
+- **Failure modes**: plugin controller down → WAL archiving stalls (Cluster archiving condition degrades, backups queue) — no data loss, recovers on controller restart. Rollback: revert the composition + keep operator ≤ 1.30.x (in-tree still present).
 
 ### File structure
 
@@ -95,7 +118,8 @@ infrastructure/base/crossplane/configuration/kcl/cloudnativepg/
 ├── main_test.k       # + ObjectStore count / method=plugin / spec.plugins assertions
 └── settings-example.yaml
 infrastructure/base/crossplane/providers/additional-rbac.yaml   # + objectstores
-crds/base/  or  infrastructure/base/cloudnative-pg-barman-plugin/  # plugin install (delivery TBD — Open Q)
+infrastructure/base/cloudnative-pg-barman-plugin/               # HelmRelease + source + CNP (CL-2)
+crds/base/                                                      # ObjectStore CRD (if not chart-managed)
 ```
 
 ### Validation path
@@ -111,27 +135,28 @@ crds/base/  or  infrastructure/base/cloudnative-pg-barman-plugin/  # plugin inst
 
 > Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../.claude/rules/process.md)).
 
-> **Requirements coverage**: FR-001 → T004; FR-002 → T005; FR-003 → T001/T006; FR-004 → T007; FR-005 → T004; FR-006 → T001 (+ Implementation Notes); FR-007 → T001/T002; FR-008 → T003; FR-009 → T008.
+> **Requirements coverage**: FR-001 → T004; FR-002 → T005; FR-003 → T006 (CL-3); FR-004 → T007; FR-005 → T004; FR-006 → T004 (default: omit `s3Credentials`) / T012 (opt-in access-key, CL-4); FR-007 → T001/T002 (CL-2); FR-008 → T003; FR-009 → T008.
 
 ### Phase 1: Prerequisites
 
-- [ ] **T001**: Confirm plugin CRD group/version, `ScheduledBackup` plugin API shape, and `s3Credentials.inheritFromIAMRole` support against `plugin-barman-cloud-v0.7.0` (resolves 3 Open questions).
-- [ ] **T002**: Decide + implement plugin delivery (HelmRelease vs raw manifests); install controller Deployment + `ObjectStore` CRD cluster-wide, with PSS-restricted securityContext, resource limits, and a default-deny `CiliumNetworkPolicy` for S3 egress.
+- [ ] **T001**: Verify the `ObjectStore` CRD apiVersion/kind and that omitting `s3Credentials` yields ambient IAM (Pod Identity) auth, against `plugin-barman-cloud` v0.7.0. (The `ScheduledBackup` / `Cluster.spec.plugins` / `externalClusters[].plugin` shapes are confirmed in CL-3.)
+- [ ] **T002**: Install the plugin via **HelmRelease** from the `plugin-barman-cloud` chart (CL-2) — HelmRepository/OCIRepository source + HelmRelease + `ObjectStore` CRD; PSS-restricted securityContext + resource limits (CL-5); default-deny `CiliumNetworkPolicy` per CL-5 (kube-dns L7 + `toFQDNs` S3 + `toEntities: host` TCP 80 Pod Identity Agent).
 - [ ] **T003**: Add `objectstores` to the Crossplane aggregate ClusterRole (`additional-rbac.yaml:13`).
 
 ### Phase 2: Implementation
 
-- [ ] **T004**: Render per-claim `ObjectStore` (backup) with destination + retention + compression; drop `Cluster.spec.backup.barmanObjectStore` (`main.k:273-288`).
+- [ ] **T004**: Render per-claim `ObjectStore` (backup) with destination + retention + compression, **no `s3Credentials`** by default (CL-4); drop `Cluster.spec.backup.barmanObjectStore` (`main.k:273-288`).
 - [ ] **T005**: Add `Cluster.spec.plugins` entry (`isWALArchiver: true`, `barmanObjectName`).
-- [ ] **T006**: Set `ScheduledBackup.spec.method: plugin` + plugin ref (`main.k:649-670`).
-- [ ] **T007**: Migrate recovery `externalClusters` to plugin recovery `ObjectStore` (`main.k:325-339`).
+- [ ] **T006**: Set `ScheduledBackup.spec.method: plugin` + `pluginConfiguration.name` (CL-3) (`main.k:649-670`).
+- [ ] **T007**: Migrate recovery `externalClusters[].plugin` + `bootstrap.recovery.source` to a recovery `ObjectStore` (CL-3) (`main.k:325-339`).
+- [ ] **T012**: (opt-in, CL-4 B) Add the optional default-off access-key mode — an optional XRD field selecting access-key auth, wiring an ESO-backed Secret (keys from OpenBao) into `ObjectStore.s3Credentials`.
 
 ### Phase 3: Validation & Documentation
 
 - [ ] **T008**: `main_test.k` asserts `ObjectStore` count + `method: plugin` + `spec.plugins` presence.
 - [ ] **T009**: Basic + recovery examples render with `crossplane render`; `grep barmanObjectStore` → 0 hits (SC-005).
 - [ ] **T010**: `./scripts/validate-manifests.sh` → exit 0, `Invalid: 0, Skipped: 0`.
-- [ ] **T011**: README / `settings-example.yaml` note the plugin backup model.
+- [ ] **T011**: README / `settings-example.yaml` note the plugin backup model + the opt-in access-key mode.
 
 ### Deviations from plan
 
@@ -141,37 +166,39 @@ crds/base/  or  infrastructure/base/cloudnative-pg-barman-plugin/  # plugin inst
 
 ## Review Checklist
 
+> Completed as a design review post-`/clarify` (2026-07-18). `[x]` = the design/CLs satisfy the rule; unchecked items require implementation artifacts not yet present.
+
 ### Project Manager
 
-- [ ] Problem statement is clear and specific
-- [ ] User stories capture real user needs
-- [ ] Acceptance scenarios are testable
-- [ ] Scope is well-defined (goals AND non-goals)
-- [ ] Success criteria are measurable
+- [x] Problem statement is clear and specific
+- [x] User stories capture real user needs
+- [x] Acceptance scenarios are testable
+- [x] Scope is well-defined (goals AND non-goals)
+- [x] Success criteria are measurable
 
 ### Platform Engineer
 
-- [ ] Design follows existing patterns (`SQLInstance` current backup rendering)
-- [ ] Resource naming follows `xplane-*` convention
-- [ ] KCL avoids mutation pattern (function-kcl #285); list comprehensions single-line
-- [ ] Both render sites (backup + recovery) covered
-- [ ] Examples provided (basic + recovery)
+- [x] Design follows existing patterns (`SQLInstance` current backup rendering; CNPG `HelmRelease`)
+- [x] Resource naming follows `xplane-*` convention
+- [x] KCL avoids mutation pattern (function-kcl #285); list comprehensions single-line
+- [x] Both render sites (backup + recovery) covered (T004 + T007)
+- [ ] Examples provided (basic + recovery) — implementation artifact, T009/T011
 
 ### Security & Compliance
 
-- [ ] `CiliumNetworkPolicy` for the plugin controller (default-deny + S3 egress)
-- [ ] Least-privilege RBAC — only `objectstores` added
-- [ ] No hardcoded credentials — S3 via IAM role (Pod Identity, `inheritFromIAMRole`)
-- [ ] Plugin securityContext non-root, read-only FS, `seccompProfile: RuntimeDefault`
-- [ ] IAM policy still scoped to `xplane-*` / the shared bucket; no new deletion perms
+- [x] `CiliumNetworkPolicy` for the plugin controller (default-deny + S3 egress) — CL-5
+- [x] Least-privilege RBAC — only `objectstores` added
+- [x] No hardcoded credentials — S3 via Pod Identity (default, CL-4); opt-in access-key via ESO (never hardcoded)
+- [x] Plugin securityContext non-root, read-only FS, `seccompProfile: RuntimeDefault` — CL-5
+- [x] IAM policy still scoped to `xplane-*` / the shared bucket; no new deletion perms
 
 ### SRE
 
-- [ ] Backup + WAL archiving health observable (Cluster status, Backup phase)
-- [ ] Metrics/logs unaffected (podMonitor still scrapes)
-- [ ] Plugin resource requests + limits set
-- [ ] Failure modes documented (plugin down → archiving stalls)
-- [ ] Recovery / rollback path clear (revert composition + operator stays ≤1.30.x)
+- [x] Backup + WAL archiving health observable (Cluster status, Backup phase)
+- [x] Metrics/logs unaffected (podMonitor still scrapes)
+- [x] Plugin resource requests + limits set — CL-5
+- [x] Failure modes documented (plugin down → archiving stalls) — Implementation Notes
+- [x] Recovery / rollback path clear (revert composition + operator stays ≤1.30.x)
 
 ---
 

--- a/docs/specs/010-cnpg-barman-cloud-plugin/plan.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/plan.md
@@ -1,0 +1,184 @@
+# Plan: Migrate SQLInstance backups to the Barman Cloud CNPG-I plugin
+
+**Spec**: [SPEC-010](spec.md)
+**Status**: draft
+**Last updated**: 2026-07-18
+
+> The **plan** covers *HOW* to deliver the spec. It may evolve during implementation. Append-only `clarifications.md` is where decisions are durable.
+
+---
+
+## Design
+
+### API / Interface
+
+User-facing XRD API is **unchanged**. Internal rendering changes from in-tree to plugin. New rendered `ObjectStore` (per claim with backup):
+
+```yaml
+apiVersion: barmancloud.cnpg.io/v1   # confirm group/version against plugin-barman-cloud v0.7.0 CRD
+kind: ObjectStore
+metadata:
+  name: xplane-<claim>-cnpg-objectstore
+  namespace: <claim namespace>
+spec:
+  configuration:
+    destinationPath: s3://<bucketName>
+    s3Credentials:
+      inheritFromIAMRole: true        # reuse existing Pod Identity — FR-006 (verify support)
+    wal: { compression: bzip2 }
+    data: { compression: bzip2 }
+  retentionPolicy: <retentionPolicy>  # moved off Cluster.spec.backup
+```
+
+`Cluster` gains the plugin ref and drops `spec.backup.barmanObjectStore`:
+
+```yaml
+spec:
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: xplane-<claim>-cnpg-objectstore
+```
+
+`ScheduledBackup` gains the plugin method:
+
+```yaml
+spec:
+  method: plugin
+  pluginConfiguration:               # confirm exact field name against plugin CRD
+    name: barman-cloud.cloudnative-pg.io
+```
+
+### Resources Created
+
+| Resource | Condition | Notes |
+|----------|-----------|-------|
+| `ObjectStore` (barman-cloud) | When `spec.backup` set | Replaces in-tree backup config; holds destination + retention + compression |
+| `ObjectStore` (recovery) | When `spec.objectStoreRecovery` set | Feeds `externalClusters` plugin recovery |
+| `Cluster.spec.plugins` entry | When backup set | `isWALArchiver: true` |
+| `ScheduledBackup` (`method: plugin`) | When `spec.backup.schedule` set | Was in-tree default |
+| RBAC `objectstores` grant | Always (one-time) | Added to `additional-rbac.yaml` aggregate ClusterRole |
+| barman-cloud plugin (Deployment + CRD) | Always (one-time, cluster-wide) | Greenfield install |
+
+### Key Entities
+
+- **`ObjectStore`** (`barmancloud.cnpg.io`): per-claim S3 backup destination, named `xplane-<claim>-cnpg-objectstore`.
+- **barman-cloud plugin controller**: cluster-wide Deployment reconciling `ObjectStore` + injecting the WAL-archiver/backup sidecar into instance pods (runs under the existing SA `<claim>-cnpg-cluster` → existing Pod Identity carries over).
+
+### Dependencies
+
+- [ ] barman-cloud CNPG-I plugin installed cluster-wide (Deployment + `ObjectStore` CRD) — **greenfield**, nothing exists today.
+- [ ] `objectstores` added to the Crossplane aggregate ClusterRole (`additional-rbac.yaml:13`).
+- [ ] Plugin `s3Credentials.inheritFromIAMRole` support confirmed (else the IAM/Pod-Identity model changes — see spec Open questions).
+- [ ] Target the migration to land **before** any operator `1.31.0` bump (in-tree removed there).
+
+### Alternatives considered
+
+Keep in-tree `barmanObjectStore` — rejected: removed in operator 1.31.0, blocks the CNPG upgrade path. Switch backup tooling entirely (e.g. off Barman) — rejected: out of scope, plugin is the sanctioned CNPG path.
+
+---
+
+## Implementation Notes
+
+- **Two render sites** must both change: backup (`main.k:273-288`) and recovery `externalClusters` (`main.k:325-339`, bootstrap source `main.k:248-253`). Don't migrate one and miss the other.
+- **No KCL dict mutation** (function-kcl #285) — build the `ObjectStore` and the `spec.plugins` list with inline conditionals, single-line list comprehensions.
+- **IAM bundle is unchanged** if `inheritFromIAMRole` is supported: the plugin sidecar runs in the instance pods under SA `<claim>-cnpg-cluster`, which already has the `PodIdentityAssociation` + IAM role/policy (`main.k:671-761`). No new EPI, no ExternalSecret.
+- **ActivationPolicy needs NO change** — `ObjectStore` is a CNPG-ecosystem CRD, not an `m.upbound.io` managed resource (activation policy only gates Upbound provider CRDs).
+- Retention field relocates: delete from `Cluster.spec.backup.retentionPolicy`, add to `ObjectStore.spec.retentionPolicy`.
+
+### File structure
+
+```
+infrastructure/base/crossplane/configuration/kcl/cloudnativepg/
+├── main.k            # both render sites + ObjectStore + spec.plugins + ScheduledBackup method
+├── main_test.k       # + ObjectStore count / method=plugin / spec.plugins assertions
+└── settings-example.yaml
+infrastructure/base/crossplane/providers/additional-rbac.yaml   # + objectstores
+crds/base/  or  infrastructure/base/cloudnative-pg-barman-plugin/  # plugin install (delivery TBD — Open Q)
+```
+
+### Validation path
+
+- `kcl fmt` passes; `./scripts/validate-kcl-compositions.sh` → exit 0
+- `crossplane render` on basic + recovery examples succeeds
+- `./scripts/validate-manifests.sh` → exit 0, `Invalid: 0, Skipped: 0` (plugin manifests schema-validate)
+- Polaris ≥ 85 on plugin Deployment
+
+---
+
+## Tasks
+
+> Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../.claude/rules/process.md)).
+
+> **Requirements coverage**: FR-001 → T004; FR-002 → T005; FR-003 → T001/T006; FR-004 → T007; FR-005 → T004; FR-006 → T001 (+ Implementation Notes); FR-007 → T001/T002; FR-008 → T003; FR-009 → T008.
+
+### Phase 1: Prerequisites
+
+- [ ] **T001**: Confirm plugin CRD group/version, `ScheduledBackup` plugin API shape, and `s3Credentials.inheritFromIAMRole` support against `plugin-barman-cloud-v0.7.0` (resolves 3 Open questions).
+- [ ] **T002**: Decide + implement plugin delivery (HelmRelease vs raw manifests); install controller Deployment + `ObjectStore` CRD cluster-wide, with PSS-restricted securityContext, resource limits, and a default-deny `CiliumNetworkPolicy` for S3 egress.
+- [ ] **T003**: Add `objectstores` to the Crossplane aggregate ClusterRole (`additional-rbac.yaml:13`).
+
+### Phase 2: Implementation
+
+- [ ] **T004**: Render per-claim `ObjectStore` (backup) with destination + retention + compression; drop `Cluster.spec.backup.barmanObjectStore` (`main.k:273-288`).
+- [ ] **T005**: Add `Cluster.spec.plugins` entry (`isWALArchiver: true`, `barmanObjectName`).
+- [ ] **T006**: Set `ScheduledBackup.spec.method: plugin` + plugin ref (`main.k:649-670`).
+- [ ] **T007**: Migrate recovery `externalClusters` to plugin recovery `ObjectStore` (`main.k:325-339`).
+
+### Phase 3: Validation & Documentation
+
+- [ ] **T008**: `main_test.k` asserts `ObjectStore` count + `method: plugin` + `spec.plugins` presence.
+- [ ] **T009**: Basic + recovery examples render with `crossplane render`; `grep barmanObjectStore` → 0 hits (SC-005).
+- [ ] **T010**: `./scripts/validate-manifests.sh` → exit 0, `Invalid: 0, Skipped: 0`.
+- [ ] **T011**: README / `settings-example.yaml` note the plugin backup model.
+
+### Deviations from plan
+
+<!-- Append as surprises show up. -->
+
+---
+
+## Review Checklist
+
+### Project Manager
+
+- [ ] Problem statement is clear and specific
+- [ ] User stories capture real user needs
+- [ ] Acceptance scenarios are testable
+- [ ] Scope is well-defined (goals AND non-goals)
+- [ ] Success criteria are measurable
+
+### Platform Engineer
+
+- [ ] Design follows existing patterns (`SQLInstance` current backup rendering)
+- [ ] Resource naming follows `xplane-*` convention
+- [ ] KCL avoids mutation pattern (function-kcl #285); list comprehensions single-line
+- [ ] Both render sites (backup + recovery) covered
+- [ ] Examples provided (basic + recovery)
+
+### Security & Compliance
+
+- [ ] `CiliumNetworkPolicy` for the plugin controller (default-deny + S3 egress)
+- [ ] Least-privilege RBAC — only `objectstores` added
+- [ ] No hardcoded credentials — S3 via IAM role (Pod Identity, `inheritFromIAMRole`)
+- [ ] Plugin securityContext non-root, read-only FS, `seccompProfile: RuntimeDefault`
+- [ ] IAM policy still scoped to `xplane-*` / the shared bucket; no new deletion perms
+
+### SRE
+
+- [ ] Backup + WAL archiving health observable (Cluster status, Backup phase)
+- [ ] Metrics/logs unaffected (podMonitor still scrapes)
+- [ ] Plugin resource requests + limits set
+- [ ] Failure modes documented (plugin down → archiving stalls)
+- [ ] Recovery / rollback path clear (revert composition + operator stays ≤1.30.x)
+
+---
+
+## References
+
+- Spec: [spec.md](spec.md)
+- Clarifications log: [clarifications.md](clarifications.md)
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- CNPG migration guide: <https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/>
+- Similar composition: `infrastructure/base/crossplane/configuration/kcl/cloudnativepg/`

--- a/docs/specs/010-cnpg-barman-cloud-plugin/spec.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/spec.md
@@ -93,7 +93,7 @@ Each criterion must be **falsifiable** — a human or `/verify-spec` must answer
 
 <!-- Resolved via /clarify → appended to clarifications.md as CL-N. -->
 
-- [x] CL-2 — Plugin delivery mechanism: `HelmRelease` from the official `plugin-barman-cloud` chart
+- [x] CL-2 — Plugin delivery mechanism — **SUPERSEDED by CL-6** (no Helm chart exists → GitRepository + Flux Kustomization)
 - [x] CL-3 — `ScheduledBackup` / `Cluster.spec.plugins` / recovery API shape (verified from upstream docs)
 - [x] CL-4 — Credential model: credential-less IAM via Pod Identity (default) + opt-in access-key Secret via ESO
 - [x] CL-5 — Plugin securityContext (PSS-restricted) + CNP egress via `toFQDNs` + Pod Identity Agent host:80

--- a/docs/specs/010-cnpg-barman-cloud-plugin/spec.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/spec.md
@@ -1,0 +1,111 @@
+# Spec: Migrate SQLInstance backups to the Barman Cloud CNPG-I plugin
+
+**ID**: SPEC-010
+**Issue**: [#1635](https://github.com/Smana/cloud-native-ref/issues/1635)
+**Status**: draft
+**Type**: composition
+**Created**: 2026-07-18
+**Last updated**: 2026-07-18
+
+> The **spec** is the contract: *WHAT* we are delivering and *why*. Freeze it once approved. How we build it lives in [`plan.md`](plan.md); decisions made during filling live append-only in [`clarifications.md`](clarifications.md).
+
+---
+
+## Summary
+
+Migrate the `SQLInstance` composition's PostgreSQL backups from the **deprecated in-tree `barmanObjectStore`** to the **Barman Cloud CNPG-I plugin** (`ObjectStore` CR + `Cluster.spec.plugins` reference), preserving the existing IAM-role (EKS Pod Identity) credential path and S3 destination. This unblocks the CloudNativePG operator `1.31.0` upgrade, which removes in-tree Barman Cloud entirely.
+
+---
+
+## Problem
+
+In-tree Barman Cloud backup (`spec.backup.barmanObjectStore`) is **deprecated since CNPG 1.26 and removed in operator 1.31.0**. The `SQLInstance` composition renders in-tree `barmanObjectStore` at **two sites** — the backup config (`kcl/cloudnativepg/main.k:273-288`) and the PITR recovery `externalClusters` (`main.k:325-339`). The cluster currently runs operator **1.30.0** (chart `0.29.0`, CRDs pinned to gitrepo `v1.30.0`), so backups still work today — but the moment we bump past 1.30.x, both **scheduled backups + WAL archiving** and **point-in-time recovery** break.
+
+We must migrate the composition to the plugin model *before* the operator bump, without changing the user-facing backup API or the S3 credential model (IAM role via Pod Identity, `inheritFromIAMRole`).
+
+---
+
+## User Stories
+
+### US-1: Backups keep working after the operator upgrade (Priority: P1)
+
+As a **platform user declaring a `SQLInstance` with backups**, I want daily backups and WAL archiving to keep working after the CNPG operator upgrade, so that my database stays recoverable.
+
+**Acceptance Scenarios**:
+1. **Given** a `SQLInstance` claim with `spec.backup.schedule` set, **When** the composition renders on the plugin-enabled operator, **Then** a `ScheduledBackup` with `method: plugin` produces a completed `Backup` object writing to S3.
+2. **Given** the same claim, **When** continuous archiving runs, **Then** WAL segments are archived to S3 via the plugin (no in-tree `barmanObjectStore` in the rendered `Cluster`).
+
+### US-2: PITR recovery keeps working (Priority: P1)
+
+As a **platform operator**, I want point-in-time recovery (`spec.objectStoreRecovery`) to keep working via the plugin, so that restore paths don't regress.
+
+**Acceptance Scenarios**:
+1. **Given** a `SQLInstance` claim with `spec.objectStoreRecovery` set, **When** the composition renders, **Then** the `Cluster` bootstraps recovery from an `ObjectStore` (plugin `externalClusters` ref), not an in-tree `barmanObjectStore`.
+
+### US-3: Composition free of deprecated APIs before 1.31.0 (Priority: P2)
+
+As a **platform maintainer**, I want the composition free of deprecated Barman APIs before operator 1.31.0, so the CNPG version bump is unblocked.
+
+**Acceptance Scenarios**:
+1. **Given** a rendered `SQLInstance`, **When** I grep the output, **Then** no `barmanObjectStore` key appears in any `Cluster` or `externalClusters` block.
+
+---
+
+## Requirements
+
+### Functional
+
+- **FR-001**: The composition MUST render one barman-cloud `ObjectStore` CR per `SQLInstance` with backups enabled, carrying the S3 `destinationPath`, `retentionPolicy`, and `wal`/`data` compression currently on `barmanObjectStore` (`main.k:273-288`).
+- **FR-002**: The `Cluster` MUST reference the plugin via `spec.plugins: [{name: barman-cloud.cloudnative-pg.io, isWALArchiver: true, parameters: {barmanObjectName: <ObjectStore name>}}]`.
+- **FR-003**: `ScheduledBackup` MUST set `spec.method: plugin` and the plugin reference (exact field — `pluginConfiguration.name` — per the targeted plugin CRD), replacing the default in-tree method (`main.k:649-670`).
+- **FR-004**: The recovery path (`externalClusters[].barmanObjectStore`, `main.k:325-339`, driven by `spec.objectStoreRecovery`) MUST migrate to the plugin recovery model (`ObjectStore` + `externalClusters` plugin ref).
+- **FR-005**: Retention MUST move from `Cluster.spec.backup.retentionPolicy` (`main.k:287`) to `ObjectStore.spec.retentionPolicy`.
+- **FR-006**: S3 credentials MUST continue via IAM role (EKS Pod Identity, `inheritFromIAMRole`) with **no new Kubernetes Secret** — reusing the existing `xplane-*-cnpg-iam-role` + `PodIdentityAssociation` (`main.k:671-761`). *(Conditional on FR-007 verification.)*
+- **FR-007**: The barman-cloud plugin (controller `Deployment` + `ObjectStore` CRD) MUST be installed cluster-wide (greenfield — nothing exists today) before the composition renders plugin refs, AND its `ObjectStore.spec.configuration.s3Credentials` MUST be confirmed to support `inheritFromIAMRole`.
+- **FR-008**: The Crossplane aggregate `ClusterRole` (`additional-rbac.yaml:6-14`) MUST grant `objectstores` (apiGroup `postgresql.cnpg.io`) so the Crossplane SA can create the CR.
+- **FR-009**: `main_test.k` (`main_test.k:43-59`) SHOULD assert the new `ObjectStore` count, `ScheduledBackup.spec.method == "plugin"`, and `Cluster.spec.plugins` presence.
+
+### Non-Goals
+
+- Not changing the shared S3 bucket (`infrastructure/base/cloudnative-pg/s3-bucket.yaml`, `cnpg-backups`) — the composition keeps taking `bucketName` and granting access.
+- Not changing the user-facing XRD backup API (`spec.backup.{schedule,bucketName,retentionPolicy}`, `spec.objectStoreRecovery.{bucketName,path}`) — this is an internal rendering change.
+- Not migrating other CNPG features (Poolers, declarative DatabaseRole, etc.).
+- Not performing the operator `1.31.0` bump itself — that is a separate PR, blocked on this one.
+- Not fixing anything outside backup/recovery rendering.
+
+---
+
+## Success Criteria
+
+Each criterion must be **falsifiable** — a human or `/verify-spec` must answer yes/no with cluster evidence.
+
+- **SC-001**: A `SQLInstance` claim with backup renders exactly one `ObjectStore` CR and a `Cluster` with `spec.plugins` — verified via `crossplane render` and `main_test.k`.
+- **SC-002**: On a live cluster, a `ScheduledBackup` with `method: plugin` produces a `Backup` object reaching `status.phase: completed`, with objects present in S3.
+- **SC-003**: WAL archiving via the plugin succeeds — `Cluster` `status` shows healthy continuous archiving and **no** in-tree `barmanObjectStore` in the rendered `Cluster`.
+- **SC-004**: Recovery from an `ObjectStore` (PITR) bootstraps a new `Cluster` successfully.
+- **SC-005**: `grep barmanObjectStore` over the rendered composition output returns **zero** hits.
+- **SC-006**: `kubectl auth can-i --as=system:serviceaccount:crossplane-system:crossplane create objectstores -A` → `yes`; the `SQLInstance` XR reaches `Synced=True` and `Ready=True` within 60s of apply.
+- **SC-007**: Polaris audit score ≥ 85 on the plugin controller `Deployment`; a default-deny `CiliumNetworkPolicy` scopes the plugin's S3 egress.
+
+---
+
+## Open questions
+
+<!-- Resolved via /clarify → appended to clarifications.md as CL-N. -->
+
+- [ ] [NEEDS CLARIFICATION: Plugin delivery mechanism — `HelmRelease` from the `plugin-barman-cloud` chart (consistent with the CNPG install) vs raw manifests under `crds/base/` + `infrastructure/base/`?]
+- [ ] [NEEDS CLARIFICATION: Exact `ScheduledBackup` plugin API shape (`method` + `pluginConfiguration`) for the targeted plugin version (`plugin-barman-cloud-v0.7.0`, 2026-06-10) — verify against its CRD.]
+- [ ] [NEEDS CLARIFICATION: Does the plugin's `ObjectStore.spec.configuration.s3Credentials` support `inheritFromIAMRole` (Pod Identity)? FR-006 (no new Secret, reuse existing IAM bundle) depends on this being yes.]
+- [ ] [NEEDS CLARIFICATION: Plugin controller security context (PSS-restricted) + resource requests/limits + `CiliumNetworkPolicy` egress shape (S3 endpoints via `toFQDNs` vs `toEntities`).]
+
+---
+
+## References
+
+- Plan: [plan.md](plan.md) — design, tasks, review checklist
+- Clarifications: [clarifications.md](clarifications.md)
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- Migration guide: <https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/>
+- Plugin chart: `plugin-barman-cloud-v0.7.0` (2026-06-10)
+- Composition: `infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k`
+- Database migrations rule: [.claude/rules/database-migrations.md](../../../.claude/rules/database-migrations.md)

--- a/docs/specs/010-cnpg-barman-cloud-plugin/spec.md
+++ b/docs/specs/010-cnpg-barman-cloud-plugin/spec.md
@@ -60,7 +60,7 @@ As a **platform maintainer**, I want the composition free of deprecated Barman A
 - **FR-003**: `ScheduledBackup` MUST set `spec.method: plugin` and the plugin reference (exact field — `pluginConfiguration.name` — per the targeted plugin CRD), replacing the default in-tree method (`main.k:649-670`).
 - **FR-004**: The recovery path (`externalClusters[].barmanObjectStore`, `main.k:325-339`, driven by `spec.objectStoreRecovery`) MUST migrate to the plugin recovery model (`ObjectStore` + `externalClusters` plugin ref).
 - **FR-005**: Retention MUST move from `Cluster.spec.backup.retentionPolicy` (`main.k:287`) to `ObjectStore.spec.retentionPolicy`.
-- **FR-006**: S3 credentials MUST continue via IAM role (EKS Pod Identity, `inheritFromIAMRole`) with **no new Kubernetes Secret** — reusing the existing `xplane-*-cnpg-iam-role` + `PodIdentityAssociation` (`main.k:671-761`). *(Conditional on FR-007 verification.)*
+- **FR-006**: **By default**, S3 credentials MUST use credential-less IAM (EKS Pod Identity) — the `ObjectStore` omits explicit `s3Credentials` and the plugin sidecar inherits ambient credentials from the existing `PodIdentityAssociation` (SA `<name>-cnpg-cluster`, `main.k:744-761`) — with **no new Kubernetes Secret**. A claim MAY opt into access-key mode (keys sourced from OpenBao via `ExternalSecret`, referenced in `ObjectStore.s3Credentials`). See CL-4. *(Default path conditional on FR-007 verifying the `ObjectStore` accepts an omitted `s3Credentials` block; the IRSA `eks.amazonaws.com/role-arn` annotation MUST NOT be used — Pod Identity supplies ambient creds.)*
 - **FR-007**: The barman-cloud plugin (controller `Deployment` + `ObjectStore` CRD) MUST be installed cluster-wide (greenfield — nothing exists today) before the composition renders plugin refs, AND its `ObjectStore.spec.configuration.s3Credentials` MUST be confirmed to support `inheritFromIAMRole`.
 - **FR-008**: The Crossplane aggregate `ClusterRole` (`additional-rbac.yaml:6-14`) MUST grant `objectstores` (apiGroup `postgresql.cnpg.io`) so the Crossplane SA can create the CR.
 - **FR-009**: `main_test.k` (`main_test.k:43-59`) SHOULD assert the new `ObjectStore` count, `ScheduledBackup.spec.method == "plugin"`, and `Cluster.spec.plugins` presence.
@@ -68,7 +68,7 @@ As a **platform maintainer**, I want the composition free of deprecated Barman A
 ### Non-Goals
 
 - Not changing the shared S3 bucket (`infrastructure/base/cloudnative-pg/s3-bucket.yaml`, `cnpg-backups`) — the composition keeps taking `bucketName` and granting access.
-- Not changing the user-facing XRD backup API (`spec.backup.{schedule,bucketName,retentionPolicy}`, `spec.objectStoreRecovery.{bucketName,path}`) — this is an internal rendering change.
+- Not changing the user-facing XRD backup API (`spec.backup.{schedule,bucketName,retentionPolicy}`, `spec.objectStoreRecovery.{bucketName,path}`) — this is an internal rendering change, **except** one optional, default-off access-key field added per CL-4.
 - Not migrating other CNPG features (Poolers, declarative DatabaseRole, etc.).
 - Not performing the operator `1.31.0` bump itself — that is a separate PR, blocked on this one.
 - Not fixing anything outside backup/recovery rendering.
@@ -93,10 +93,10 @@ Each criterion must be **falsifiable** — a human or `/verify-spec` must answer
 
 <!-- Resolved via /clarify → appended to clarifications.md as CL-N. -->
 
-- [ ] [NEEDS CLARIFICATION: Plugin delivery mechanism — `HelmRelease` from the `plugin-barman-cloud` chart (consistent with the CNPG install) vs raw manifests under `crds/base/` + `infrastructure/base/`?]
-- [ ] [NEEDS CLARIFICATION: Exact `ScheduledBackup` plugin API shape (`method` + `pluginConfiguration`) for the targeted plugin version (`plugin-barman-cloud-v0.7.0`, 2026-06-10) — verify against its CRD.]
-- [ ] [NEEDS CLARIFICATION: Does the plugin's `ObjectStore.spec.configuration.s3Credentials` support `inheritFromIAMRole` (Pod Identity)? FR-006 (no new Secret, reuse existing IAM bundle) depends on this being yes.]
-- [ ] [NEEDS CLARIFICATION: Plugin controller security context (PSS-restricted) + resource requests/limits + `CiliumNetworkPolicy` egress shape (S3 endpoints via `toFQDNs` vs `toEntities`).]
+- [x] CL-2 — Plugin delivery mechanism: `HelmRelease` from the official `plugin-barman-cloud` chart
+- [x] CL-3 — `ScheduledBackup` / `Cluster.spec.plugins` / recovery API shape (verified from upstream docs)
+- [x] CL-4 — Credential model: credential-less IAM via Pod Identity (default) + opt-in access-key Secret via ESO
+- [x] CL-5 — Plugin securityContext (PSS-restricted) + CNP egress via `toFQDNs` + Pod Identity Agent host:80
 
 ---
 


### PR DESCRIPTION
## What

Add the SPEC-010 artifacts (`spec.md` / `plan.md` / `clarifications.md`) for migrating the `SQLInstance` composition's PostgreSQL backups from the deprecated in-tree `barmanObjectStore` to the **Barman Cloud CNPG-I plugin** (`ObjectStore` CR + `Cluster.spec.plugins`).

Refs #1635.

## Status

Draft — **spec only, no composition code changes yet**. Next: `/clarify` the 4 open questions (plugin delivery mechanism, `ScheduledBackup` plugin API shape, `inheritFromIAMRole` support, plugin securityContext/CNP) → `/validate` → implement in a follow-up PR.

## Why now

In-tree Barman Cloud is removed in CNPG operator 1.31.0. This spec unblocks the operator upgrade past 1.30.x while preserving the IAM-role (EKS Pod Identity, `inheritFromIAMRole`) credential path and the shared `cnpg-backups` S3 bucket. Two render sites migrate: backup (`main.k:273-288`) and PITR recovery (`main.k:325-339`); RBAC gains `objectstores`.

Validates clean via `./scripts/validate-spec.sh` (only the draft-state review checklist is intentionally unfilled — completed at `/validate`, before implementation).
