### PR TITLE
spec(SPEC-011): opt-in InferencePool saturation autoscaling

### DIFF
--- a/docs/specs/011-inferencepool-saturation-keda/clarifications.md
+++ b/docs/specs/011-inferencepool-saturation-keda/clarifications.md
@@ -1,0 +1,38 @@
+# Clarifications Log — Opt-in InferencePool saturation autoscaling (KEDA)
+
+**Spec**: [SPEC-011](spec.md)
+
+> **Append-only.** Never rewrite earlier entries. Every entry has a stable ID (`CL-1`, `CL-2`, ...) so `spec.md` and `plan.md` can reference the decision by ID. This is the durable "why did we pick option A?" audit trail.
+
+---
+
+## CL-1 — 2026-07-18 — How to handle the EPP dependency of the saturation gauge?
+
+**Asked by**: User (recency-assessment session)
+**Context**: The InferencePool saturation gauge is emitted **only** by the EndpointPicker (EPP). The EPP is [SPEC-004](../004-per-inferenceservice-inferencepool-endpoint/spec.md), opt-in, default-off, and enabled on **zero** models today. There is no independent pool controller emitting the gauge. So a KEDA trigger sourced from it can only be live where the EPP runs — the spec must decide how to handle that dependency.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | Gate the new trigger on `endpointPicker.enabled`; non-EPP models keep the 3 raw triggers | No forced EPP rollout; strictly opt-in and non-breaking; composes with SPEC-004; respects CEL-exclusivity with `canaries[]` | Saturation-based scaling only available on EPP-enabled models |
+| B | Make the EPP a fleet-wide prerequisite; saturation gauge becomes the primary KEDA signal | One clean signal everywhere; retires the inert cache trigger (per SPEC-001's finding) fleet-wide | Large blast radius; forces dropping `canaries[]` on `qwen-coder`; SPEC-004 still draft; EPP becomes mandatory |
+| C | Defer the whole spec until SPEC-004 GA | No work now | Loses the chance to validate the signal on the first EPP-enabled model; the inert-cache-trigger problem lingers |
+
+**Decision**: **A** — gate the new trigger on the EPP (opt-in).
+**Rationale**: Keeps the change non-breaking and layered on top of SPEC-004's default-off EPP. Non-EPP models (the majority, incl. `canaries[]` models that are CEL-blocked from the EPP) are untouched. Lets us empirically validate the pool saturation signal (SPEC-001 flags the cache trigger as dead weight on L4 GPUs) before considering a broader replacement (tracked as a deferred follow-up in FR-007 / spec Open question 3).
+**Decided by**: User, recency-assessment session, 2026-07-18.
+**References**: SPEC-004 (EPP opt-in, FR-001 "default MUST be off"); SPEC-001 (cache trigger inert on L4); spec.md FR-001/FR-002.
+
+---
+
+<!-- Remaining open questions (exact saturation gauge metric name, default saturationThreshold,
+     ADD-vs-REPLACE long term) are tracked in spec.md "Open questions" and appended here as
+     subsequent CL-N entries once resolved via /clarify. -->
+
+---
+
+## Related
+
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- ADRs: [docs/decisions/](../../decisions/)

--- a/docs/specs/011-inferencepool-saturation-keda/plan.md
+++ b/docs/specs/011-inferencepool-saturation-keda/plan.md
@@ -1,0 +1,160 @@
+# Plan: Opt-in InferencePool saturation autoscaling (KEDA)
+
+**Spec**: [SPEC-011](spec.md)
+**Status**: draft
+**Last updated**: 2026-07-18
+
+> The **plan** covers *HOW* to deliver the spec. It may evolve during implementation. Append-only `clarifications.md` is where decisions are durable.
+
+---
+
+## Design
+
+### API / Interface
+
+New optional claim field (default keeps today's behavior):
+
+```yaml
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: InferenceService
+metadata:
+  name: xplane-qwen3-8b
+  namespace: llm
+spec:
+  gateway:
+    endpointPicker:
+      enabled: true          # existing (SPEC-004) — gates the whole feature
+  scaling:
+    saturationThreshold: "0.8"   # NEW, optional; only used when endpointPicker.enabled
+```
+
+Rendered `ScaledObject` (when `endpointPicker.enabled`) gains a 4th trigger appended to the existing three:
+
+```yaml
+- type: prometheus
+  metadata:
+    serverAddress: http://vmsingle-victoria-metrics-k8s-stack.observability.svc:8428
+    query: 'max(inference_pool_<saturation_gauge>{...="<name>"})'   # exact name TBD (FR-005)
+    threshold: "<saturationThreshold>"        # default from spec.scaling
+    activationThreshold: "0.05"
+```
+
+### Resources Created
+
+| Resource | Condition | Notes |
+|----------|-----------|-------|
+| 4th KEDA trigger on the `ScaledObject` | When `endpointPicker.enabled` | OR-combined with the 3 existing (FR-007) |
+| (no new scrape) | — | EPP `VMServiceScrape` (`main.k:726-737`) already scrapes the gauge when EPP on |
+
+No new standalone Kubernetes objects — this is an additive trigger inside the existing per-claim `ScaledObject`.
+
+### Key Entities
+
+- **`ScaledObject`** (`main.k:522-570`): one per `InferenceService`; today 3 triggers, gains a 4th when EPP on.
+- **EPP (`<name>-epp`)**: the only emitter of the pool saturation gauge; rendered only when `endpointPicker.enabled` (SPEC-004 HelmRelease `main.k:670-720` + `VMServiceScrape` `main.k:726-737`).
+
+### Dependencies
+
+- [ ] **EPP running for the model** — hard dependency. The gauge exists only when `spec.gateway.endpointPicker.enabled` (SPEC-004, opt-in, default-off). See [CL-1](clarifications.md).
+- [ ] EPP `VMServiceScrape` feeding the gauge into VictoriaMetrics (already rendered by SPEC-004 when EPP on).
+- [ ] Exact v1.5.0 saturation gauge metric name confirmed (spec Open questions / T001).
+
+### Alternatives considered
+
+**Make the EPP a fleet-wide prerequisite** (turn it on everywhere, saturation gauge becomes the primary signal) — rejected in [CL-1](clarifications.md): larger blast radius, forces dropping `canaries[]` on `qwen-coder`, and SPEC-004 is still draft. **Replace the raw triggers entirely for EPP models** — deferred (FR-007): ADD first, validate (SC-003), then consider replacing. **Defer the whole spec until SPEC-004 GA** — rejected: the gated design is cheap and lets us validate the signal on the first EPP-enabled model.
+
+---
+
+## Implementation Notes
+
+- **Insertion point**: append a 4th trigger dict in the `triggers` list at `main.k:532-567` (after L566), wrapped in an `if _endpointPickerEnabled` conditional. Add `_saturationThreshold` default near `main.k:39-45`. Expose `spec.scaling.saturationThreshold` in `inference-service-definition.yaml` (scaling block ~L25).
+- **No KCL dict mutation** (function-kcl #285): build the triggers list with a single-line comprehension / inline conditional append, not by mutating the list after creation.
+- **Reuse the gate variable** the composition already computes for `endpointPicker` (the same switch that flips `_baseRuleBackendRefsFor` to the InferencePool backend, `main.k:355-357`) — do not introduce a second source of truth.
+- **Metric name is unverified** — `main.k` and the gateway dashboard reference `inference_pool_average_*`; the *pool-wide saturation* gauge (v1.5.0) is new and not yet in the repo. T001 must pin the exact name before wiring the query.
+
+### File structure
+
+```
+infrastructure/base/crossplane/configuration/kcl/inference-service/
+├── main.k            # 4th trigger (gated) + _saturationThreshold default
+├── main_test.k       # 4-triggers-when-EPP / 3-when-not assertions
+└── inference-service-definition.yaml   # spec.scaling.saturationThreshold field
+```
+
+### Validation path
+
+- `kcl fmt` passes; `./scripts/validate-kcl-compositions.sh` → exit 0
+- `crossplane render` on an EPP-on example (4 triggers) and an EPP-off example (3 triggers)
+- `./scripts/validate-manifests.sh` → exit 0, `Invalid: 0, Skipped: 0`
+
+---
+
+## Tasks
+
+> Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../.claude/rules/process.md)).
+
+> **Requirements coverage**: FR-001 → T003; FR-002 → T003/T005; FR-003 → T003; FR-004 → T005; FR-005 → T001; FR-006 → T001/T002; FR-007 → Design (ADD not replace); FR-008 → T004.
+
+### Phase 1: Prerequisites
+
+- [ ] **T001**: Confirm the exact v1.5.0 pool saturation gauge metric name + PromQL from the EPP `/metrics` (resolves spec Open question 1); pick a conservative default `saturationThreshold` (Open question 2).
+
+### Phase 2: Implementation
+
+- [ ] **T002**: Add `spec.scaling.saturationThreshold` to `inference-service-definition.yaml` (optional, defaulted).
+- [ ] **T003**: Add `_saturationThreshold` default (`main.k:~39-45`) and append the gated 4th trigger (`main.k:532-567`), reusing the existing `endpointPicker` gate variable.
+
+### Phase 3: Validation & Documentation
+
+- [ ] **T004**: `main_test.k` asserts 4 triggers with EPP on, 3 with EPP off (SC-001, SC-004).
+- [ ] **T005**: `crossplane render` — EPP-on example renders 4 triggers; EPP-off example diff vs pre-change is empty.
+- [ ] **T006**: `./scripts/validate-manifests.sh` → exit 0, `Invalid: 0, Skipped: 0`.
+- [ ] **T007**: Live validation on the first EPP-enabled model — gauge present in VictoriaMetrics (SC-002), scales up under load (SC-003). *(Deferred to cluster availability.)*
+- [ ] **T008**: README / settings-example note the opt-in saturation trigger + its EPP dependency.
+
+### Deviations from plan
+
+<!-- Append as surprises show up. -->
+
+---
+
+## Review Checklist
+
+### Project Manager
+
+- [ ] Problem statement is clear and specific
+- [ ] User stories capture real user needs
+- [ ] Acceptance scenarios are testable
+- [ ] Scope is well-defined (goals AND non-goals)
+- [ ] Success criteria are measurable
+
+### Platform Engineer
+
+- [ ] Design follows existing patterns (`inference-service` ScaledObject rendering, SPEC-001)
+- [ ] API consistent with the existing `spec.scaling` block
+- [ ] KCL avoids mutation pattern (function-kcl #285); trigger append is single-line/inline-conditional
+- [ ] Reuses the existing `endpointPicker` gate variable (no second source of truth)
+- [ ] Examples provided (EPP-on + EPP-off)
+
+### Security & Compliance
+
+- [ ] No new network surface — reuses EPP `VMServiceScrape` (already CNP-scoped to vmagent, `main.k:320-329`)
+- [ ] No new credentials
+- [ ] No RBAC change (trigger lives in the existing `ScaledObject`; `scaledobjects` already granted, `additional-rbac.yaml:149`)
+
+### SRE
+
+- [ ] Metric sourced from VictoriaMetrics (same `serverAddress` as existing triggers)
+- [ ] No scale-to-zero (min ≥ 1, per SPEC-001's min=1 default)
+- [ ] Failure mode: EPP down → gauge stale → trigger contributes nothing, raw triggers still scale (safe degradation)
+- [ ] Rollback: remove the field / set `endpointPicker.enabled: false` → reverts to 3 triggers
+
+---
+
+## References
+
+- Spec: [spec.md](spec.md)
+- Clarifications log: [clarifications.md](clarifications.md)
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- Depends on: [SPEC-004](../004-per-inferenceservice-inferencepool-endpoint/spec.md)
+- Builds on: [SPEC-001](../0001-llm-platform-prometheus-autoscaling/spec.md)

--- a/docs/specs/011-inferencepool-saturation-keda/spec.md
+++ b/docs/specs/011-inferencepool-saturation-keda/spec.md
@@ -1,0 +1,112 @@
+# Spec: Opt-in InferencePool saturation autoscaling (KEDA)
+
+**ID**: SPEC-011
+**Issue**: [#1636](https://github.com/Smana/cloud-native-ref/issues/1636)
+**Status**: draft
+**Type**: composition
+**Created**: 2026-07-18
+**Last updated**: 2026-07-18
+
+> The **spec** is the contract: *WHAT* we are delivering and *why*. Freeze it once approved. How we build it lives in [`plan.md`](plan.md); decisions made during filling live append-only in [`clarifications.md`](clarifications.md).
+
+---
+
+## Summary
+
+Add an **opt-in** fourth KEDA trigger to the `inference-service` composition that scales a vLLM model on the **InferencePool saturation gauge** emitted by the EndpointPicker (EPP, Gateway API Inference Extension v1.5.0), **gated on `spec.gateway.endpointPicker.enabled`**. Models without the EPP keep today's three vLLM-raw triggers unchanged. This layers cleanly on top of the (default-off) EPP from [SPEC-004](../004-per-inferenceservice-inferencepool-endpoint/spec.md) — it does **not** force the EPP on.
+
+---
+
+## Problem
+
+Today the composition scales every vLLM model on **three OR-combined vLLM-raw Prometheus triggers** (`kcl/inference-service/main.k:532-567`): running-ratio (`vllm:num_requests_running / maxNumSeqs`, threshold 0.7), KV-cache (`vllm:kv_cache_usage_perc`, 0.6), and queue-depth (`vllm:num_requests_waiting`, 8). Two problems:
+
+1. **The KV-cache trigger is dead weight on L4 GPUs.** [SPEC-001](../0001-llm-platform-prometheus-autoscaling/spec.md) records (its inert-cache-trigger finding) that with `maxNumSeqs=32` the running-ratio trigger always fires first, so the cache trigger is never practically exercised — three triggers where one is inert.
+2. When the **EPP** is enabled (SPEC-004), the Inference Extension v1.5.0 EPP emits a **pool-level saturation gauge** (plus inflight-token saturation) that could be a cleaner *single* leading signal than three raw per-replica metrics. But that gauge **only exists when the EPP runs** — there is no independent pool controller emitting it, and the EPP is opt-in, default-off, and enabled on **zero models today**.
+
+We want an opt-in path to scale on the pool saturation signal for EPP-enabled models, **without** forcing an EPP rollout and **without** changing autoscaling for the (majority) non-EPP models.
+
+---
+
+## User Stories
+
+### US-1: Cleaner pool-level scaling signal for EPP-enabled models (Priority: P1)
+
+As a **platform user running a model with `endpointPicker.enabled: true`**, I want KEDA to scale on the InferencePool saturation gauge, so that autoscaling uses a single pool-level leading signal instead of three raw vLLM metrics (one of which is inert on our GPUs).
+
+**Acceptance Scenarios**:
+1. **Given** a claim with `spec.gateway.endpointPicker.enabled: true`, **When** the composition renders the `ScaledObject`, **Then** it contains a fourth Prometheus trigger querying the InferencePool saturation gauge.
+2. **Given** that model under load, **When** pool saturation crosses the threshold, **Then** KEDA scales the model Deployment up.
+
+### US-2: Non-EPP autoscaling is unchanged (Priority: P1)
+
+As a **platform user not using the EPP**, I want autoscaling to be byte-identical to today (running-ratio + KV-cache + queue), so that this change is non-breaking and strictly opt-in.
+
+**Acceptance Scenarios**:
+1. **Given** a claim without `endpointPicker` (or `enabled: false`), **When** the composition renders, **Then** the `ScaledObject` has exactly the three existing triggers and the rendered diff vs pre-change is empty.
+
+### US-3: The saturation trigger is validated before trust (Priority: P2)
+
+As a **platform maintainer**, I want the saturation trigger validated against real EPP metrics on a live cluster before we consider it a replacement for the raw triggers, so we don't regress scaling behavior.
+
+**Acceptance Scenarios**:
+1. **Given** an EPP-enabled model on a live cluster, **When** I query VictoriaMetrics for the saturation gauge, **Then** it returns data, and under load the trigger scales up before/comparably to running-ratio.
+
+---
+
+## Requirements
+
+### Functional
+
+- **FR-001**: When `spec.gateway.endpointPicker.enabled` is true, the composition MUST render an additional KEDA Prometheus trigger sourced from the InferencePool saturation gauge, appended to the existing triggers (`main.k:532-567`).
+- **FR-002**: When `endpointPicker` is absent or false, the `ScaledObject` MUST render exactly today's three triggers — **no change** (opt-in, default-off).
+- **FR-003**: The saturation trigger MUST use the same `serverAddress` as the existing triggers — `http://vmsingle-victoria-metrics-k8s-stack.observability.svc:8428` (`main.k:108`).
+- **FR-004**: The metric MUST be scraped by the EPP `VMServiceScrape` already rendered when `endpointPicker` is on (`main.k:726-737`); no new scrape config is required for EPP-enabled models.
+- **FR-005**: The exact saturation gauge metric name + PromQL MUST be confirmed against the GAIE v1.5.0 EPP `/metrics` output before implementation (repo dashboard already references the `inference_pool_*` naming family: `inference_pool_average_kv_cache_utilization`, `inference_pool_average_queue_size`).
+- **FR-006**: The saturation threshold MUST be claim-overridable via a new `spec.scaling.saturationThreshold` field with a conservative default; the trigger MUST also set an `activationThreshold` consistent with the min=1 design.
+- **FR-007**: The new trigger MUST **add to** (OR-combine with) the existing triggers initially, not replace them — replacing raw triggers for EPP models is deferred to a follow-up after empirical validation (US-3).
+- **FR-008**: `main_test.k` MUST assert **4** triggers when `endpointPicker` is on and **3** when off (`main_test.k:96-101`).
+
+### Non-Goals
+
+- **Not** turning the EPP on by default — it stays SPEC-004 opt-in, default-off.
+- **Not** removing the three existing triggers for non-EPP models.
+- **Not** making the EPP a fleet-wide prerequisite (rejected — see [CL-1](clarifications.md)).
+- **Not** forcing `qwen-coder` (or any `canaries[]` model) off canaries — the EPP is CEL-mutually-exclusive with `canaries[]`, so those models simply don't get the new trigger.
+- **Not** fixing the pre-existing `num_requests_waiting` trigger inconsistency (code `main.k:562` re-added it despite SPEC-001 CL-1 dropping it) — flagged for a **separate** cleanup PR.
+
+---
+
+## Success Criteria
+
+Each criterion must be **falsifiable** — a human or `/verify-spec` must answer yes/no with cluster evidence.
+
+- **SC-001**: A claim with `endpointPicker.enabled: true` renders a `ScaledObject` with **4** triggers; a claim without it renders **3** — verified via `crossplane render` + `main_test.k`.
+- **SC-002**: On a live cluster with an EPP-enabled model, the saturation gauge metric is present in VictoriaMetrics (query returns non-empty data).
+- **SC-003**: Under load, the saturation trigger scales the model up before or comparably to the running-ratio trigger — evidence: KEDA/HPA scale events + the two metrics' timeseries.
+- **SC-004**: A non-EPP model's rendered `ScaledObject` is **byte-identical** to pre-change (empty diff).
+- **SC-005**: No scale-to-zero — `minReplicaCount` stays ≥ 1 for all models (consistent with SPEC-001's min=1 default).
+
+---
+
+## Open questions
+
+<!-- Resolved via /clarify → appended to clarifications.md as CL-N. -->
+
+- [ ] [NEEDS CLARIFICATION: Exact v1.5.0 saturation gauge metric name + PromQL — verify from the EPP source/`/metrics` (candidate family `inference_pool_*`; the *pool-wide saturation* gauge name is not yet referenced anywhere in the repo).]
+- [ ] [NEEDS CLARIFICATION: Default value for `spec.scaling.saturationThreshold` — needs empirical tuning; start conservative.]
+- [ ] [NEEDS CLARIFICATION: Long-term, should the saturation trigger REPLACE the raw triggers for EPP models (cleaner single signal) rather than OR-combine? Deferred to a follow-up after SC-003 validation — FR-007 keeps ADD for now.]
+
+<!-- Resolved: CL-1 — gate the new trigger on the EPP (opt-in), do not force EPP rollout. -->
+
+---
+
+## References
+
+- Plan: [plan.md](plan.md) — design, tasks, review checklist
+- Clarifications: [clarifications.md](clarifications.md)
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- Depends on: [SPEC-004 — per-InferenceService InferencePool + EPP](../004-per-inferenceservice-inferencepool-endpoint/spec.md) (opt-in, default-off)
+- Builds on: [SPEC-001 — LLM platform Prometheus autoscaling](../0001-llm-platform-prometheus-autoscaling/spec.md) (its lagging-signal + inert-cache-trigger decisions)
+- Composition: `infrastructure/base/crossplane/configuration/kcl/inference-service/main.k`
+- EPP metrics precedent: `apps/base/ai/llm/grafana-dashboard-gateway.yaml`


### PR DESCRIPTION
## What

Add the SPEC-011 artifacts for an **opt-in** fourth KEDA trigger on the `inference-service` composition that scales vLLM on the InferencePool **saturation gauge** (Gateway API Inference Extension v1.5.0), gated on `spec.gateway.endpointPicker.enabled`. Non-EPP models keep today's three vLLM-raw triggers unchanged.

Refs #1636.

## Status

Draft — **spec only, no composition changes yet**. The gate-on-EPP decision is recorded as CL-1: the saturation gauge is EPP-emitted and the EPP is opt-in / default-off / enabled on zero models today, so this layers on SPEC-004 **without forcing an EPP rollout**. Next: `/clarify` (exact v1.5.0 saturation metric name, default threshold, ADD-vs-replace long-term) → `/validate` → implement.

## Why now

SPEC-001 records the KV-cache trigger as inert on L4 GPUs (running-ratio always fires first) — a single pool-level gauge is a cleaner leading signal where the EPP runs. This captures that as an opt-in path before the first EPP-enabled model lands.

Validates clean via `./scripts/validate-spec.sh` (only the draft-state review checklist is intentionally unfilled).
