### PR TITLE
fix(eks): helm_release.cilium wait=false (decouple apply from DaemonSet roll)

### DIFF
--- a/opentofu/eks/configure/main.tf
+++ b/opentofu/eks/configure/main.tf
@@ -80,7 +80,7 @@ resource "helm_release" "cilium" {
     }
   ]
 
-  wait    = true
+  wait    = false
   timeout = 600
 }
 


### PR DESCRIPTION
Back-ports the `wait=false` on `helm_release.cilium` from `chore/july-updates_02` to main. The Cilium DaemonSet roll is fragile under spot churn — nodes reclaimed mid-roll leave undrainable pods that block the rollout and time out the helm upgrade (the failure mode hit repeatedly this session). `wait=false` lets the apply complete and Cilium roll in the background. The Flux helm_releases keep `wait=true` (they depend on Cilium being ready).