### PR TITLE
chore(app-wizard): bump image to main-a23e28f (NamingGate removed)

### DIFF
--- a/apps/platform/app-wizard/app.yaml
+++ b/apps/platform/app-wizard/app.yaml
@@ -29,7 +29,7 @@ spec:
     # the XRD, and ships github+dev auth only. Bump to the newest main-<short-sha>
     # when the upstream wizard changes.
     repository: ghcr.io/smana/app-wizard
-    tag: "main-f0a8361"
+    tag: "main-a23e28f"
     pullPolicy: IfNotPresent
 
   # Single stateless replica — the wizard holds no persistent state (sessions


### PR DESCRIPTION
Rolls the App Wizard to `main-a23e28f`, which removes the `NamingGate` (Smana/app-wizard#2). Paired with the composition change (#1648) that moves the `xplane-*` prefix ownership into the composition — developers now name apps plainly.