### PR TITLE
feat(SPEC-010): migrate SQLInstance backups to the Barman Cloud CNPG-I plugin

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -165,14 +165,14 @@
         "filename": "infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k",
         "hashed_secret": "249ba36000029bbe97499c03db5a9001f6b734ec",
         "is_verified": false,
-        "line_number": 377
+        "line_number": 415
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 384
+        "line_number": 422
       }
     ],
     "infrastructure/base/crossplane/configuration/kcl/inference-service/main.k": [
@@ -503,5 +503,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-13T22:40:49Z"
+  "generated_at": "2026-07-18T10:49:09Z"
 }

--- a/crds/base/kustomization-barman-cloud-plugin.yaml
+++ b/crds/base/kustomization-barman-cloud-plugin.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: crds-barman-cloud-plugin
+  namespace: infrastructure
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: barman-cloud-plugin
+  # ObjectStore CRD (barmancloud.cnpg.io/v1) only. The controller bundle
+  # (infrastructure/base/cloudnative-pg-barman-plugin) deletes this same CRD
+  # from its own render so this Kustomization is its sole owner — installed
+  # early with the other CRDs, before Crossplane renders any ObjectStore.
+  path: "./config/crd/bases"
+  prune: true
+  timeout: 10m

--- a/crds/base/kustomization.yaml
+++ b/crds/base/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - kustomization-inference-extension.yaml
   - kustomization-kyverno.yaml
   - kustomization-cloudnative-pg.yaml
+  - kustomization-barman-cloud-plugin.yaml
   - kustomization-tailscale-operator.yaml
   - kustomization-victoria-metrics-operator.yaml

--- a/flux/sources/gitrepo-barman-cloud-plugin.yaml
+++ b/flux/sources/gitrepo-barman-cloud-plugin.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: barman-cloud-plugin
+  namespace: infrastructure
+spec:
+  interval: 5m0s
+  url: https://github.com/cloudnative-pg/plugin-barman-cloud.git
+  ref:
+    # Pinned to the release contemporary with CNPG operator 1.30.0 (SPEC-010
+    # migrates to the plugin *before* the 1.31.0 bump). Bump this tag together
+    # with the operator upgrade; scripts/flux-schema/gen-catalog.sh reads it as
+    # the single source of truth for the ObjectStore CRD schema.
+    tag: v0.7.0

--- a/infrastructure/base/cloudnative-pg-barman-plugin/barman-cloud-plugin.yaml
+++ b/infrastructure/base/cloudnative-pg-barman-plugin/barman-cloud-plugin.yaml
@@ -1,0 +1,83 @@
+# Barman Cloud CNPG-I plugin controller (SPEC-010, CL-6).
+#
+# No Helm chart exists for the plugin (upstream #351), so it is installed the
+# same way this repo installs CNPG's own CRDs: a Flux Kustomization sourcing the
+# plugin GitRepository at a pinned tag. The upstream `kubernetes/` overlay ships
+# a controller Deployment + Service + RBAC + cert-manager Issuer/Certificates
+# for the plugin<->operator mTLS, defaulting to namespace `cnpg-system`.
+#
+# Patches applied here (kustomize semantics via spec.patches / spec.targetNamespace):
+#   - targetNamespace: infrastructure  -> co-locate with the CNPG operator
+#     (the plugin MUST run in the operator's namespace).
+#   - Deployment barman-cloud: add resource requests + limits (upstream ships
+#     `resources: {}`) and restate the PSS-restricted securityContext explicitly.
+#   - delete the ObjectStore CRD from this render — it is owned by the
+#     `crds-barman-cloud-plugin` Kustomization (crds/base) so the two do not
+#     fight over the same cluster-scoped object.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg-barman-plugin
+spec:
+  interval: 10m
+  timeout: 5m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: barman-cloud-plugin
+  path: "./kubernetes"
+  targetNamespace: infrastructure
+  # cert-manager (Issuer/Certificates for plugin<->operator mTLS) lives in the
+  # `security` stage; the `infrastructure` parent does NOT depend on it, so gate
+  # here explicitly. `crds` provides the ObjectStore CRD the controller watches.
+  dependsOn:
+    - name: crds
+      namespace: flux-system
+    - name: security
+      namespace: flux-system
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: barman-cloud
+      namespace: infrastructure
+  patches:
+    - patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: barman-cloud
+        spec:
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: barman-cloud
+                  resources:
+                    requests:
+                      cpu: 10m
+                      memory: 64Mi
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                    runAsNonRoot: true
+                    capabilities:
+                      drop:
+                        - ALL
+                    seccompProfile:
+                      type: RuntimeDefault
+    # Owned by crds-barman-cloud-plugin; drop it from the controller bundle.
+    - target:
+        kind: CustomResourceDefinition
+        name: objectstores.barmancloud.cnpg.io
+      patch: |
+        $patch: delete
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: objectstores.barmancloud.cnpg.io

--- a/infrastructure/base/cloudnative-pg-barman-plugin/kustomization.yaml
+++ b/infrastructure/base/cloudnative-pg-barman-plugin/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: infrastructure
+
+resources:
+  - barman-cloud-plugin.yaml
+  - network-policy.yaml

--- a/infrastructure/base/cloudnative-pg-barman-plugin/network-policy.yaml
+++ b/infrastructure/base/cloudnative-pg-barman-plugin/network-policy.yaml
@@ -1,0 +1,89 @@
+# Default-deny + explicit allow for the Barman Cloud plugin controller
+# (SPEC-010 CL-5). Zero-trust posture per platform constitution.
+#
+# The controller (`app: barman-cloud`) serves the CNPG-I gRPC API on :9090 to
+# the CloudNativePG operator and instance managers, reconciles ObjectStore /
+# Backup CRs against the Kubernetes API, and performs object-store operations
+# (backup listing / store validation) directly against S3. The actual WAL
+# archiving / base-backup I/O is done by a sidecar injected into the CNPG
+# instance pods (SA `<name>-cnpg-cluster`); that sidecar's egress is governed by
+# a CNP rendered by the SQLInstance composition, not here.
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: barman-cloud-plugin
+spec:
+  description: "Barman Cloud CNPG-I plugin controller — S3 backups for CloudNativePG"
+  endpointSelector:
+    matchLabels:
+      app: barman-cloud
+  ingress:
+    # Kubelet TCP readiness probe on the gRPC port (host network).
+    - fromEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # CNPG operator (same namespace) dials the plugin gRPC API.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: infrastructure
+            app.kubernetes.io/name: cloudnative-pg
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # CNPG instance managers (in any claim namespace) also dial the plugin.
+    - fromEndpoints:
+        - matchLabels:
+            cnpg.io/podRole: instance
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+  egress:
+    # DNS — L7 inspection is MANDATORY for toFQDNs to resolve (CNP rule #1):
+    # without rules.dns Cilium never learns the S3 IPs and every TCP follow-up
+    # is silently dropped.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # Kubernetes API server (reconciles ObjectStore / Backup / Cluster status).
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # S3 backup store. matchPattern is single-segment (CNP rule #2):
+    # `*.s3.<region>...` covers virtual-hosted bucket URLs; the bare regional
+    # host covers path-style + the S3 API endpoint.
+    - toFQDNs:
+        - matchName: s3.${region}.amazonaws.com
+        - matchPattern: "*.s3.${region}.amazonaws.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # EKS Pod Identity Agent (169.254.170.23:80) for ambient IAM credentials
+    # (inheritFromIAMRole). It runs on the node host network, so Cilium
+    # classifies it as the `host` entity — toCIDR alone would silently fail
+    # (CNP rule #3).
+    - toEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "cloudnativepg"
 edition = "v0.11.3"
-version = "0.2.6"
+version = "0.3.0"

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k
@@ -270,22 +270,20 @@ _items += [
                                 }
                         }
                 }
-            if oxr.spec.backup:
-                backup = {
-                    barmanObjectStore = {
-                        destinationPath = "s3://" + oxr.spec.backup.bucketName
-                        s3Credentials = {
-                            inheritFromIAMRole = True
-                        }
-                        wal = {
-                            compression = "bzip2"
-                        }
-                        data = {
-                            compression = "bzip2"
+            # Barman Cloud CNPG-I plugin (SPEC-010): the plugin must be loaded for
+            # backup (WAL archiving) OR recovery. isWALArchiver only when backing up;
+            # barmanObjectName points at the backup ObjectStore, else the recovery one.
+            if oxr.spec.backup or oxr.spec.objectStoreRecovery:
+                plugins = [
+                    {
+                        name = "barman-cloud.cloudnative-pg.io"
+                        if oxr.spec.backup:
+                            isWALArchiver = True
+                        parameters = {
+                            barmanObjectName = (oxr.metadata.name + "-cnpg-objectstore") if oxr.spec.backup else (oxr.metadata.name + "-cnpg-objectstore-recovery")
                         }
                     }
-                    retentionPolicy = oxr.spec.backup.retentionPolicy
-                }
+                ]
             if oxr.spec.createSuperuser:
                 superuserSecret = {
                     name = oxr.metadata.name + "-cnpg-superuser"
@@ -326,13 +324,11 @@ _items += [
                 externalClusters = [
                     {
                         name = oxr.spec.objectStoreRecovery.path
-                        barmanObjectStore = {
-                            destinationPath = "s3://" + oxr.spec.objectStoreRecovery.bucketName
-                            s3Credentials = {
-                                inheritFromIAMRole = True
-                            }
-                            wal: {
-                                maxParallel: 8
+                        plugin = {
+                            name = "barman-cloud.cloudnative-pg.io"
+                            parameters = {
+                                barmanObjectName = oxr.metadata.name + "-cnpg-objectstore-recovery"
+                                serverName = oxr.spec.objectStoreRecovery.path
                             }
                         }
                     }
@@ -352,6 +348,48 @@ _items += [
         }
     }
 ]
+
+# Barman Cloud plugin ObjectStore(s) (SPEC-010) — replace the deprecated in-tree
+# barmanObjectStore. spec.configuration is the same BarmanObjectStoreConfiguration
+# type as the in-tree field, so s3Credentials.inheritFromIAMRole (Pod Identity) is a
+# verbatim carry-over; retentionPolicy relocates from Cluster.spec.backup to here.
+if oxr.spec.backup:
+    _items += [{
+        apiVersion = "barmancloud.cnpg.io/v1"
+        kind = "ObjectStore"
+        metadata = {
+            name = oxr.metadata.name + "-cnpg-objectstore"
+            namespace = oxr.metadata.namespace
+            annotations = {"krm.kcl.dev/ready" = "True"}
+        }
+        spec = {
+            configuration = {
+                destinationPath = "s3://" + oxr.spec.backup.bucketName
+                s3Credentials = {inheritFromIAMRole = True}
+                wal = {compression = "bzip2"}
+                data = {compression = "bzip2"}
+            }
+            retentionPolicy = oxr.spec.backup.retentionPolicy
+        }
+    }]
+
+if oxr.spec.objectStoreRecovery:
+    _items += [{
+        apiVersion = "barmancloud.cnpg.io/v1"
+        kind = "ObjectStore"
+        metadata = {
+            name = oxr.metadata.name + "-cnpg-objectstore-recovery"
+            namespace = oxr.metadata.namespace
+            annotations = {"krm.kcl.dev/ready" = "True"}
+        }
+        spec = {
+            configuration = {
+                destinationPath = "s3://" + oxr.spec.objectStoreRecovery.bucketName
+                s3Credentials = {inheritFromIAMRole = True}
+                wal = {maxParallel = 8}
+            }
+        }
+    }]
 
 # Create ExternalSecrets for database owners (used by initdb, roles, and applications)
 # Each database gets a secret named after the database (not the role) to support CNPG initdb bootstrap
@@ -663,6 +701,11 @@ if oxr.spec.backup?.schedule:
             spec = {
                 schedule = oxr.spec.backup.schedule
                 backupOwnerReference = "self"
+                # Plugin-based backup (SPEC-010, CL-3) — replaces the in-tree barmanObjectStore method.
+                method = "plugin"
+                pluginConfiguration = {
+                    name = "barman-cloud.cloudnative-pg.io"
+                }
                 cluster = {
                     name = oxr.metadata.name + "-cnpg-cluster"
                 }

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main_test.k
@@ -47,6 +47,20 @@ test_backup_resources = lambda {
         backups = [r for r in items if r.kind == "ScheduledBackup"]
         assert len(backups) == 1, "expected 1 ScheduledBackup"
         assert backups[0].spec.schedule == _oxr.spec.backup.schedule
+        # SPEC-010: plugin-based backup, not the in-tree barmanObjectStore method
+        assert backups[0].spec.method == "plugin", "ScheduledBackup must use method=plugin"
+        assert backups[0].spec.pluginConfiguration.name == "barman-cloud.cloudnative-pg.io"
+        # ObjectStore CR carries the S3 config + retention (moved off the Cluster)
+        objectstores = [r for r in items if r.kind == "ObjectStore"]
+        assert len(objectstores) == 1, "expected 1 ObjectStore for backup"
+        assert objectstores[0].spec.configuration.destinationPath == "s3://" + _oxr.spec.backup.bucketName
+        assert objectstores[0].spec.retentionPolicy == _oxr.spec.backup.retentionPolicy
+        # Cluster loads the barman-cloud WAL archiver plugin, not in-tree spec.backup
+        clusters = [r for r in items if r.kind == "Cluster"]
+        assert len(clusters[0].spec.plugins) == 1, "expected the barman-cloud plugin on the Cluster"
+        assert clusters[0].spec.plugins[0].name == "barman-cloud.cloudnative-pg.io"
+        assert clusters[0].spec.plugins[0].isWALArchiver == True
+        assert not clusters[0].spec?.backup, "Cluster must not carry in-tree spec.backup (SC-005)"
         # IAM resources for backup
         roles = [r for r in items if r.kind == "Role"]
         assert len(roles) >= 1, "expected at least 1 IAM Role for backup"

--- a/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-cloudnativepg:0.3.0-pr1643
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-cloudnativepg:0.3.0
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-cloudnativepg:0.2.6
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-cloudnativepg:0.3.0-pr1643
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/providers/additional-rbac.yaml
+++ b/infrastructure/base/crossplane/providers/additional-rbac.yaml
@@ -12,6 +12,10 @@ rules:
   - apiGroups: ["postgresql.cnpg.io"]
     resources: ["databases", "clusters", "roles", "scheduledbackups"]
     verbs: ["*"]
+  #  Manage Barman Cloud plugin ObjectStore CRs (SPEC-010 plugin-based backups)
+  - apiGroups: ["barmancloud.cnpg.io"]
+    resources: ["objectstores"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/infrastructure/mycluster-0/kustomization.yaml
+++ b/infrastructure/mycluster-0/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../base/aws-load-balancer-controller
   - ../base/cilium
   - ../base/cloudnative-pg
+  - ../base/cloudnative-pg-barman-plugin
   - ../base/external-dns
   - ../base/gapi
   - ../base/keda

--- a/scripts/flux-schema/gen-catalog.sh
+++ b/scripts/flux-schema/gen-catalog.sh
@@ -77,6 +77,24 @@ if [[ -z "${KARPENTER_VERSION}" ]]; then
   exit 1
 fi
 
+# Barman Cloud CNPG-I plugin: the ObjectStore CRD (barmancloud.cnpg.io/v1) is
+# absent from the hosted ecosystem catalog and the plugin ships no Helm chart,
+# so extract it straight from the GitRepository Flux installs from. URL + tag
+# come from that same source file (single source of truth — Renovate bumps the
+# tag, this follows it). The URL is https (git), not oci, hence a distinct regex.
+BARMAN_PLUGIN_SOURCE="flux/sources/gitrepo-barman-cloud-plugin.yaml"
+BARMAN_PLUGIN_URL="$(sed -nE 's#^[[:space:]]*url:[[:space:]]*"?(https?://[^"[:space:]]+)"?[[:space:]]*$#\1#p' "${BARMAN_PLUGIN_SOURCE}" | head -n1 || true)"
+BARMAN_PLUGIN_VERSION="$(sed -nE 's/^[[:space:]]*tag:[[:space:]]*"?(v?[0-9][^"[:space:]]*)"?[[:space:]]*$/\1/p' "${BARMAN_PLUGIN_SOURCE}" | head -n1 || true)"
+
+if [[ -z "${BARMAN_PLUGIN_URL}" ]]; then
+  echo "error: could not read the barman-cloud plugin git url from ${BARMAN_PLUGIN_SOURCE}" >&2
+  exit 1
+fi
+if [[ -z "${BARMAN_PLUGIN_VERSION}" ]]; then
+  echo "error: could not read the barman-cloud plugin tag from ${BARMAN_PLUGIN_SOURCE}" >&2
+  exit 1
+fi
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 

--- a/scripts/flux-schema/gen-catalog.sh
+++ b/scripts/flux-schema/gen-catalog.sh
@@ -124,10 +124,19 @@ echo "==> Rendering Karpenter CRDs (chart ${KARPENTER_VERSION})"
   --set settings.clusterName=catalog \
   > "${tmp}/karpenter-crds.yaml"
 
+echo "==> Fetching Barman Cloud plugin ObjectStore CRD (git ${BARMAN_PLUGIN_VERSION})"
+# The plugin ships no Helm chart (only manifest/Kustomize install), so its CRD
+# comes from a shallow clone of the pinned Git tag Flux installs from - not a
+# helm render. config/crd/bases is the same path the crds-barman-cloud-plugin
+# Kustomization applies (single source of truth for what lands on the cluster).
+git clone --quiet --depth 1 --branch "${BARMAN_PLUGIN_VERSION}" "${BARMAN_PLUGIN_URL}" "${tmp}/barman-plugin"
+cat "${tmp}/barman-plugin/config/crd/bases"/*.yaml > "${tmp}/barman-crds.yaml"
+
 echo "==> Extracting JSON Schemas into ${build_dir}/"
 "${FLUX_BIN}" schema extract crd "${tmp}/xrd-crds.yaml" -d "${build_dir}"
 "${FLUX_BIN}" schema extract crd "${tmp}/aigateway-crds.yaml" -d "${build_dir}"
 "${FLUX_BIN}" schema extract crd "${tmp}/karpenter-crds.yaml" -d "${build_dir}"
+"${FLUX_BIN}" schema extract crd "${tmp}/barman-crds.yaml" -d "${build_dir}"
 
 echo "==> Verifying the catalog is complete"
 for kind in app sqlinstance inferenceservice epi; do
@@ -148,6 +157,13 @@ fi
 # schema landed".
 if [[ ! -s "${build_dir}/karpenter.k8s.aws/ec2nodeclass_v1.json" ]]; then
   echo "error: catalog build produced no karpenter.k8s.aws/ec2nodeclass_v1.json (chart ${KARPENTER_VERSION} rendered no CRDs?)" >&2
+  exit 1
+fi
+
+# The ObjectStore CRD (barmancloud.cnpg.io/v1) is the reason the barman-cloud
+# source block exists; assert it specifically, not just "some barman schema landed".
+if [[ ! -s "${build_dir}/barmancloud.cnpg.io/objectstore_v1.json" ]]; then
+  echo "error: catalog build produced no barmancloud.cnpg.io/objectstore_v1.json (plugin ${BARMAN_PLUGIN_VERSION} shipped no ObjectStore CRD at config/crd/bases?)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What

Implements **SPEC-010** — migrates the `SQLInstance` composition's PostgreSQL backups from the deprecated in-tree `barmanObjectStore` to the **Barman Cloud CNPG-I plugin**, unblocking the CloudNativePG operator upgrade past 1.30.x (in-tree is removed in 1.31.0). Refs #1635.

Spec + clarifications live on `main` (`docs/specs/010-cnpg-barman-cloud-plugin/`, merged via #1641). CL-6 corrected the delivery mechanism to GitRepository + Flux Kustomization after implementation found the plugin ships **no Helm chart**.

## Changes (Units A–D)

- **A — Plugin install** (GitRepository + Flux Kustomization, CL-6):
  - `flux/sources/gitrepo-barman-cloud-plugin.yaml` (tag `v0.7.0`)
  - `crds/base/kustomization-barman-cloud-plugin.yaml` — `ObjectStore` CRD, registered in `crds/base/kustomization.yaml`
  - `infrastructure/base/cloudnative-pg-barman-plugin/` — controller bundle patched to ns `infrastructure` (same as the CNPG operator) + PSS-restricted securityContext + resource limits + default-deny `CiliumNetworkPolicy` (CL-5: kube-dns L7, `toFQDNs` S3, `toEntities: host` :80 for the Pod Identity Agent)
  - `scripts/flux-schema/gen-catalog.sh` — clones the pinned git tag and extracts the `ObjectStore` CRD into the schema catalog so `flux schema validate` knows `barmancloud.cnpg.io/v1` (`skipMissingSchemas: false`)
- **B — RBAC**: grant Crossplane `barmancloud.cnpg.io/objectstores` on the aggregate ClusterRole.
- **C — Composition** (`kcl/cloudnativepg/main.k`): both render sites migrated — backup → `ObjectStore` CR + `Cluster.spec.plugins` (WAL archiver); recovery → `externalClusters[].plugin` + recovery `ObjectStore`; `ScheduledBackup.spec.method: plugin`; retention relocated to `ObjectStore.spec.retentionPolicy`. Credentials keep `inheritFromIAMRole` (Pod Identity) — same `BarmanObjectStoreConfiguration` type (CL-6 side-finding), IAM/PodIdentity bundle unchanged.
- **D — Tests**: `main_test.k` asserts `ObjectStore`, `method: plugin`, `spec.plugins`, and absence of in-tree `spec.backup`.

## Validation (local — cluster not live)

- `./scripts/validate-manifests.sh` → **exit 0**, `Valid: 1225, Invalid: 0, Skipped: 0`, all gates passed (the rendered `ObjectStore` schema-validates via the catalog extension).
- `./scripts/validate-kcl-compositions.sh` → composition renders (basic + complete examples).
- `kcl test . -Y settings-example.yaml` → **10/10 pass**.
- `grep barmanObjectStore` on the composition → **0** (SC-005).

## Deferred to cluster bootstrap (runtime SCs)

SC-002/003/004 (backup completes, WAL archiving healthy, PITR restores) require a live cluster. Two semantic assumptions to confirm on first deploy:
1. **Recovery-only plugin loading** — for a restore without ongoing backup, `spec.plugins` loads the plugin pointing at the recovery `ObjectStore` (no `isWALArchiver`); confirm CNPG loads it for `externalClusters[].plugin`.
2. **Recovery `serverName`** — mapped from `spec.objectStoreRecovery.path`; confirm it matches the source cluster's server name.

## Notes

- **Do NOT bump the CNPG operator past 1.30.x until this merges** (in-tree removal lands in 1.31.0).
- Minor follow-up: README note on the plugin backup model.
