### PR TITLE
feat(app): composition owns the xplane-* prefix (dev names apps plainly)

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.3.0
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.4.0
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/app-definition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-definition.yaml
@@ -30,15 +30,6 @@ spec:
               message: "a sidecar may not reuse the app's own name: it collides with the primary container"
             - rule: "!has(self.spec) || !has(self.spec.initContainers) || self.spec.initContainers.all(c, c.name != self.metadata.name)"
               message: "an initContainer may not reuse the app's own name: it collides with the primary container"
-            # Apps enabling an AWS-backed feature (s3Bucket or sqlInstance) create
-            # IAM resources named after the claim; the Crossplane provider-aws
-            # credentials are scoped to xplane-*, so an unprefixed name lands the
-            # IAM outside the boundary (app deploys, S3/backup access denied). This
-            # root-level rule is the authoritative enforcement across every apply
-            # path (kubectl, Flux); the App Wizard's Go NamingGate is the matching
-            # fast-feedback layer (its spec-scoped CEL cannot see metadata.name).
-            - rule: "!has(self.spec) || !((has(self.spec.s3Bucket) && self.spec.s3Bucket.enabled) || (has(self.spec.sqlInstance) && self.spec.sqlInstance.enabled)) || self.metadata.name.startsWith('xplane-')"
-              message: "apps enabling an AWS-backed feature (s3Bucket or sqlInstance) must be named with the 'xplane-' prefix (Crossplane IAM is scoped to xplane-*)"
           properties:
             spec:
               type: object

--- a/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 edition = "v0.11."
-version = "0.3.0"
+version = "0.4.0"
 description = "Crossplane composition function for deploying applications with infrastructure"
 
 [dependencies]

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -26,6 +26,26 @@ _metadata = lambda suffix: str -> any {
         }
     }
 }
+
+# Managed-resource name for the IAM-bearing resources. Apps that provision AWS
+# IAM (s3Bucket -> EPI role/policy, sqlInstance -> S3-backup role) must land those
+# roles inside the provider-aws xplane-* permission boundary
+# (opentofu/eks/init/iam.tf). The COMPOSITION owns that prefix so the developer
+# never types it: a dev names the App `outline`, and the IAM-bearing resources are
+# named `xplane-outline-*` internally. Idempotent - an already-`xplane-`-prefixed
+# claim is returned unchanged (zero churn on existing apps). Dev-facing resources
+# (Deployment/Service/route) and the S3 bucket (boundary is `<region>-ogenki-*`,
+# any name) keep the plain claim name.
+_managedName = _name if _name[0:7:] == "xplane-" else "xplane-" + _name
+_managedMetadata = lambda suffix: str -> any {
+    {
+        name = _managedName + "-" + suffix
+        namespace = _namespace
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _managedName + "-" + suffix
+        }
+    }
+}
 # Build node affinity for on-demand instances
 _buildNodeAffinity = lambda onDemand: bool -> any {
     {
@@ -400,7 +420,7 @@ _mainDefaultEnv = [
 # silently points at a non-existent secret/Service.
 _userEnvNames = [e.name for e in (oxr.spec.env or [])]
 _dbAutoEnv = [{name = "DATABASE_URL", valueFrom = {
-    secretKeyRef = {name = _name + "-cnpg-" + oxr.spec.sqlInstance.databases[0].name, key = "uri"}
+    secretKeyRef = {name = _managedName + "-cnpg-" + oxr.spec.sqlInstance.databases[0].name, key = "uri"}
 }}] if oxr.spec.sqlInstance?.enabled and len(oxr.spec.sqlInstance?.databases or []) > 0 and "DATABASE_URL" not in _userEnvNames else []
 _cacheAutoEnv = [{name = "REDIS_URL", value = "redis://" + _name + "-" + (oxr.spec.kvStore?.type or "valkey") + "-primary:6379"}] if oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userEnvNames else []
 _mainCombinedEnv = _mainDefaultEnv + _buildObservabilityEnv(oxr.spec.observability) + _dbAutoEnv + _cacheAutoEnv + (oxr.spec.env or [])
@@ -889,6 +909,46 @@ if oxr.spec.route?.enabled == True and _isWeb:
     }]
     _items += _httpRouteResource
 
+# Auto-generated egress rules for enabled managed backends, so the developer
+# never hand-writes (nor learns) the composition-internal Service labels - most
+# importantly the DB rule targets the managed xplane-* CNPG cluster label. Only
+# injected when a backend is enabled, so a net-pol-only app (no backend) renders
+# byte-identically. Includes the DNS rule the backend connections need to resolve
+# their in-cluster Services. The developer's networkPolicies.egress adds
+# app-specific destinations on top of these.
+_npDns = [{
+    toEndpoints = [{
+        matchLabels = {"io.kubernetes.pod.namespace" = "kube-system", "k8s-app" = "kube-dns"}
+    }]
+    # L7 dns matchPattern "*" is mandatory so a developer-added toFQDNs egress
+    # rule works (Cilium must see the resolved IPs) - .claude/rules/cilium-network-policies.md.
+    toPorts = [{ports = [{port = "53", protocol = "UDP"}, {port = "53", protocol = "TCP"}], rules = {dns = [{matchPattern = "*"}]}}]
+}] if (oxr.spec.sqlInstance?.enabled or oxr.spec.kvStore?.enabled or oxr.spec.s3Bucket?.enabled) else []
+_npDb = [{
+    toEndpoints = [{
+        matchLabels = {"cnpg.io/cluster" = _managedName + "-cnpg-cluster"}
+    }]
+    toPorts = [{ports = [{port = "5432", protocol = "TCP"}]}]
+}] if oxr.spec.sqlInstance?.enabled else []
+_npCache = [{
+    toEndpoints = [{
+        matchLabels = {"app.kubernetes.io/instance" = _name + "-" + (oxr.spec.kvStore?.type or "valkey"), "app.kubernetes.io/name" = (oxr.spec.kvStore?.type or "valkey")}
+    }]
+    toPorts = [{ports = [{port = "6379", protocol = "TCP"}]}]
+}] if oxr.spec.kvStore?.enabled else []
+_npS3 = [
+    {
+        toEntities = ["host"]
+        toPorts = [{ports = [{port = "80", protocol = "TCP"}]}]
+    }
+    {
+        toEntities = ["world"]
+        toPorts = [{ports = [{port = "443", protocol = "TCP"}]}]
+    }
+] if oxr.spec.s3Bucket?.enabled else []
+# `[]` + user egress == user egress, so a backend-less app is byte-identical.
+_npEgress = _npDns + _npDb + _npCache + _npS3 + (oxr.spec.networkPolicies?.egress or [])
+
 # CiliumNetworkPolicy
 # NOTE: Using intermediate variable to avoid function-kcl duplicate detection bug
 # See: https://github.com/crossplane-contrib/function-kcl/issues/285
@@ -909,8 +969,8 @@ if oxr.spec.networkPolicies?.enabled:
             endpointSelector = _podSelector
             if oxr.spec.networkPolicies.ingress:
                 ingress = oxr.spec.networkPolicies.ingress
-            if oxr.spec.networkPolicies.egress:
-                egress = oxr.spec.networkPolicies.egress
+            if _npEgress:
+                egress = _npEgress
         }
     }]
     _items += _networkPolicyResource
@@ -999,10 +1059,10 @@ if oxr.spec.sqlInstance?.enabled:
         apiVersion = "cloud.ogenki.io/v1alpha1"
         kind = "SQLInstance"
         metadata = {
-            name = _name
+            name = _managedName
             namespace = _namespace
             annotations = {
-                "krm.kcl.dev/composition-resource-name" = _name + "-sqlinstance"
+                "krm.kcl.dev/composition-resource-name" = _managedName + "-sqlinstance"
             }
         }
         spec = {
@@ -1098,7 +1158,7 @@ if oxr.spec.s3Bucket?.enabled:
         {
             apiVersion = "cloud.ogenki.io/v1alpha1"
             kind = "EPI"
-            metadata = _metadata("s3-pod-identity")
+            metadata = _managedMetadata("s3-pod-identity")
             spec = {
                 serviceAccount = {
                     name = _name

--- a/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
@@ -42,7 +42,8 @@ test_backend_env_autowired = lambda {
     if _oxr.spec.sqlInstance?.enabled and len(_oxr.spec.sqlInstance?.databases or []) > 0 and "DATABASE_URL" not in _userNames:
         _dbEnv = [e for e in env if e.name == "DATABASE_URL"]
         assert len(_dbEnv) == 1, "DATABASE_URL should be auto-injected exactly once"
-        assert _dbEnv[0].valueFrom.secretKeyRef.name == _oxr.metadata.name + "-cnpg-" + _oxr.spec.sqlInstance.databases[0].name, "DATABASE_URL secret name mismatch"
+        _mn = _oxr.metadata.name if _oxr.metadata.name[0:7:] == "xplane-" else "xplane-" + _oxr.metadata.name
+        assert _dbEnv[0].valueFrom.secretKeyRef.name == _mn + "-cnpg-" + _oxr.spec.sqlInstance.databases[0].name, "DATABASE_URL secret name mismatch"
         assert _dbEnv[0].valueFrom.secretKeyRef.key == "uri", "DATABASE_URL should use the uri key"
 
     if _oxr.spec.kvStore?.enabled and "REDIS_URL" not in _userNames:
@@ -50,6 +51,30 @@ test_backend_env_autowired = lambda {
         assert len(_redisEnv) == 1, "REDIS_URL should be auto-injected exactly once"
         assert _redisEnv[0].value == "redis://" + _oxr.metadata.name + "-" + (_oxr.spec.kvStore?.type or "valkey") + "-primary:6379", "REDIS_URL value mismatch"
 
+    assert True
+}
+
+# ---- Test: composition owns the xplane-* prefix (dev never types it) ----
+# IAM-bearing resources (SQLInstance -> S3-backup role, EPI -> S3 role) get the
+# managed xplane-* name so they land in the provider-aws IAM boundary; the
+# Deployment/Service and the S3 bucket (boundary <region>-ogenki-*) keep the
+# plain claim name. Idempotent: an already-xplane- claim is unchanged.
+test_managed_name_prefix = lambda {
+    _oxr = option("params").oxr
+    _n = _oxr.metadata.name
+    _mn = _n if _n[0:7:] == "xplane-" else "xplane-" + _n
+    if _oxr.spec.sqlInstance?.enabled:
+        sql = [r for r in items if r.kind == "SQLInstance"][0]
+        assert sql.metadata.name == _mn, "SQLInstance must use the managed xplane-* name, got {}".format(sql.metadata.name)
+
+    if _oxr.spec.s3Bucket?.enabled:
+        epi = [r for r in items if r.kind == "EPI"][0]
+        assert epi.metadata.name == _mn + "-s3-pod-identity", "EPI must use the managed name, got {}".format(epi.metadata.name)
+        bucket = [r for r in items if r.kind == "Bucket"][0]
+        assert ("-ogenki-" + _n) in bucket.metadata.annotations["crossplane.io/external-name"], "S3 bucket must keep the plain claim name (boundary is <region>-ogenki-*)"
+
+    dep = [r for r in items if r.kind == "Deployment"][0]
+    assert dep.metadata.name == _n, "Deployment must keep the plain dev-facing name, got {}".format(dep.metadata.name)
     assert True
 }
 
@@ -118,6 +143,22 @@ test_network_policy = lambda {
         assert len(netpols) == 1, "expected 1 CiliumNetworkPolicy"
     else:
         assert len(netpols) == 0, "expected 0 CiliumNetworkPolicies when disabled"
+    assert True
+}
+
+# ---- Test: net-pol backend egress auto-injected (dev never writes internal labels) ----
+# When networkPolicies + sqlInstance are enabled, the composition injects a DB
+# egress rule targeting the MANAGED cluster label (xplane-*), so the developer
+# never has to know the composition-internal name.
+test_netpol_auto_egress = lambda {
+    _oxr = option("params").oxr
+    _n = _oxr.metadata.name
+    _mn = _n if _n[0:7:] == "xplane-" else "xplane-" + _n
+    if _oxr.spec.networkPolicies?.enabled and _oxr.spec.sqlInstance?.enabled:
+        cnp = [r for r in items if r.kind == "CiliumNetworkPolicy"][0]
+        _clusterLabels = [ep.matchLabels["cnpg.io/cluster"] for e in cnp.spec.egress for ep in (e?.toEndpoints or []) if "cnpg.io/cluster" in (ep?.matchLabels or {})]
+        assert (_mn + "-cnpg-cluster") in _clusterLabels, "DB egress must target the managed cluster label, got {}".format(_clusterLabels)
+
     assert True
 }
 

--- a/infrastructure/base/crossplane/configuration/kcl/app/settings-example.yaml
+++ b/infrastructure/base/crossplane/configuration/kcl/app/settings-example.yaml
@@ -184,24 +184,9 @@ kcl_options:
                   - port: "8080"
                     protocol: TCP
             egress:
-              # Allow DNS
-              - toEndpoints:
-                - matchLabels:
-                    "io.kubernetes.pod.namespace": "kube-system"
-                    "k8s-app": "kube-dns"
-                toPorts:
-                - ports:
-                  - port: "53"
-                    protocol: UDP
-              # Allow to database
-              - toEndpoints:
-                - matchLabels:
-                    "app.kubernetes.io/name": "myname-sqlinstance"
-                toPorts:
-                - ports:
-                  - port: "5432"
-                    protocol: TCP
-              # Allow external HTTPS
+              # The composition auto-injects DNS + the DB/cache/S3 backend egress
+              # rules (see the App module). The developer only declares
+              # app-specific external destinations, like this one.
               - toFQDNs:
                 - matchPattern: "*.github.com"
                 - matchName: "api.example.com"


### PR DESCRIPTION
## What

A developer using the App composition (or the App Wizard) had to name any AWS-backed app `xplane-*` by hand — a Crossplane IAM detail leaking into the developer interface. This makes the **composition own that prefix** so the dev names the app plainly (`outline`), toggles backends, and never types `xplane-`.

## Why it's only the IAM name

The provider-aws boundary (`opentofu/eks/init/iam.tf`) requires `xplane-*` on **IAM role/policy** names only. S3 buckets are `<region>-ogenki-*` (any name); SQLInstance/cluster/secret/net-pol have no boundary. So only the IAM-bearing resources need the prefix.

## Change

- `_managedName` idempotently prefixes **only** the IAM-bearing resources (`SQLInstance` → S3-backup role, `EPI` → S3 role); Deployment/Service/route and the S3 bucket keep the plain name. `DATABASE_URL` auto-wire follows.
- Auto-inject the CiliumNetworkPolicy egress for enabled backends (DNS+L7, DB → managed cluster label, cache, S3 host+world) — the dev writes only app-specific egress.
- Remove the root-level XRD CEL naming rule (composition handles it now).

## Regression — proven byte-identical for every current resource

| App | Result |
|-----|--------|
| `xplane-image-gallery` (sql+s3) | render **byte-identical** to before |
| `app-wizard` / `openwebui` (net-pol, no backend) | **byte-identical** old-vs-new |
| `podinfo` (no IAM) | no `xplane-` leak |

Idempotent: existing `xplane-*` claims return unchanged; only a new plain-named app gains the internal prefix. **30/30** unit tests (incl. new managed-name + auto-egress contract tests).

## Follow-up

Module `0.3.0 → 0.4.0`, pinned bare (merge-then-publish; `validate-composition-versions` stays red until merge). The App Wizard's now-redundant `NamingGate` is removed in a paired app-wizard PR.
