### PR TITLE
chore(zitadel): rotate CNPG recovery source to zitadel-20260719

### DIFF
--- a/security/base/zitadel/sqlinstance.yaml
+++ b/security/base/zitadel/sqlinstance.yaml
@@ -12,18 +12,20 @@ spec:
   # initial provisioning — `bootstrap` is immutable post-create).
   #
   # Frozen-dated-snapshot pattern (matches the prior zitadel-20241202
-  # / zitadel-20251028 / zitadel-20260201 history): `zitadel-20260505`
-  # is a one-time copy of the live prefix taken on 2026-05-05 after
-  # OAuth client config in AWS Secrets Manager
-  # (`apps/openwebui/oauth-zitadel`) was re-verified end-to-end. Two
-  # base backups are present (T102929 + T103616); CNPG picks the
-  # most recent. WAL chain present too (000000030000000100000063-64).
+  # / zitadel-20251028 / zitadel-20260201 / zitadel-20260505 history):
+  # `zitadel-20260719` is the entire former live prefix
+  # `xplane-zitadel-cnpg-cluster/` moved aside on 2026-07-20 (cluster
+  # stopped first; 140 objects / 57 MiB, base backups + full WAL
+  # chain, verified byte-identical before deleting the source).
+  # Moving — rather than the usual copy — also leaves the live prefix
+  # empty, so the recreated cluster's WAL archiver starts a fresh
+  # timeline there without tripping barman's expected-empty-archive
+  # check.
   #
-  # The live prefix `xplane-zitadel-cnpg-cluster/` keeps accruing
-  # daily ScheduledBackups but is NOT used for recovery — that
-  # decoupling means a bad day on the live cluster (corruption,
-  # accidental DROP) doesn't cascade into recovery from a poisoned
-  # state.
+  # The live prefix `xplane-zitadel-cnpg-cluster/` accrues daily
+  # ScheduledBackups but is NOT used for recovery — that decoupling
+  # means a bad day on the live cluster (corruption, accidental DROP)
+  # doesn't cascade into recovery from a poisoned state.
   #
   # Promotion procedure (rotate the frozen snapshot when zitadel
   # changes meaningfully — new OAuth apps, schema migration,
@@ -42,7 +44,7 @@ spec:
   # configured recovery prefix is empty.
   objectStoreRecovery:
     bucketName: "eu-west-3-ogenki-cnpg-backups"
-    path: "zitadel-20260505"
+    path: "zitadel-20260719"
   backup:
     schedule: "0 0 * * *"
     bucketName: "eu-west-3-ogenki-cnpg-backups"


### PR DESCRIPTION
## What

Points the zitadel `SQLInstance` recovery source at the new dated backup prefix:

```yaml
objectStoreRecovery:
  bucketName: "eu-west-3-ogenki-cnpg-backups"
  path: "zitadel-20260719"   # was zitadel-20260505
```

The composition uses `path` as both the bootstrap `recovery.source` and the barman `serverName`, so this is the only field that changes. The in-file doc comment is updated to record the new snapshot's provenance.

## Context

The former live prefix `xplane-zitadel-cnpg-cluster/` was moved to `zitadel-20260719/` on 2026-07-20 with the cluster stopped:

- 140 objects / 57 MiB (base backups + full WAL chain)
- copy verified byte-identical (object count + total size) before the source prefix was deleted

Unlike the usual copy-based rotation, this was a **move** — it leaves the live prefix empty, so the recreated cluster's WAL archiver starts a fresh timeline there without tripping barman's expected-empty-archive check.

## Rollout

`bootstrap` is immutable post-create: this takes effect only when the CNPG Cluster is provisioned fresh. After merge + Flux reconcile, delete the existing Cluster/XR so Crossplane recreates it; CNPG then bootstraps from `zitadel-20260719` and daily backups resume into a clean `xplane-zitadel-cnpg-cluster/`.

## Validation

- `./scripts/validate-manifests.sh` → exit 0, all gates passed (schema validation with `skipMissingSchemas: false` + polaris)