### PR TITLE
perf(ci): parallelize manifest rendering and skip unchanged docs in rendered diff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,21 +157,20 @@ jobs:
         run: ./scripts/flux-schema/render-both.sh "origin/${{ github.base_ref }}"
 
       # stdout (tee'd) is the size-capped PR comment; rendered-diff-full.md is
-      # the untruncated report, published two ways: as the job summary (the
-      # human-readable page the comment's truncation link points at — capped
-      # at the 1MiB summary limit) and as a downloadable artifact.
+      # the full report (capped only by the job-summary limit, inside the
+      # script, so a cut is boundary-aware and visibly noted), published two
+      # ways: as the job summary — the human-readable page the comment's
+      # truncation link points at — and as a downloadable artifact.
       - name: Compute rendered diff
         run: |
           python3 scripts/flux-schema/diff-bundles.py /tmp/base/.bundle-base .bundle-head rendered-diff-full.md | tee rendered-diff.md
-          head -c 1000000 rendered-diff-full.md >> "$GITHUB_STEP_SUMMARY"
+          cat rendered-diff-full.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload full diff artifact
         uses: actions/upload-artifact@v7
         with:
           name: rendered-diff
-          path: |
-            rendered-diff-full.md
-            rendered-diff.md
+          path: rendered-diff-full.md
           if-no-files-found: ignore
 
       - name: Post/update PR comment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,8 +176,8 @@ jobs:
               python3 scripts/flux-schema/render-bundle.py /tmp/base/.bundle-base
           ) &
           base_pid=$!
-          wait "${head_pid}" || echo "head render failed (best-effort — continuing)"
-          wait "${base_pid}" || echo "base render failed (best-effort — continuing)"
+          wait "${head_pid}" || echo "::warning::head render failed — the rendered diff below is unreliable"
+          wait "${base_pid}" || echo "::warning::base render failed — the rendered diff may show everything as added"
 
       - name: Compute rendered diff
         run: python3 scripts/flux-schema/diff-bundles.py /tmp/base/.bundle-base .bundle-head | tee rendered-diff.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,23 +154,30 @@ jobs:
       # render-bundle.py itself shows up in the diff. Renders are best-effort:
       # a render error must not sink this informational job (the hard gate is
       # the kubernetes-validation job above).
-      - name: Render PR head
-        run: python3 scripts/flux-schema/render-bundle.py .bundle-head || true
-
-      - name: Render base (merge-base)
+      #
+      # The two renders are independent, so they run concurrently — but helm's
+      # repository cache is not safe for concurrent writers across processes
+      # (index files + chart tarballs share one dir), so the base render gets
+      # its own seeded COPY of the cache instead of the shared one.
+      - name: Render head and base (concurrent)
         run: |
-          set -euo pipefail
-          base_sha="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
-          echo "base merge-base: ${base_sha}"
-          git worktree add /tmp/base "${base_sha}"
-          if [[ -f /tmp/base/scripts/flux-schema/render-bundle.py ]]; then
-            ( cd /tmp/base && python3 scripts/flux-schema/render-bundle.py /tmp/base/.bundle-base ) || true
-          else
-            # Transitional: only the PR that introduces render-bundle.py has a
-            # merge-base without it. Safe to delete this branch once merged.
-            echo "base ref predates render-bundle.py — treating base as empty (everything shows as added)."
-            mkdir -p /tmp/base/.bundle-base
-          fi
+          set -uo pipefail
+          python3 scripts/flux-schema/render-bundle.py .bundle-head &
+          head_pid=$!
+          (
+            set -euo pipefail
+            base_sha="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+            echo "base merge-base: ${base_sha}"
+            git worktree add /tmp/base "${base_sha}"
+            mkdir -p ~/.cache/helm /tmp/helm-cache-base
+            cp -r ~/.cache/helm/. /tmp/helm-cache-base/
+            cd /tmp/base
+            HELM_REPOSITORY_CACHE=/tmp/helm-cache-base/repository \
+              python3 scripts/flux-schema/render-bundle.py /tmp/base/.bundle-base
+          ) &
+          base_pid=$!
+          wait "${head_pid}" || echo "head render failed (best-effort — continuing)"
+          wait "${base_pid}" || echo "base render failed (best-effort — continuing)"
 
       - name: Compute rendered diff
         run: python3 scripts/flux-schema/diff-bundles.py /tmp/base/.bundle-base .bundle-head | tee rendered-diff.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,34 +150,11 @@ jobs:
           key: helm-${{ hashFiles('**/*helmrelease*.yaml', 'flux/sources/**') }}
           restore-keys: helm-
 
-      # Render both sides with each ref's OWN renderer, so a change to
-      # render-bundle.py itself shows up in the diff. Renders are best-effort:
-      # a render error must not sink this informational job (the hard gate is
-      # the kubernetes-validation job above).
-      #
-      # The two renders are independent, so they run concurrently — but helm's
-      # repository cache is not safe for concurrent writers across processes
-      # (index files + chart tarballs share one dir), so the base render gets
-      # its own seeded COPY of the cache instead of the shared one.
+      # Orchestration (concurrent best-effort renders, worktree, helm cache
+      # isolation) lives in the script so it is shellcheck-covered and
+      # documented next to the renderer it drives.
       - name: Render head and base (concurrent)
-        run: |
-          set -uo pipefail
-          python3 scripts/flux-schema/render-bundle.py .bundle-head &
-          head_pid=$!
-          (
-            set -euo pipefail
-            base_sha="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
-            echo "base merge-base: ${base_sha}"
-            git worktree add /tmp/base "${base_sha}"
-            mkdir -p ~/.cache/helm /tmp/helm-cache-base
-            cp -r ~/.cache/helm/. /tmp/helm-cache-base/
-            cd /tmp/base
-            HELM_REPOSITORY_CACHE=/tmp/helm-cache-base/repository \
-              python3 scripts/flux-schema/render-bundle.py /tmp/base/.bundle-base
-          ) &
-          base_pid=$!
-          wait "${head_pid}" || echo "::warning::head render failed — the rendered diff below is unreliable"
-          wait "${base_pid}" || echo "::warning::base render failed — the rendered diff may show everything as added"
+        run: ./scripts/flux-schema/render-both.sh "origin/${{ github.base_ref }}"
 
       - name: Compute rendered diff
         run: python3 scripts/flux-schema/diff-bundles.py /tmp/base/.bundle-base .bundle-head | tee rendered-diff.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,14 +156,22 @@ jobs:
       - name: Render head and base (concurrent)
         run: ./scripts/flux-schema/render-both.sh "origin/${{ github.base_ref }}"
 
+      # stdout (tee'd) is the size-capped PR comment; rendered-diff-full.md is
+      # the untruncated report, published two ways: as the job summary (the
+      # human-readable page the comment's truncation link points at — capped
+      # at the 1MiB summary limit) and as a downloadable artifact.
       - name: Compute rendered diff
-        run: python3 scripts/flux-schema/diff-bundles.py /tmp/base/.bundle-base .bundle-head | tee rendered-diff.md
+        run: |
+          python3 scripts/flux-schema/diff-bundles.py /tmp/base/.bundle-base .bundle-head rendered-diff-full.md | tee rendered-diff.md
+          head -c 1000000 rendered-diff-full.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload full diff artifact
         uses: actions/upload-artifact@v7
         with:
           name: rendered-diff
-          path: rendered-diff.md
+          path: |
+            rendered-diff-full.md
+            rendered-diff.md
           if-no-files-found: ignore
 
       - name: Post/update PR comment

--- a/scripts/flux-schema/diff-bundles.py
+++ b/scripts/flux-schema/diff-bundles.py
@@ -103,9 +103,62 @@ def canonical(doc):
     return TIMESTAMP_RE.sub("<render-timestamp>", text)
 
 
+def _truncation_note():
+    """Point at the full diff. In CI, a clickable link to the workflow run
+    page, where the full diff is readable as the job summary and downloadable
+    as the `rendered-diff` artifact; plain text outside CI."""
+    repo, run_id = os.environ.get("GITHUB_REPOSITORY"), os.environ.get("GITHUB_RUN_ID")
+    if repo and run_id:
+        server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+        return (
+            "\n> ⚠️ Diff truncated to fit the comment size limit — "
+            f"[full human-readable diff]({server}/{repo}/actions/runs/{run_id}) "
+            "(job summary on the run page; also downloadable as the `rendered-diff` artifact).\n"
+        )
+    return "\n> ⚠️ Diff truncated to fit the comment size limit — see the workflow artifact for the full diff.\n"
+
+
+def render_report(chunks, counts, cap=None):
+    """Assemble the markdown report; `cap` bounds the total size (the PR
+    comment), None renders everything (the artifact / job summary)."""
+    lines = ["### 🔍 Rendered manifest diff — this PR vs `main` (desired state)", ""]
+    if not chunks:
+        lines.append("No changes to the rendered desired state. ✅")
+        return "\n".join(lines) + "\n"
+    lines += [
+        f"**{counts['changed']} changed · {counts['added']} added · {counts['removed']} removed**",
+        "",
+        "> Rendered with `kustomize build` + `helm template` (source of truth = git), "
+        "so Helm-expanded workloads are included. Shows what Flux will apply — not a diff "
+        "against live cluster state (drift is alerted on separately), and not "
+        "CRD-defaulted / webhook-mutated output. Secret values are redacted; "
+        "per-render noise (webhook `caBundle`s, `checksum/*` annotations, render "
+        "timestamps) is normalized out.",
+        "",
+    ]
+    body = "\n".join(lines) + "\n"
+
+    truncated = False
+    for key, tag, diff in chunks:
+        section = (
+            f"<details><summary>{MARKERS[tag]} — <code>{key}</code></summary>\n\n"
+            f"```diff\n{diff}```\n</details>\n\n"
+        )
+        if cap is not None and len(body) + len(section) > cap:
+            truncated = True
+            break
+        body += section
+    if truncated:
+        body += _truncation_note()
+    return body
+
+
 def main():
-    if len(sys.argv) != 3:
-        print("usage: diff-bundles.py <base-bundle-dir> <head-bundle-dir>", file=sys.stderr)
+    if len(sys.argv) not in (3, 4):
+        print(
+            "usage: diff-bundles.py <base-bundle-dir> <head-bundle-dir> [full-report-path]",
+            file=sys.stderr,
+        )
         return 2
     base, head = load_bundle(sys.argv[1]), load_bundle(sys.argv[2])
 
@@ -134,38 +187,13 @@ def main():
         ))
         chunks.append((key, tag, diff))
 
-    lines = ["### 🔍 Rendered manifest diff — this PR vs `main` (desired state)", ""]
-    if not chunks:
-        lines.append("No changes to the rendered desired state. ✅")
-        sys.stdout.write("\n".join(lines) + "\n")
-        return 0
-    lines += [
-        f"**{counts['changed']} changed · {counts['added']} added · {counts['removed']} removed**",
-        "",
-        "> Rendered with `kustomize build` + `helm template` (source of truth = git), "
-        "so Helm-expanded workloads are included. Shows what Flux will apply — not a diff "
-        "against live cluster state (drift is alerted on separately), and not "
-        "CRD-defaulted / webhook-mutated output. Secret values are redacted; "
-        "per-render noise (webhook `caBundle`s, `checksum/*` annotations, render "
-        "timestamps) is normalized out.",
-        "",
-    ]
-    body = "\n".join(lines) + "\n"
-
-    truncated = False
-    for key, tag, diff in chunks:
-        section = (
-            f"<details><summary>{MARKERS[tag]} — <code>{key}</code></summary>\n\n"
-            f"```diff\n{diff}```\n</details>\n\n"
-        )
-        if len(body) + len(section) > MAX_TOTAL:
-            truncated = True
-            break
-        body += section
-    if truncated:
-        body += "\n> ⚠️ Diff truncated to fit the comment size limit — see the workflow artifact for the full diff.\n"
-
-    sys.stdout.write(body)
+    # stdout is the size-capped PR comment; the optional third argument gets
+    # the untruncated report (previously the artifact was a tee of the capped
+    # stdout, so "see the artifact for the full diff" pointed at the same
+    # truncated content).
+    sys.stdout.write(render_report(chunks, counts, cap=MAX_TOTAL))
+    if len(sys.argv) == 4:
+        pathlib.Path(sys.argv[3]).write_text(render_report(chunks, counts))
     return 0
 
 

--- a/scripts/flux-schema/diff-bundles.py
+++ b/scripts/flux-schema/diff-bundles.py
@@ -18,6 +18,7 @@ Usage: diff-bundles.py <base-bundle-dir> <head-bundle-dir>
 import difflib
 import os
 import pathlib
+import re
 import sys
 
 import yaml
@@ -40,6 +41,41 @@ REDACTED = "<redacted by diff-bundles>"
 MAX_TOTAL = int(os.environ.get("DIFF_MAX_CHARS", "58000"))  # GitHub comment cap is 65536
 MARKERS = {"added": "🟢 added", "removed": "🔴 removed", "changed": "🟡 changed"}
 
+# `helm template` regenerates some values on every render, so they differ
+# between the base and head renders even when nothing changed — pure noise
+# that crowds real changes out of the size-capped PR comment. Measured on a
+# real bundle pair, all three classes below appeared and the single genuine
+# change did not fit in the comment:
+#   * webhook clientConfig.caBundle (genSignedCert: aws-load-balancer-
+#     controller, victoria-metrics-operator admission webhooks)
+#   * checksum/* pod annotations over per-render-random Secrets (harbor,
+#     grafana)
+#   * a render timestamp embedded in a resource NAME (oncall's migrate Job),
+#     which otherwise shows as an added+removed pair of full manifests
+# Trade-off: a genuine change to a static caBundle/checksum, or a change
+# only distinguishable by such a timestamp, is masked — acceptable for an
+# informational diff, same deal as Secret redaction.
+TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}")
+
+
+def scrub(node):
+    """Blank the per-render nondeterministic fields listed above."""
+    if isinstance(node, dict):
+        out = {}
+        for key, value in node.items():
+            if key == "caBundle" and isinstance(value, str):
+                out[key] = REDACTED
+            elif key == "annotations" and isinstance(value, dict):
+                out[key] = {
+                    k: (REDACTED if k.startswith("checksum/") else v) for k, v in value.items()
+                }
+            else:
+                out[key] = scrub(value)
+        return out
+    if isinstance(node, list):
+        return [scrub(item) for item in node]
+    return node
+
 
 def load_bundle(directory):
     """Every rendered document keyed by apiVersion/kind/namespace/name."""
@@ -56,22 +92,27 @@ def load_bundle(directory):
             if not isinstance(doc, dict) or not doc.get("kind"):
                 continue
             meta = doc.get("metadata") or {}
-            key = "{}/{}/{}/{}".format(
+            # Timestamped names (oncall's migrate Job) are normalized in the
+            # grouping key too, so the two sides line up as one "changed"
+            # candidate instead of an added+removed pair of full manifests.
+            key = TIMESTAMP_RE.sub("<render-timestamp>", "{}/{}/{}/{}".format(
                 doc.get("apiVersion", "?"), doc["kind"],
                 meta.get("namespace", "-"), meta.get("name", "?"),
-            )
+            ))
             resources[key] = doc
     return resources
 
 
 def canonical(doc):
-    """Stable, secret-safe YAML for diffing: sorted keys, redacted Secret data."""
-    doc = dict(doc)
+    """Stable, secret-safe, noise-free YAML for diffing: sorted keys, redacted
+    Secret data, per-render nondeterminism scrubbed (see TIMESTAMP_RE above)."""
+    doc = scrub(doc)
     if doc.get("kind") == "Secret":
         for field in ("data", "stringData"):
             if isinstance(doc.get(field), dict):
                 doc[field] = {k: REDACTED for k in doc[field]}
-    return yaml.dump(doc, Dumper=YAML_DUMPER, sort_keys=True, default_flow_style=False, width=10 ** 6)
+    text = yaml.dump(doc, Dumper=YAML_DUMPER, sort_keys=True, default_flow_style=False, width=10 ** 6)
+    return TIMESTAMP_RE.sub("<render-timestamp>", text)
 
 
 def main():
@@ -86,9 +127,12 @@ def main():
         # Fast path: equal parsed docs can't produce a diff (canonical() is a
         # pure function of the doc), and in a typical PR ~99% of resources are
         # unchanged - canonicalizing all of them dominated this script's runtime.
-        # Docs differing only in redacted Secret values fall through to the
-        # canonical comparison below, which still treats them as unchanged.
-        if in_base and in_head and base[key] == head[key]:
+        # repr() rather than == because Python's == conflates True/1/1.0 across
+        # types, which would silently skip a genuine `true` -> `1` manifest
+        # change; repr is type-faithful for YAML-representable data and stays
+        # C-speed. Docs differing only in redacted/scrubbed values fall through
+        # to the canonical comparison below, which still treats them as unchanged.
+        if in_base and in_head and repr(base[key]) == repr(head[key]):
             continue
         before = canonical(base[key]) if in_base else ""
         after = canonical(head[key]) if in_head else ""
@@ -113,7 +157,9 @@ def main():
         "> Rendered with `kustomize build` + `helm template` (source of truth = git), "
         "so Helm-expanded workloads are included. Shows what Flux will apply — not a diff "
         "against live cluster state (drift is alerted on separately), and not "
-        "CRD-defaulted / webhook-mutated output. Secret values are redacted.",
+        "CRD-defaulted / webhook-mutated output. Secret values are redacted; "
+        "per-render noise (webhook `caBundle`s, `checksum/*` annotations, render "
+        "timestamps) is normalized out.",
         "",
     ]
     body = "\n".join(lines) + "\n"

--- a/scripts/flux-schema/diff-bundles.py
+++ b/scripts/flux-schema/diff-bundles.py
@@ -23,19 +23,7 @@ import sys
 
 import yaml
 
-# libyaml-backed loader/dumper when the wheel ships it (5-10x faster parse of
-# the two full bundles); pure-Python fallback keeps a libyaml-less PyYAML working.
-YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
-YAML_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
-
-# Same PyYAML workaround render-bundle.py registers: a bare `=` scalar (the
-# prometheus-operator-crds AlertmanagerConfig matchType enum `!=`,`=`,`=~`,`!~`)
-# is the reserved tag:yaml.org,2002:value, which SafeLoader refuses to construct.
-# Without this, safe_load_all raises and load_bundle() would silently drop the
-# whole document from the diff. Keep in lockstep with render-bundle.py.
-YAML_LOADER.add_constructor(
-    "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
-)
+from yamlcompat import YAML_DUMPER, YAML_LOADER
 
 REDACTED = "<redacted by diff-bundles>"
 MAX_TOTAL = int(os.environ.get("DIFF_MAX_CHARS", "58000"))  # GitHub comment cap is 65536

--- a/scripts/flux-schema/diff-bundles.py
+++ b/scripts/flux-schema/diff-bundles.py
@@ -28,6 +28,7 @@ from yamlcompat import YAML_DUMPER, YAML_LOADER
 
 REDACTED = "<redacted by diff-bundles>"
 MAX_TOTAL = int(os.environ.get("DIFF_MAX_CHARS", "58000"))  # GitHub comment cap is 65536
+SUMMARY_MAX = 1_000_000  # GitHub job-summary cap is 1MiB; headroom for the note
 MARKERS = {"added": "🟢 added", "removed": "🔴 removed", "changed": "🟡 changed"}
 
 # `helm template` regenerates some values on every render, so they differ
@@ -188,13 +189,15 @@ def main():
         ))
         chunks.append((key, tag, diff))
 
-    # stdout is the size-capped PR comment; the optional third argument gets
-    # the untruncated report (previously the artifact was a tee of the capped
-    # stdout, so "see the artifact for the full diff" pointed at the same
-    # truncated content).
+    # stdout is the comment-capped report; the optional third argument gets the
+    # full report (previously the artifact was a tee of the capped stdout, so
+    # "see the artifact for the full diff" pointed at the same truncated
+    # content). The full report is itself capped at the job-summary limit -
+    # boundary-aware with a visible note, instead of the workflow byte-chopping
+    # it mid-fence/mid-codepoint - which only fires on pathological >1MB diffs.
     sys.stdout.write(render_report(chunks, counts, cap=MAX_TOTAL))
     if len(sys.argv) == 4:
-        pathlib.Path(sys.argv[3]).write_text(render_report(chunks, counts))
+        pathlib.Path(sys.argv[3]).write_text(render_report(chunks, counts, cap=SUMMARY_MAX))
     return 0
 
 

--- a/scripts/flux-schema/diff-bundles.py
+++ b/scripts/flux-schema/diff-bundles.py
@@ -13,7 +13,8 @@ Reads two bundle dirs produced by render-bundle.py, groups every document by its
 Kubernetes identity, redacts Secret payloads, canonicalizes (sorted keys), and
 prints a unified diff + summary as GitHub-flavored markdown on stdout.
 
-Usage: diff-bundles.py <base-bundle-dir> <head-bundle-dir>
+Usage: diff-bundles.py <base-bundle-dir> <head-bundle-dir> [full-report-path]
+(stdout is capped for the PR comment; the optional path gets the full report)
 """
 import difflib
 import os

--- a/scripts/flux-schema/diff-bundles.py
+++ b/scripts/flux-schema/diff-bundles.py
@@ -22,12 +22,17 @@ import sys
 
 import yaml
 
+# libyaml-backed loader/dumper when the wheel ships it (5-10x faster parse of
+# the two full bundles); pure-Python fallback keeps a libyaml-less PyYAML working.
+YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+YAML_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
+
 # Same PyYAML workaround render-bundle.py registers: a bare `=` scalar (the
 # prometheus-operator-crds AlertmanagerConfig matchType enum `!=`,`=`,`=~`,`!~`)
 # is the reserved tag:yaml.org,2002:value, which SafeLoader refuses to construct.
 # Without this, safe_load_all raises and load_bundle() would silently drop the
 # whole document from the diff. Keep in lockstep with render-bundle.py.
-yaml.SafeLoader.add_constructor(
+YAML_LOADER.add_constructor(
     "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
 )
 
@@ -44,7 +49,7 @@ def load_bundle(directory):
         return resources
     for path in sorted(base.rglob("*.yaml")):
         try:
-            docs = list(yaml.safe_load_all(path.read_text()))
+            docs = list(yaml.load_all(path.read_text(), Loader=YAML_LOADER))
         except (yaml.YAMLError, OSError):
             continue
         for doc in docs:
@@ -66,7 +71,7 @@ def canonical(doc):
         for field in ("data", "stringData"):
             if isinstance(doc.get(field), dict):
                 doc[field] = {k: REDACTED for k in doc[field]}
-    return yaml.safe_dump(doc, sort_keys=True, default_flow_style=False, width=10 ** 6)
+    return yaml.dump(doc, Dumper=YAML_DUMPER, sort_keys=True, default_flow_style=False, width=10 ** 6)
 
 
 def main():
@@ -78,6 +83,13 @@ def main():
     chunks, counts = [], {"added": 0, "removed": 0, "changed": 0}
     for key in sorted(set(base) | set(head)):
         in_base, in_head = key in base, key in head
+        # Fast path: equal parsed docs can't produce a diff (canonical() is a
+        # pure function of the doc), and in a typical PR ~99% of resources are
+        # unchanged - canonicalizing all of them dominated this script's runtime.
+        # Docs differing only in redacted Secret values fall through to the
+        # canonical comparison below, which still treats them as unchanged.
+        if in_base and in_head and base[key] == head[key]:
+            continue
         before = canonical(base[key]) if in_base else ""
         after = canonical(head[key]) if in_head else ""
         if before == after:

--- a/scripts/flux-schema/render-both.sh
+++ b/scripts/flux-schema/render-both.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Render the PR head and the merge-base concurrently, for the render-diff CI
+# job (SPEC-007). Output paths are the contract with .github/workflows/ci.yaml's
+# "Compute rendered diff" step: .bundle-head (head) and /tmp/base/.bundle-base
+# (merge-base, rendered from a worktree with each ref's OWN renderer so a
+# change to render-bundle.py itself shows up in the diff).
+#
+# Both renders are best-effort: a render failure must not sink the
+# informational diff job (the hard gate is the kubernetes-validation job), but
+# it is surfaced as a ::warning:: annotation - a silent failure here produces
+# a misleading "everything added" / "no changes" comment.
+#
+# helm's repository cache is not safe for concurrent writers across processes
+# (index files and chart tarballs share one dir), so the base render gets its
+# own seeded COPY of the cache instead of the shared one. Within one renderer
+# process the same invariant is handled by per-source-URL locks in
+# render-bundle.py - keep the two in sync.
+set -uo pipefail
+
+BASE_REF="${1:?usage: render-both.sh <base-ref> (e.g. origin/main)}"
+
+python3 scripts/flux-schema/render-bundle.py .bundle-head &
+head_pid=$!
+
+(
+  set -euo pipefail
+  base_sha="$(git merge-base "${BASE_REF}" HEAD)"
+  echo "base merge-base: ${base_sha}"
+  git worktree add /tmp/base "${base_sha}"
+  mkdir -p "${HOME}/.cache/helm" /tmp/helm-cache-base
+  cp -r "${HOME}/.cache/helm/." /tmp/helm-cache-base/
+  cd /tmp/base
+  HELM_REPOSITORY_CACHE=/tmp/helm-cache-base/repository \
+    python3 scripts/flux-schema/render-bundle.py /tmp/base/.bundle-base
+) &
+base_pid=$!
+
+wait "${head_pid}" || echo "::warning::head render failed — the rendered diff is unreliable"
+wait "${base_pid}" || echo "::warning::base render failed — the rendered diff may show everything as added"
+exit 0

--- a/scripts/flux-schema/render-bundle.py
+++ b/scripts/flux-schema/render-bundle.py
@@ -9,6 +9,7 @@ Three inputs, one output directory:
 Rendered output is what Flux actually applies, so it is the only artifact worth
 asserting on (CL-1): raw patch fragments can never satisfy a full schema.
 """
+import concurrent.futures
 import os
 import pathlib
 import re
@@ -16,8 +17,15 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 
 import yaml
+
+# libyaml-backed loader/dumper when the wheel ships it (5-10x faster on the
+# multi-MB helm outputs postprocess round-trips); pure-Python fallback keeps
+# the script working on a libyaml-less PyYAML build.
+YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+YAML_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
 
 # PyYAML 1.1-spec quirk, not a real document defect: a bare, unquoted `=`
 # scalar (e.g. an enum member `- =`, as in the prometheus-operator-crds
@@ -26,9 +34,28 @@ import yaml
 # which SafeLoader registers no constructor - safe_load then raises
 # ConstructorError on an otherwise perfectly valid document. Treat it as the
 # plain string it is; this is the standard workaround (see pyyaml/pyyaml#89).
-yaml.SafeLoader.add_constructor(
+YAML_LOADER.add_constructor(
     "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
 )
+
+# Renders are independent subprocesses (helm/kustomize), so they parallelize
+# near-linearly; the loops in main() were sequential and dominated the runtime
+# (~130s of a ~140s validate run for 67 overlays + 40 charts).
+MAX_WORKERS = int(os.environ.get("RENDER_WORKERS", "8"))
+
+# helm shares one repository cache dir for index files AND chart tarballs
+# (`<chart>-<version>.tgz` - not namespaced by repo, and OCI pulls land there
+# too). Two concurrent helm invocations against the same source can race on
+# the same cache file (e.g. the two gha-runner-scale-set HelmReleases share a
+# chart), so helm calls are serialized per source URL; distinct sources still
+# run fully parallel.
+_repo_locks = {}
+_repo_locks_guard = threading.Lock()
+
+
+def _repo_lock(url):
+    with _repo_locks_guard:
+        return _repo_locks.setdefault(url, threading.Lock())
 
 MANIFEST_DIRS = [
     "infrastructure",
@@ -172,7 +199,7 @@ def substitute(text):
 
 def load_docs(path):
     try:
-        return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+        return [d for d in yaml.load_all(path.read_text(), Loader=YAML_LOADER) if isinstance(d, dict)]
     except yaml.YAMLError:
         return []
 
@@ -232,7 +259,7 @@ def postprocess(text):
     Polaris validation, and dropped anyway once helm/kustomize post-renderers
     round-trip through YAML.
     """
-    docs = unwrap_lists([d for d in yaml.safe_load_all(text) if isinstance(d, dict)])
+    docs = unwrap_lists([d for d in yaml.load_all(text, Loader=YAML_LOADER) if isinstance(d, dict)])
     # Drop non-resource docs before they reach the bundle. `helm template`
     # (notably Helm v4) can emit a stray YAML document that is a non-empty dict
     # yet carries no apiVersion/kind - not an applyable Kubernetes resource, but
@@ -246,7 +273,7 @@ def postprocess(text):
     for doc in docs:
         normalize_quantities(doc)
     return "\n---\n".join(
-        yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=1000000).strip()
+        yaml.dump(doc, Dumper=YAML_DUMPER, sort_keys=False, default_flow_style=False, width=1000000).strip()
         for doc in docs
     ) + "\n"
 
@@ -561,7 +588,12 @@ def render_helmrelease(doc, sources, outdir, namespace):
             # the cluster's. Exact pins (tag / exact semver) are unaffected.
             cmd += ["--version", version]
 
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        # Local git checkouts touch no shared helm cache - no lock needed.
+        if is_git:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        else:
+            with _repo_lock(url):
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
     finally:
         os.unlink(values_file)
         if git_clone_dir:
@@ -593,16 +625,12 @@ def main():
 
     errors = []
     overlays = top_most_overlays()
-    for overlay in overlays:
-        error = render_overlay(overlay, outdir)
-        if error:
-            errors.append(f"kustomize {overlay}: {error}")
-
     sources = index_sources()
     namespaces = index_namespaces()
     covered = {str(o) for o in overlays}
     charts = standalone = 0
 
+    helmreleases = []
     for root in MANIFEST_DIRS:
         base = pathlib.Path(root)
         if not base.exists():
@@ -622,17 +650,33 @@ def main():
                 # (no chart at all) are still validated via the overlay.
                 hr_spec = doc.get("spec", {})
                 if doc.get("kind") == "HelmRelease" and (hr_spec.get("chart") or hr_spec.get("chartRef")):
-                    namespace = namespaces.get(path.resolve())
-                    error = render_helmrelease(doc, sources, outdir, namespace)
-                    if error:
-                        errors.append(error)
-                    else:
-                        charts += 1
+                    helmreleases.append((doc, namespaces.get(path.resolve())))
             if not in_overlay and docs:
                 (outdir / ("standalone-" + str(path).replace("/", "-"))).write_text(
                     substitute(path.read_text())
                 )
                 standalone += 1
+
+    # Every render writes its own uniquely-named output file, so the only
+    # shared mutable state is the helm cache (serialized per source URL above).
+    # Futures are drained in submission order to keep error output
+    # deterministic regardless of completion order.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        overlay_futures = [pool.submit(render_overlay, o, outdir) for o in overlays]
+        chart_futures = [
+            pool.submit(render_helmrelease, doc, sources, outdir, namespace)
+            for doc, namespace in helmreleases
+        ]
+        for overlay, future in zip(overlays, overlay_futures):
+            error = future.result()
+            if error:
+                errors.append(f"kustomize {overlay}: {error}")
+        for future in chart_futures:
+            error = future.result()
+            if error:
+                errors.append(error)
+            else:
+                charts += 1
 
     print(
         f"RENDER: overlays={len(overlays)} charts={charts} "

--- a/scripts/flux-schema/render-bundle.py
+++ b/scripts/flux-schema/render-bundle.py
@@ -10,6 +10,7 @@ Rendered output is what Flux actually applies, so it is the only artifact worth
 asserting on (CL-1): raw patch fragments can never satisfy a full schema.
 """
 import concurrent.futures
+import contextlib
 import os
 import pathlib
 import re
@@ -21,22 +22,7 @@ import threading
 
 import yaml
 
-# libyaml-backed loader/dumper when the wheel ships it (5-10x faster on the
-# multi-MB helm outputs postprocess round-trips); pure-Python fallback keeps
-# the script working on a libyaml-less PyYAML build.
-YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
-YAML_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
-
-# PyYAML 1.1-spec quirk, not a real document defect: a bare, unquoted `=`
-# scalar (e.g. an enum member `- =`, as in the prometheus-operator-crds
-# chart's AlertmanagerConfig CRD matchType enum: `!=`, `=`, `=~`, `!~`) is
-# reserved as the special "default value" tag `tag:yaml.org,2002:value`, for
-# which SafeLoader registers no constructor - safe_load then raises
-# ConstructorError on an otherwise perfectly valid document. Treat it as the
-# plain string it is; this is the standard workaround (see pyyaml/pyyaml#89).
-YAML_LOADER.add_constructor(
-    "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
-)
+from yamlcompat import YAML_DUMPER, YAML_LOADER
 
 # Renders are independent subprocesses (helm/kustomize), so they parallelize
 # near-linearly; the loops in main() were sequential and dominated the runtime
@@ -424,16 +410,22 @@ def resolve_source(sources, source_ref, hr_namespace):
 
 
 def index_namespaces():
-    """Map each locally-listed kustomize resource file to its effective namespace.
+    """Map each locally-listed kustomize resource file to its effective
+    namespace, and collect the set of ALL files any kustomization references.
 
-    This repo's convention is `base/<component>/kustomization.yaml` carrying
-    both `namespace: X` and a `resources:` list of local files (helmrelease.yaml
-    among them) - the namespace transformer stamps X onto them at apply time,
-    even though the raw HelmRelease YAML on disk has no metadata.namespace.
-    Without this, HelmReleases relying on that convention default to the wrong
-    namespace and both their own render and their sourceRef lookup fail.
+    Namespaces: this repo's convention is `base/<component>/kustomization.yaml`
+    carrying both `namespace: X` and a `resources:` list of local files
+    (helmrelease.yaml among them) - the namespace transformer stamps X onto
+    them at apply time, even though the raw HelmRelease YAML on disk has no
+    metadata.namespace. Without this, HelmReleases relying on that convention
+    default to the wrong namespace and both their own render and their
+    sourceRef lookup fail.
+
+    Referenced set: used to pick between ALTERNATIVE HelmRelease variants of
+    the same release (see main()) - the variant a kustomization actually lists
+    is the one Flux applies; the commented-out sibling is not.
     """
-    index = {}
+    index, referenced = {}, set()
     for root in MANIFEST_DIRS:
         base = pathlib.Path(root)
         if not base.exists():
@@ -443,13 +435,13 @@ def index_namespaces():
             if not docs:
                 continue
             namespace = docs[0].get("namespace")
-            if not namespace:
-                continue
             for resource in docs[0].get("resources") or []:
                 candidate = (kfile.parent / resource).resolve()
                 if candidate.is_file():
-                    index[candidate] = namespace
-    return index
+                    referenced.add(candidate)
+                    if namespace:
+                        index[candidate] = namespace
+    return index, referenced
 
 
 def clone_git_source(url, ref, dest):
@@ -589,11 +581,9 @@ def render_helmrelease(doc, sources, outdir, namespace):
             cmd += ["--version", version]
 
         # Local git checkouts touch no shared helm cache - no lock needed.
-        if is_git:
+        lock = contextlib.nullcontext() if is_git else _repo_lock(url)
+        with lock:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
-        else:
-            with _repo_lock(url):
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
     finally:
         os.unlink(values_file)
         if git_clone_dir:
@@ -626,11 +616,23 @@ def main():
     errors = []
     overlays = top_most_overlays()
     sources = index_sources()
-    namespaces = index_namespaces()
+    namespaces, referenced = index_namespaces()
     covered = {str(o) for o in overlays}
     charts = standalone = 0
 
-    helmreleases = []
+    # Keyed by the OUTPUT identity (effective namespace, name): the repo keeps
+    # alternative HelmRelease variants for the same release side by side (e.g.
+    # victoria-metrics-k8s-stack's helmrelease-vmsingle.yaml vs
+    # helmrelease-vmcluster.yaml, one commented out in the kustomization), and
+    # this wiring-agnostic scan picks up both - yet they write the same
+    # chart-<ns>-<name>.yaml, so only one can be rendered. The winner is the
+    # variant some kustomization actually references (that is what Flux
+    # applies; scan-order last-write-wins previously picked victoria-logs'
+    # UNREFERENCED vlcluster variant, and under parallel rendering the winner
+    # was whichever FINISHED last). Among equally-referenced (or equally
+    # unreferenced) duplicates, last in scan order wins. Dropped duplicates
+    # are logged, never silent.
+    helmreleases = {}
     for root in MANIFEST_DIRS:
         base = pathlib.Path(root)
         if not base.exists():
@@ -650,7 +652,24 @@ def main():
                 # (no chart at all) are still validated via the overlay.
                 hr_spec = doc.get("spec", {})
                 if doc.get("kind") == "HelmRelease" and (hr_spec.get("chart") or hr_spec.get("chartRef")):
-                    helmreleases.append((doc, namespaces.get(path.resolve())))
+                    kustomize_ns = namespaces.get(path.resolve())
+                    effective_ns = doc["metadata"].get("namespace") or kustomize_ns or "default"
+                    key = (effective_ns, doc["metadata"]["name"])
+                    is_referenced = path.resolve() in referenced
+                    if key in helmreleases and helmreleases[key][2] and not is_referenced:
+                        print(
+                            f"note: duplicate HelmRelease/{key[0]}/{key[1]}: skipping "
+                            f"unreferenced variant {path} (a kustomization references the other)",
+                            file=sys.stderr,
+                        )
+                        continue
+                    if key in helmreleases:
+                        print(
+                            f"note: duplicate HelmRelease/{key[0]}/{key[1]}: rendering {path} "
+                            "(kustomization-referenced, or last in scan order)",
+                            file=sys.stderr,
+                        )
+                    helmreleases[key] = (doc, kustomize_ns, is_referenced)
             if not in_overlay and docs:
                 (outdir / ("standalone-" + str(path).replace("/", "-"))).write_text(
                     substitute(path.read_text())
@@ -662,12 +681,12 @@ def main():
     # Futures are drained in submission order to keep error output
     # deterministic regardless of completion order.
     with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
-        overlay_futures = [pool.submit(render_overlay, o, outdir) for o in overlays]
+        overlay_futures = [(o, pool.submit(render_overlay, o, outdir)) for o in overlays]
         chart_futures = [
             pool.submit(render_helmrelease, doc, sources, outdir, namespace)
-            for doc, namespace in helmreleases
+            for doc, namespace, _ in helmreleases.values()
         ]
-        for overlay, future in zip(overlays, overlay_futures):
+        for overlay, future in overlay_futures:
             error = future.result()
             if error:
                 errors.append(f"kustomize {overlay}: {error}")

--- a/scripts/flux-schema/render-bundle.py
+++ b/scripts/flux-schema/render-bundle.py
@@ -382,7 +382,7 @@ def index_sources():
         base = pathlib.Path(root)
         if not base.exists():
             continue
-        for path in base.rglob("*.yaml"):
+        for path in sorted(base.rglob("*.yaml")):
             for doc in load_docs(path):
                 # GitRepository is included alongside HelmRepository/OCIRepository:
                 # one HelmRelease (runlore) points `chart.spec.sourceRef` at a
@@ -430,7 +430,7 @@ def index_namespaces():
         base = pathlib.Path(root)
         if not base.exists():
             continue
-        for kfile in base.rglob("kustomization.yaml"):
+        for kfile in sorted(base.rglob("kustomization.yaml")):
             docs = load_docs(kfile)
             if not docs:
                 continue
@@ -637,7 +637,7 @@ def main():
         base = pathlib.Path(root)
         if not base.exists():
             continue
-        for path in base.rglob("*.yaml"):
+        for path in sorted(base.rglob("*.yaml")):
             if path.as_posix() in NON_MANIFEST_FILES:
                 continue
             docs = load_docs(path)

--- a/scripts/flux-schema/render-bundle.py
+++ b/scripts/flux-schema/render-bundle.py
@@ -517,9 +517,17 @@ def _resolve_chart(spec, sources, namespace):
     return source, chart_spec.get("chart"), chart_spec.get("version")
 
 
+def effective_namespace(doc, kustomize_namespace):
+    """metadata.namespace > enclosing kustomization's namespace transformer >
+    "default". Shared by render_helmrelease and the duplicate-variant dedupe
+    key in main() - they MUST agree, since the key decides which variant is
+    rendered under the chart-<ns>-<name>.yaml filename this resolves."""
+    return doc["metadata"].get("namespace") or kustomize_namespace or "default"
+
+
 def render_helmrelease(doc, sources, outdir, namespace):
     meta, spec = doc["metadata"], doc["spec"]
-    namespace = meta.get("namespace") or namespace or "default"
+    namespace = effective_namespace(doc, namespace)
 
     source, chart, version = _resolve_chart(spec, sources, namespace)
     if not source or not source.get("url"):
@@ -652,18 +660,19 @@ def main():
                 # (no chart at all) are still validated via the overlay.
                 hr_spec = doc.get("spec", {})
                 if doc.get("kind") == "HelmRelease" and (hr_spec.get("chart") or hr_spec.get("chartRef")):
-                    kustomize_ns = namespaces.get(path.resolve())
-                    effective_ns = doc["metadata"].get("namespace") or kustomize_ns or "default"
-                    key = (effective_ns, doc["metadata"]["name"])
-                    is_referenced = path.resolve() in referenced
-                    if key in helmreleases and helmreleases[key][2] and not is_referenced:
+                    resolved = path.resolve()
+                    kustomize_ns = namespaces.get(resolved)
+                    key = (effective_namespace(doc, kustomize_ns), doc["metadata"]["name"])
+                    is_referenced = resolved in referenced
+                    prev = helmreleases.get(key)
+                    if prev and prev[2] and not is_referenced:
                         print(
                             f"note: duplicate HelmRelease/{key[0]}/{key[1]}: skipping "
                             f"unreferenced variant {path} (a kustomization references the other)",
                             file=sys.stderr,
                         )
                         continue
-                    if key in helmreleases:
+                    if prev:
                         print(
                             f"note: duplicate HelmRelease/{key[0]}/{key[1]}: rendering {path} "
                             "(kustomization-referenced, or last in scan order)",

--- a/scripts/flux-schema/yamlcompat.py
+++ b/scripts/flux-schema/yamlcompat.py
@@ -1,0 +1,21 @@
+"""Shared PyYAML setup for the flux-schema scripts (render-bundle, diff-bundles).
+
+libyaml-backed loader/dumper when the wheel ships it (5-10x faster on the
+multi-MB bundles both scripts round-trip); pure-Python fallback keeps a
+libyaml-less PyYAML build working.
+"""
+import yaml
+
+YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+YAML_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
+
+# PyYAML 1.1-spec quirk, not a real document defect: a bare, unquoted `=`
+# scalar (e.g. an enum member `- =`, as in the prometheus-operator-crds
+# chart's AlertmanagerConfig CRD matchType enum: `!=`, `=`, `=~`, `!~`) is
+# reserved as the special "default value" tag `tag:yaml.org,2002:value`, for
+# which SafeLoader registers no constructor - loading then raises
+# ConstructorError on an otherwise perfectly valid document. Treat it as the
+# plain string it is; this is the standard workaround (see pyyaml/pyyaml#89).
+YAML_LOADER.add_constructor(
+    "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
+)


### PR DESCRIPTION
## What

Cuts the manifest-validation path roughly 3x, measured:

| Path | Before | After |
|---|---|---|
| `validate-manifests.sh` (local, warm cache) | 142s | **48s** |
| `render-bundle.py` alone | 135s | **36s** |
| `diff-bundles.py` on a real bundle pair | 40.7s | **2.6s** |
| CI `render-diff` job render+diff steps | ~226s | ~60s expected |

## How

**`render-bundle.py` — parallel rendering.** Overlays and HelmReleases render on a `ThreadPoolExecutor` (`RENDER_WORKERS`, default 8); each render is an independent `helm template`/`kustomize build` subprocess writing its own uniquely-named output file. helm invocations are serialized **per source URL**: helm's repository cache keeps index files and chart tarballs (`<chart>-<version>.tgz`, not namespaced by repo) in one shared dir, so concurrent writers against the same source can race — e.g. the two `gha-runner-scale-set` HelmReleases share a chart. Also switches PyYAML to the libyaml `CSafeLoader`/`CSafeDumper` when available (pure-Python fallback kept).

**`diff-bundles.py` — skip unchanged docs.** Docs that compare equal as parsed dicts cannot produce a diff (`canonical()` is a pure function of the doc), and in a typical PR ~99% of resources are unchanged — canonicalizing all of them dominated the runtime. Docs differing only in redacted Secret values still fall through to the canonical comparison, unchanged behavior.

**`ci.yaml` render-diff job — concurrent head/base render.** Both renders are independent; they now run in one step concurrently. The base render gets its own seeded *copy* of the helm cache (`HELM_REPOSITORY_CACHE`) because the cache is not safe for concurrent writers across processes. Also removes the transitional merge-base guard whose own comment marked it safe to delete once its introducing PR merged.

## Verification

- Sequential vs parallel bundle: **byte-identical for all 180 deterministic files**; the 5 differing files (`aws-load-balancer-controller`, `harbor`, `oncall`, `victoria-metrics-k8s-stack`, `envoy-ai-gateway`) are template-time nondeterminism (`genSignedCert`/`randAlphaNum`) and differ between any two renders of the *same* code (verified: two runs of the new renderer differ in exactly the same 5 files).
- Old vs new `diff-bundles.py` on the same bundle pair: **output byte-identical** (10 changed · 1 added · 1 removed, both).
- `./scripts/validate-manifests.sh` → exit 0, `RENDER: overlays=67 charts=40 standalone=78 failed=0`, both gates passed.

## Second commit (review findings + caBundle noise)

A fresh-eyes review of the first commit plus a report of caBundle noise in the PR comment led to `dd3c6ecd`:

- **diff-bundles.py scrubs per-render nondeterminism** before comparing: webhook `caBundle`s (genSignedCert), `checksum/*` annotations over per-render-random Secrets, and render timestamps embedded in resource names (oncall migrate Job, previously an added+removed pair). Measured: 12 phantom entries → the 1 genuine change; two renders of identical code now report "No changes".
- **Fast-path fix**: Python `==` conflates `True`/`1`/`1.0`, so a genuine `true` → `1` manifest change would have been skipped; now compares `repr()` (type-faithful, still C-speed).
- **ci.yaml**: failed head/base renders now emit `::warning::` annotations instead of a silent echo + misleading diff.

## Third commit (`0399ff3d`) — duplicate-variant race fix + simplify pass

The PR's own rendered diff exposed a real race in the parallel renderer: alternative HelmRelease variants kept side by side (`helmrelease-vmsingle`/`-vmcluster`, `-vlsingle`/`-vlcluster`) both render into the same `chart-<ns>-<name>.yaml` — sequentially "last in scan order" won (vmsingle, by filename luck); in parallel, "last to finish" won (vmcluster showed up in the diff).

**Fix**: dedupe render tasks by output identity and pick the variant a kustomization actually references (what Flux applies), falling back to last-in-scan-order; dropped duplicates are logged. This also corrected a **pre-existing fidelity gap**: scan order had silently been picking victoria-logs' *unreferenced* `vlcluster` variant, so the gates validated a bundle diverging from the deployed `vlsingle`. The rendered-diff comment below showing the vlcluster→vlsingle flip is that correction (desired-state validation artifact only — the cluster always ran vlsingle).

Also applied from a 4-angle simplify pass: shared `yamlcompat.py` (was copy-pasted loader/dumper setup in both scripts), `contextlib.nullcontext` instead of a duplicated subprocess call, tuple-paired futures instead of parallel lists, and the render-diff orchestration bash extracted to shellcheck-covered `scripts/flux-schema/render-both.sh`.

## Follow-up

The flaky `tflint --init` 403 in the pre-commit job won't be fixed in the dagger module — **dagger is being phased out of the stack**. Instead, a follow-up PR should migrate the `Validate Opentofu configuration` step to run pre-commit natively in the workflow (with `GITHUB_TOKEN` env, which fixes the rate limit for free).
