### PR TITLE
feat: DB-backed apps just work — connection uri (sqlinstance) + auto-wired DATABASE_URL/REDIS_URL (app)

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.2.0
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.3.0
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/app-definition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-definition.yaml
@@ -30,6 +30,15 @@ spec:
               message: "a sidecar may not reuse the app's own name: it collides with the primary container"
             - rule: "!has(self.spec) || !has(self.spec.initContainers) || self.spec.initContainers.all(c, c.name != self.metadata.name)"
               message: "an initContainer may not reuse the app's own name: it collides with the primary container"
+            # Apps enabling an AWS-backed feature (s3Bucket or sqlInstance) create
+            # IAM resources named after the claim; the Crossplane provider-aws
+            # credentials are scoped to xplane-*, so an unprefixed name lands the
+            # IAM outside the boundary (app deploys, S3/backup access denied). This
+            # root-level rule is the authoritative enforcement across every apply
+            # path (kubectl, Flux); the App Wizard's Go NamingGate is the matching
+            # fast-feedback layer (its spec-scoped CEL cannot see metadata.name).
+            - rule: "!has(self.spec) || !((has(self.spec.s3Bucket) && self.spec.s3Bucket.enabled) || (has(self.spec.sqlInstance) && self.spec.sqlInstance.enabled)) || self.metadata.name.startsWith('xplane-')"
+              message: "apps enabling an AWS-backed feature (s3Bucket or sqlInstance) must be named with the 'xplane-' prefix (Crossplane IAM is scoped to xplane-*)"
           properties:
             spec:
               type: object

--- a/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 edition = "v0.11."
-version = "0.2.0"
+version = "0.3.0"
 description = "Crossplane composition function for deploying applications with infrastructure"
 
 [dependencies]

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -382,7 +382,21 @@ _mainDefaultEnv = [
         }
     }
 ]
-_mainCombinedEnv = _mainDefaultEnv + _buildObservabilityEnv(oxr.spec.observability) + (oxr.spec.env or [])
+
+# Auto-wired backend connection env: when a managed backend is enabled, inject
+# the conventional connection variable pointing at the composition-created
+# secret/service - UNLESS the user already set that variable (their value wins,
+# so nothing is ever double-set). DATABASE_URL consumes the SQLInstance
+# connection secret's `uri` key (a ready postgresql:// DSN, from the first
+# database); REDIS_URL targets the Valkey primary Service. This lets a
+# DB/cache-backed app work from just `sqlInstance.enabled`/`kvStore.enabled`
+# with no hand-wired secretKeyRef - the App Wizard needs only the toggle.
+_userEnvNames = [e.name for e in (oxr.spec.env or [])]
+_dbAutoEnv = [{name = "DATABASE_URL", valueFrom = {
+    secretKeyRef = {name = _name + "-cnpg-" + oxr.spec.sqlInstance.databases[0].name, key = "uri"}
+}}] if oxr.spec.sqlInstance?.enabled and len(oxr.spec.sqlInstance?.databases or []) > 0 and "DATABASE_URL" not in _userEnvNames else []
+_cacheAutoEnv = [{name = "REDIS_URL", value = "redis://" + _name + "-valkey-primary:6379"}] if oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userEnvNames else []
+_mainCombinedEnv = _mainDefaultEnv + _buildObservabilityEnv(oxr.spec.observability) + _dbAutoEnv + _cacheAutoEnv + (oxr.spec.env or [])
 
 # Main application container (SPEC-007 T007). Built in one shot (no mutation).
 _mainContainer = {

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -388,14 +388,21 @@ _mainDefaultEnv = [
 # secret/service - UNLESS the user already set that variable (their value wins,
 # so nothing is ever double-set). DATABASE_URL consumes the SQLInstance
 # connection secret's `uri` key (a ready postgresql:// DSN, from the first
-# database); REDIS_URL targets the Valkey primary Service. This lets a
+# database); REDIS_URL targets the kvStore primary Service. This lets a
 # DB/cache-backed app work from just `sqlInstance.enabled`/`kvStore.enabled`
 # with no hand-wired secretKeyRef - the App Wizard needs only the toggle.
+#
+# SHARED CONTRACT (restated across a module boundary - separate kcl.mod
+# packages, no shared import): the `<name>-cnpg-<db>` secret name is owned by
+# the cloudnativepg module (its ExternalSecret target); the `<name>-<type>`
+# release name (hence `-primary` Service) is owned by the kvStore block below.
+# Keep both in sync - if either convention changes, the auto-wired reference
+# silently points at a non-existent secret/Service.
 _userEnvNames = [e.name for e in (oxr.spec.env or [])]
 _dbAutoEnv = [{name = "DATABASE_URL", valueFrom = {
     secretKeyRef = {name = _name + "-cnpg-" + oxr.spec.sqlInstance.databases[0].name, key = "uri"}
 }}] if oxr.spec.sqlInstance?.enabled and len(oxr.spec.sqlInstance?.databases or []) > 0 and "DATABASE_URL" not in _userEnvNames else []
-_cacheAutoEnv = [{name = "REDIS_URL", value = "redis://" + _name + "-valkey-primary:6379"}] if oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userEnvNames else []
+_cacheAutoEnv = [{name = "REDIS_URL", value = "redis://" + _name + "-" + (oxr.spec.kvStore?.type or "valkey") + "-primary:6379"}] if oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userEnvNames else []
 _mainCombinedEnv = _mainDefaultEnv + _buildObservabilityEnv(oxr.spec.observability) + _dbAutoEnv + _cacheAutoEnv + (oxr.spec.env or [])
 
 # Main application container (SPEC-007 T007). Built in one shot (no mutation).

--- a/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
@@ -30,6 +30,29 @@ test_security_context = lambda {
     assert "ALL" in container.securityContext.capabilities.drop, "should drop ALL capabilities"
 }
 
+# ---- Test: backend connection env auto-wired ----
+# DATABASE_URL from the SQLInstance connection secret's `uri` key (when
+# sqlInstance + databases); REDIS_URL from the Valkey primary Service (when
+# kvStore). Both skip when the user already set that variable.
+test_backend_env_autowired = lambda {
+    _oxr = option("params").oxr
+    dep = [r for r in items if r.kind == "Deployment"][0]
+    env = dep.spec.template.spec.containers[0].env
+    _userNames = [e.name for e in (_oxr.spec.env or [])]
+    if _oxr.spec.sqlInstance?.enabled and len(_oxr.spec.sqlInstance?.databases or []) > 0 and "DATABASE_URL" not in _userNames:
+        _dbEnv = [e for e in env if e.name == "DATABASE_URL"]
+        assert len(_dbEnv) == 1, "DATABASE_URL should be auto-injected exactly once"
+        assert _dbEnv[0].valueFrom.secretKeyRef.name == _oxr.metadata.name + "-cnpg-" + _oxr.spec.sqlInstance.databases[0].name, "DATABASE_URL secret name mismatch"
+        assert _dbEnv[0].valueFrom.secretKeyRef.key == "uri", "DATABASE_URL should use the uri key"
+
+    if _oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userNames:
+        _redisEnv = [e for e in env if e.name == "REDIS_URL"]
+        assert len(_redisEnv) == 1, "REDIS_URL should be auto-injected exactly once"
+        assert _redisEnv[0].value == "redis://" + _oxr.metadata.name + "-valkey-primary:6379", "REDIS_URL value mismatch"
+
+    assert True
+}
+
 # ---- Test: Autoscaling creates HPA ----
 test_autoscaling_hpa = lambda {
     _oxr = option("params").oxr

--- a/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
@@ -48,7 +48,7 @@ test_backend_env_autowired = lambda {
     if _oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userNames:
         _redisEnv = [e for e in env if e.name == "REDIS_URL"]
         assert len(_redisEnv) == 1, "REDIS_URL should be auto-injected exactly once"
-        assert _redisEnv[0].value == "redis://" + _oxr.metadata.name + "-valkey-primary:6379", "REDIS_URL value mismatch"
+        assert _redisEnv[0].value == "redis://" + _oxr.metadata.name + "-" + (_oxr.spec.kvStore?.type or "valkey") + "-primary:6379", "REDIS_URL value mismatch"
 
     assert True
 }

--- a/infrastructure/base/crossplane/configuration/kcl/app/settings-example.yaml
+++ b/infrastructure/base/crossplane/configuration/kcl/app/settings-example.yaml
@@ -226,6 +226,12 @@ kcl_options:
               url: "https://github.com/Smana/image-gallery"
               ref: "main"
               path: "internal/platform/database/migrations"
+            roles:
+              - name: "myname-user"
+                superuser: false
+            databases:
+              - name: "appdb"
+                owner: "myname-user"
           s3Bucket: # This creates an S3 but also the lifecycle policies. The bucket encrytion is SSE-S3. the EKS pod identity using the composition  EPI.
             enabled: true
             providerConfigRef:

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "cloudnativepg"
 edition = "v0.11.3"
-version = "0.3.0"
+version = "0.3.1"

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k
@@ -429,6 +429,9 @@ if oxr.spec.databases:
             target = {
                 creationPolicy = "Owner"
                 deletionPolicy = "Retain"
+                # SHARED CONTRACT: `<xr>-cnpg-<db>`. The App composition auto-wires
+                # DATABASE_URL to this secret by name (app module main.k); keep the
+                # two encodings in sync if this naming ever changes.
                 name = oxr.metadata.name + "-cnpg-" + db.name
                 # Always template a ready-to-consume connection secret (Option C):
                 # username/password/uri, so any app can reference `key: uri` as its

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k
@@ -430,15 +430,18 @@ if oxr.spec.databases:
                 creationPolicy = "Owner"
                 deletionPolicy = "Retain"
                 name = oxr.metadata.name + "-cnpg-" + db.name
-                if oxr.spec.atlasSchema:
-                    template = {
-                        engineVersion = "v2"
-                        data = {
-                            username = "{{ .username }}"
-                            password = "{{ .password }}"
-                            uri = "postgresql://{{ .username | urlquery }}:{{ .password | urlquery }}@" + oxr.metadata.name + "-cnpg-cluster-rw." + oxr.metadata.namespace + ".svc:5432/" + db.name
-                        }
+                # Always template a ready-to-consume connection secret (Option C):
+                # username/password/uri, so any app can reference `key: uri` as its
+                # DATABASE_URL - not only Atlas-migrated apps. The password is
+                # urlquery-escaped so special characters can't break the DSN.
+                template = {
+                    engineVersion = "v2"
+                    data = {
+                        username = "{{ .username }}"
+                        password = "{{ .password }}"
+                        uri = "postgresql://{{ .username | urlquery }}:{{ .password | urlquery }}@" + oxr.metadata.name + "-cnpg-cluster-rw." + oxr.metadata.namespace + ".svc:5432/" + db.name
                     }
+                }
             }
         }
     } for db in oxr.spec.databases]

--- a/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main_test.k
@@ -40,6 +40,21 @@ test_databases_resources = lambda {
     assert True
 }
 
+# ---- Test: DB connection secret always exposes a ready-to-use `uri` (Option C) ----
+# The username/password/uri template is unconditional (not gated on atlasSchema),
+# so any DB-backed app can consume `key: uri` directly as its DATABASE_URL.
+test_db_connection_secret_uri = lambda {
+    _oxr = option("params").oxr
+    dbs = _oxr.spec.databases or []
+    if len(dbs) > 0:
+        dbSecrets = [r for r in items if r.kind == "ExternalSecret" and "superuser" not in r.metadata.name]
+        assert len(dbSecrets) == len(dbs), "expected {} db ExternalSecrets, got {}".format(len(dbs), len(dbSecrets))
+        withUri = [s for s in dbSecrets if s.spec?.target?.template?.data?.uri]
+        assert len(withUri) == len(dbs), "every db ExternalSecret must template a uri key, got {} of {}".format(len(withUri), len(dbs))
+
+    assert True
+}
+
 # ---- Test: Backup creates ScheduledBackup and IAM resources ----
 test_backup_resources = lambda {
     _oxr = option("params").oxr

--- a/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/sql-instance-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-cloudnativepg:0.3.0
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-cloudnativepg:0.3.1
 
         - step: ready
           functionRef:


### PR DESCRIPTION
Makes DB/cache-backed apps work from just a backend toggle — no hand-wired secret references — and enforces safe naming for AWS-backed apps. Three related pieces.

## 1. `cloudnativepg` (SQLInstance) — unconditional connection `uri`

The per-database connection secret only templated a ready-to-use `uri` (a `postgresql://…` DSN) when `atlasSchema` was set. Now it's **unconditional** — every database's ExternalSecret exposes `username` / `password` / `uri`, password `urlquery`-escaped. Module `0.3.0 → 0.3.1`.

## 2. `app` composition — auto-wire `DATABASE_URL` + `REDIS_URL`

When `sqlInstance` (with a database) or `kvStore` is enabled, the App composition injects the conventional connection variable — **unless the user already set it**:

- `DATABASE_URL` → `secretKeyRef{<app>-cnpg-<db>, key: uri}` (consumes #1's `uri`)
- `REDIS_URL` → `redis://<app>-<kvStore.type>-primary:6379`

A DB/cache-backed app works from just the toggle — no `env[].valueFrom.secretKeyRef` by hand. This is what lets the schema-driven App Wizard produce a working DB claim. Module `0.2.0 → 0.3.0`.

## 3. `app-definition.yaml` — enforce `xplane-*` for AWS-backed apps

Apps enabling `s3Bucket` or `sqlInstance` create IAM resources named after the claim; provider-aws is scoped to `xplane-*`, so an unprefixed name lands the IAM outside the boundary (app deploys, S3/backup access silently denied). A root-level `x-kubernetes-validations` rule now requires the `xplane-` prefix in that case — **authoritative across every apply path** (kubectl, Flux). The App Wizard's Go `NamingGate` ([Smana/app-wizard#1](https://github.com/Smana/app-wizard/pull/1)) is the matching fast-feedback layer; the wizard extracts spec-level CEL only, so the root rule doesn't interfere.

## Why together

(1) guarantees the `uri` key exists, (2) consumes it automatically, (3) keeps the AWS-backed apps that (2) enables inside the IAM boundary. All one coherent "AWS/DB-backed apps just work — safely" change.

## Compatibility

Additive. Existing secrets gain `uri` on next ESO refresh; apps that already set `DATABASE_URL`/`REDIS_URL` (e.g. `xplane-image-gallery`) are skipped. The naming rule only fires for AWS-backed apps; all existing such apps already carry the `xplane-` prefix.

## Validation

- `cloudnativepg`: `kcl test` 11/11.
- `app`: `kcl test` 28/28 (incl. `test_backend_env_autowired`); render shows `DATABASE_URL → secretKeyRef{…, uri}` and `REDIS_URL → redis://…-valkey-primary:6379`.
- Quality: passed a 4-angle `/simplify` pass (reuse/simplification/efficiency/altitude) — fixes folded in (REDIS_URL type-derivation, shared-contract docs).

## Follow-up (merge → publish)

Post-merge, once CI publishes the OCI modules, bump both source pins: `sql-instance-composition.yaml` → `0.3.1` and `app-composition.yaml` → `0.3.0` (strip any `-pr<N>` suffix).
