### PR TITLE
chore(app-wizard): bump image to main-f0a8361 (xplane-* naming guard)

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -29,7 +29,7 @@ spec:
     # the XRD, and ships github+dev auth only. Bump to the newest main-<short-sha>
     # when the upstream wizard changes.
     repository: ghcr.io/smana/app-wizard
-    tag: "main-119c516"
+    tag: "main-f0a8361"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions


### PR DESCRIPTION
Rolls the deployed App Wizard to `ghcr.io/smana/app-wizard:main-f0a8361`, which includes the `xplane-*` naming guard from [Smana/app-wizard#1](https://github.com/Smana/app-wizard/pull/1) (blocks generating an unprefixed AWS-backed app). Pairs with the XRD root-CEL enforcement already on main (#1645).

Hold merge until the image is confirmed pullable (build in progress at author time).