### PR TITLE
feat(crossplane): KVStore composition backed by the official valkey-helm chart (SPEC-012, 1/2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,6 +159,22 @@
         "line_number": 168
       }
     ],
+    "infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml",
+        "hashed_secret": "76876bb923d9619ae57846f5f9dd2623b79e9d83",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
     "infrastructure/base/crossplane/configuration/kcl/cloudnativepg/main.k": [
       {
         "type": "Secret Keyword",
@@ -182,6 +198,52 @@
         "hashed_secret": "e99bc35202bf01813106ef4488a209b35f91899e",
         "is_verified": false,
         "line_number": 104
+      }
+    ],
+    "infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k": [
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k",
+        "hashed_secret": "fa25e2e0578e0fdb4945a296a2b3349b47dbe33f",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k",
+        "hashed_secret": "d0930f351951c6dd23c069f046e70711269fbb48",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k",
+        "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 97
+      }
+    ],
+    "infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml",
+        "hashed_secret": "76876bb923d9619ae57846f5f9dd2623b79e9d83",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 13
       }
     ],
     "infrastructure/base/gapi/platform-private-gateway-certificate.yaml": [
@@ -503,5 +565,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-18T20:23:24Z"
+  "generated_at": "2026-07-21T06:28:32Z"
 }

--- a/docs/specs/012-kvstore-composition-replace-bitnami/clarifications.md
+++ b/docs/specs/012-kvstore-composition-replace-bitnami/clarifications.md
@@ -1,0 +1,122 @@
+# Clarifications Log — KVStore composition: replace Bitnami Valkey with official valkey-helm chart behind a cloud.ogenki.io XRD
+
+**Spec**: [SPEC-012](spec.md)
+
+> **Append-only.** Never rewrite earlier entries. Every entry has a stable ID (`CL-1`, `CL-2`, ...) so `spec.md` and `plan.md` can reference the decision by ID. This is the durable "why did we pick option A?" audit trail.
+
+---
+
+<!-- Template for each entry:
+
+## CL-N — 2026-07-20 — <one-line question>
+
+**Asked by**: <role or user>
+**Context**: <1–3 sentences: why this decision matters; what is constrained>
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | <answer> | <pro> | <con> |
+| B | <answer> | <pro> | <con> |
+| C | <answer> | <pro> | <con> |
+
+**Decision**: <Option letter + answer>
+**Rationale**: <Why — tie back to constitution, existing patterns, or SC-XXX>
+**Decided by**: <who — conversation / PR reviewer / ADR>
+**References**: <links to ADR, similar spec, vendor doc>
+
+-->
+
+## CL-1 — 2026-07-20 — In-cluster Valkey or AWS-managed ElastiCache?
+
+**Asked by**: Spec author (brainstorming session)
+**Context**: All three Valkey consumers (Harbor, Grafana OnCall, App composition `kvStore`) run on the frozen `bitnamilegacy` supply chain. Replacing the delivery mechanism forces the in-cluster vs managed question.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | In-cluster | Matches CNPG precedent for stateful services; no per-instance AWS cost; works for per-app kvStore | Self-managed upgrades |
+| B | ElastiCache (Valkey engine) via Crossplane | Zero ops | ~$13+/mo per instance, slower provisioning, MR + activation-policy + CNP work per consumer |
+| C | Hybrid (in-cluster + ElastiCache tier in App API) | Best of both | Two backends to maintain for cache-grade data |
+
+**Decision**: A — in-cluster
+**Rationale**: SQLInstance/CloudNativePG sets the repo precedent: stateful data services run in-cluster behind an XRD. Cache-grade data does not justify managed-service cost or provisioning latency.
+**Decided by**: User (brainstorming, 2026-07-20)
+**References**: `infrastructure/base/crossplane/configuration/kcl/cloudnativepg/`
+
+## CL-2 — 2026-07-20 — Required availability level?
+
+**Asked by**: Spec author (brainstorming session)
+**Context**: The Bitnami "replication" architecture in use today runs primary+replica with **no automatic failover**. Whether any consumer needs Sentinel-style failover determines operator vs chart.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | Cache semantics (restart-and-refill acceptable) | Small footprint; no operator machinery | Warm-cache loss on restart |
+| B | Automatic failover | Resilience | Requires operator; none of the consumers stores durable data |
+| C | Tiered `ha` flag | Flexibility | API surface for a need nobody has |
+
+**Decision**: A — cache semantics; standalone by default, optional read replicas, no auto-failover
+**Rationale**: All three consumers use Valkey as cache/broker. YAGNI.
+**Decided by**: User (brainstorming, 2026-07-20)
+
+## CL-3 — 2026-07-20 — Delivery mechanism: XRD + official chart, in-place swap, or operator?
+
+**Asked by**: Spec author (brainstorming session)
+**Context**: Drivers confirmed: leave `bitnamilegacy`, improve ops model, consolidate three copy-pasted delivery paths. The Valkey project now ships an official Helm chart (valkey-io/valkey-helm) created in response to the Bitnami shutdown; CloudPirates is discussing deprecating its chart in favor of it; hyperspike/valkey-operator remains v0.0.x.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | `KVStore` XRD wrapping official valkey-helm chart | Hits all three drivers; mirrors the `sqlInstance` → SQLInstance nesting precedent; backend swappable later | New composition → spec + migration touching service names/labels |
+| B | In-place chart swap (3 edits) | Minimal churn | Solves supply chain only; consolidation unaddressed |
+| C | valkey-operator behind the XRD | True operator ops model | Immature (v0.0.x); failover machinery CL-2 says we don't need |
+
+**Decision**: A — new namespaced `KVStore` XRD (`cloud.ogenki.io/v1alpha1`) wrapping the official chart
+**Rationale**: Only option meeting all three drivers; the XRD boundary makes a future operator swap (option C) invisible to consumers.
+**Decided by**: User (brainstorming, 2026-07-20)
+**References**: <https://valkey.io/blog/valkey-helm-chart/>; <https://github.com/valkey-io/valkey-helm>
+
+## CL-4 — 2026-07-20 — Default persistence: PVC or ephemeral?
+
+**Asked by**: Spec author (brainstorming session)
+**Context**: All three instances currently mount 4Gi PVCs. CL-2 establishes cache semantics.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | Ephemeral (emptyDir) default; `persistence.size` opts into a PVC | Honest about cache semantics; no orphaned PVCs; faster pod cycling | Cold cache after restart |
+| B | PVC default (4Gi), matching today | Warm cache survives restarts | PVC lifecycle management per instance |
+
+**Decision**: A — ephemeral by default, PVC opt-in
+**Rationale**: Consistent with CL-2; consumers that want warm restarts set `persistence.size` explicitly.
+**Decided by**: User (brainstorming, 2026-07-20)
+
+## CL-5 — 2026-07-20 — What happens to the App API's `kvStore.type` field (valkey|redis)?
+
+**Asked by**: Plan author
+**Context**: FR-005 freezes the App API surface, but the new backend is Valkey-only — the Bitnami-era `type: redis` option has no equivalent in the official chart.
+
+**Options considered**:
+
+| Option | Answer | Pros | Cons |
+|--------|--------|------|------|
+| A | Keep the field in the schema, ignore its value | No breaking change for existing claims; API frozen per FR-005 | Silent no-op for `type: redis` |
+| B | Remove the field | Honest API | Breaking schema change contradicts US-2 |
+| C | Add a redis backend to KVStore | Full compat | Reintroduces the unmaintained-chart problem the spec exists to remove |
+
+**Decision**: A — schema keeps `type`, composition ignores it; deprecation noted in `docs/apps-user-guide.md` and the module README
+**Rationale**: US-2/FR-005 require zero claim changes; no in-repo claim uses `type: redis`; the field can be dropped in a future App XRD version bump.
+**Decided by**: Plan author (design review, 2026-07-20)
+
+---
+
+## Related
+
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- ADRs: [docs/decisions/](../../decisions/)

--- a/docs/specs/012-kvstore-composition-replace-bitnami/plan.md
+++ b/docs/specs/012-kvstore-composition-replace-bitnami/plan.md
@@ -1,0 +1,218 @@
+# Plan: KVStore composition: replace Bitnami Valkey with official valkey-helm chart behind a cloud.ogenki.io XRD
+
+**Spec**: [SPEC-012](spec.md)
+**Status**: draft
+**Last updated**: 2026-07-20
+
+> The **plan** covers *HOW* to deliver the spec. It may evolve during implementation (unlike `spec.md`, which freezes after approval). Append-only `clarifications.md` is where decisions are durable.
+
+> **For agentic workers:** execute task-by-task with fresh evidence before every `[x]` (`.claude/rules/process.md`). Tasks are grouped by PR.
+
+---
+
+## Design
+
+### Verified chart facts (research 2026-07-20, source of truth for all tasks)
+
+Chart: `valkey` **0.10.0** (appVersion 9.1.0) from <https://valkey.io/valkey-helm/> (repo [valkey-io/valkey-helm](https://github.com/valkey-io/valkey-helm), `valkey/` directory — NOT `valkey-operator/`/`valkey-resources/`, which are the official operator charts, deliberately not used per CL-3).
+
+- **Naming**: `fullname` = release name when it contains "valkey". We set `fullnameOverride` explicitly anyway. Main Service = `<fullname>` (port 6379, name `tcp`); metrics Service = `<fullname>-metrics` (port 9121); headless Service `<fullname>-headless` (replica mode only).
+- **Labels** (selector): `app.kubernetes.io/name: valkey`, `app.kubernetes.io/instance: <releaseName>` — **identical to today's Bitnami labels**, so the App CNP egress selector shape survives.
+- **Workload**: standalone = Deployment `<fullname>`; `replica.enabled` = StatefulSet. Standalone is ephemeral unless `dataStorage.enabled` (default **false** — CL-4 is the chart default). Replica mode **requires** `replica.persistence.size` (chart `fail`s otherwise).
+- **Auth**: `auth.enabled` + `auth.usersExistingSecret` + `auth.aclUsers` map; a `default` user with `permissions` is **mandatory** when auth is on; `passwordKey` selects the key in the secret. Classic `AUTH <password>` authenticates as `default` — Harbor/OnCall password secrets work unchanged.
+- **Security**: default `securityContext` already restricted-compliant (non-root, drop ALL, RO rootfs, no-priv-esc); `podSecurityContext.seccompProfile: RuntimeDefault` at pod level. **Gap**: `metrics.exporter.securityContext` defaults to `{}` — we must set it. `resources` default `{}` — we must set them.
+- **Probes**: startup + liveness on by default (`valkey-cli ping` exec); `readinessProbe.enabled` defaults **false** — we enable it.
+- **Metrics**: exporter sidecar `ghcr.io/oliver006/redis_exporter:v1.79.0`, metrics Service + optional `metrics.serviceMonitor` (`monitoring.coreos.com` ServiceMonitor — already converted by the VictoriaMetrics operator in this cluster; Harbor's Bitnami valkey uses the same mechanism today).
+- Chart ships an optional native NetworkPolicy (`networkPolicy: {}`) — left off; we render a CiliumNetworkPolicy.
+
+### API / Interface (FR-001)
+
+```yaml
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: KVStore
+metadata:
+  name: xplane-harbor
+  namespace: tooling
+spec:
+  size: nano            # Optional: nano|small|medium|large, default "small"
+  replicas: 0           # Optional: 0 = standalone (default), 1-5 = read replicas (no auto-failover, CL-2)
+  auth:                 # Optional: omitted = auth disabled
+    existingSecret: harbor-valkey-password
+    passwordKey: REDIS_PASSWORD   # Optional, default "password"
+  persistence:          # Optional: omitted = ephemeral (CL-4); required-with-default in replica mode
+    size: 4Gi
+  metrics: true         # Optional, default true
+```
+
+Consumers reach the instance at `<xr-name>-valkey:6379` (namespace-local DNS).
+
+### Resources Created
+
+| Resource | Condition | Notes |
+|----------|-----------|-------|
+| HelmRelease `<xr-name>-valkey` | Always | chart `valkey` 0.10.0, sourceRef HelmRepository `valkey`/flux-system; static-ready per repo convention (FR-002) |
+| CiliumNetworkPolicy `<xr-name>-valkey` | Always | default-deny; see Security below (FR-003) |
+
+(ServiceMonitor, Services, workload are chart-rendered inside the HelmRelease, not composed resources.)
+
+### Size map (FR-008 — replaces Bitnami `resourcesPreset`)
+
+| size | requests | limits | exporter (fixed) |
+|------|----------|--------|------------------|
+| nano | 100m / 128Mi | 150m / 192Mi | req 50m/64Mi, lim 100m/128Mi |
+| small | 250m / 256Mi | 375m / 384Mi | same |
+| medium | 500m / 512Mi | 750m / 768Mi | same |
+| large | 1000m / 1Gi | 1500m / 1536Mi | same |
+
+### Security (FR-003, FR-008)
+
+CNP per instance, endpointSelector `{app.kubernetes.io/name: valkey, app.kubernetes.io/instance: <xr-name>-valkey}`:
+
+- Ingress: TCP 6379 from all endpoints in the same namespace (`fromEndpoints: [{}]`); TCP 9121 from `{io.kubernetes.pod.namespace: observability}` (vmagent scrape — without this rule SC-005 fails).
+- Egress (replica mode only): kube-dns 53 with `rules.dns.matchPattern: "*"` (cilium rule 1) + TCP 6379 to the instance's own selector (replica→primary sync). Standalone renders **no egress** (needs none).
+
+Exporter sidecar securityContext (chart default is `{}`): `runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}` (pod-level seccompProfile covers it).
+
+### Consumer wiring (FR-005, FR-006)
+
+| Consumer | XR/claim name | Service DNS (new) | Today |
+|---|---|---|---|
+| App composition | `_managedName` (`xplane-<app>`) | `xplane-<app>-valkey` | `<claim>-valkey-primary` |
+| Harbor | `xplane-harbor` | `xplane-harbor-valkey` | `harbor-valkey-primary` |
+| OnCall | `xplane-oncall` | `xplane-oncall-valkey` | `oncall-valkey-primary` |
+
+App API unchanged (`kvStore.enabled/size/type`); `type` is accepted but **ignored** (valkey-only backend) — documented, CL-5 if contested during review. `REDIS_URL` becomes `redis://<xr-name>-valkey:6379`. The Bitnami HRs' `useExternalDNS` Route53 records are dropped — both consumers use in-cluster DNS; nothing references the external names (verify in T007/T008).
+
+### Dependencies
+
+- [ ] HelmRepository `valkey` in `flux/sources/` (unsharded — flux-controller-sharding gotcha)
+- [ ] Chart 0.10.0 present in <https://valkey.io/valkey-helm/index.yaml> (verify in T001; pin whatever latest stable ≤0.x actually published)
+- [ ] No Crossplane RBAC/activation changes needed (HelmRelease + CiliumNetworkPolicy already writable by existing compositions)
+
+### Alternatives considered
+
+ElastiCache, in-place chart swap, and operators (hyperspike; official `valkey-operator` 0.4.0 discovered during research) — rejected in CL-1/CL-2/CL-3. The XRD boundary keeps the official operator available as a future backend swap invisible to consumers.
+
+### Failure modes & rollback
+
+- Chart renders `fail` if replica mode lacks `persistence.size` → composition always defaults it (4Gi) when `replicas > 0`.
+- Auth misconfig (missing `default` user) is a chart-level `fail` → composition owns the aclUsers block; user only supplies secret name/key.
+- Ephemeral default: pod restart = cold cache (accepted, CL-2/CL-4). Harbor/OnCall tolerate this today (job queue/broker refill).
+- Rollback path: revert the consumer commit (PR 2) — Bitnami HRs return; no data to restore (caches). Composition PR (PR 1) is additive and inert until consumed.
+
+---
+
+## Implementation Notes
+
+- KCL: no post-creation dict mutation (function-kcl #285) — build `values` with inline conditionals; single-line comprehensions; `kcl fmt` before commit.
+- `fullnameOverride = <xr-name>-valkey` is set explicitly so naming never depends on the release-name-contains-chart-name heuristic.
+- Static readiness (`krm.kcl.dev/ready = "True"`) on both HelmRelease and CNP per `.claude/rules/crossplane-validation.md`; XR readiness via function-auto-ready (mirrors SQLInstance).
+- App module (`kcl/app/main.k`) deletions: `_kvSizeToPreset` (line ~102), `_observedKVStore`/`_helmReleaseReady` (~line 562), the kvStore HelmRelease block (~979–1052). The `_npCache` egress selector switches `_name` → `_managedName`; the SHARED CONTRACT comment near `_cacheAutoEnv` (~line 412) is updated: the `<xr>-valkey` Service name is now owned by the **kvstore module**.
+- OCI pin flow (kcl-crossplane rule 5): PR CI publishes `<version>-pr<N>`; pin that during PR validation, strip to `<version>` in the final pre-merge commit. `crossplane-modules.yml` auto-detects the new `kvstore/` module (any dir with `kcl.mod`).
+- The `bitnami` HelmRepository **stays** — `kubernetes-event-exporter` and OnCall's `rabbitmq` still consume it (FR-007's conditional: only Valkey usages are removed; full removal is a future spec).
+
+### File structure (FR-009)
+
+```
+infrastructure/base/crossplane/configuration/
+├── kcl/kvstore/
+│   ├── kcl.mod                  # name "kvstore", version "0.1.0", edition "v0.11.3"
+│   ├── main.k
+│   ├── main_test.k
+│   ├── settings-example.yaml
+│   └── README.md
+├── kvstore-definition.yaml      # XRD (apiextensions.crossplane.io/v2, Namespaced)
+├── kvstore-composition.yaml     # pipeline: function-kcl (OCI crossplane-kvstore) → function-auto-ready
+├── examples/kvstore-basic.yaml
+├── examples/kvstore-complete.yaml
+└── kustomization.yaml           # + 2 entries
+flux/sources/helmrepo-valkey.yaml
+```
+
+### Validation path
+
+- `kcl fmt` passes; `kcl run -Y settings-example.yaml` renders; `kcl test` (main_test.k) passes
+- `./scripts/validate-kcl-compositions.sh` exit 0 (SC-007)
+- `./scripts/validate-manifests.sh` exit 0, `Invalid: 0, Skipped: 0` (SC-001)
+- Polaris score ≥ 85 on rendered bundle
+- Post-merge: `/verify-spec` against SC-002..SC-006 (Hubble, VictoriaMetrics `up`, XR conditions)
+
+---
+
+## Tasks
+
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+
+### Phase 1 — PR 1: composition (FR-001..004, FR-008, FR-009)
+
+- [ ] **T001**: `flux/sources/helmrepo-valkey.yaml` — HelmRepository `valkey`, `url: https://valkey.io/valkey-helm/`, `interval: 12h`, namespace flux-system, **no shard label** (copy `helmrepo-cloudnative-pg.yaml` shape). First `curl -s https://valkey.io/valkey-helm/index.yaml | yq '.entries.valkey[0].version'` and pin that version everywhere this plan says `0.10.0`. (FR-002)
+- [ ] **T002**: KCL module `kcl/kvstore/` — `kcl.mod` + `main.k` reading `option("params").oxr` and rendering the HelmRelease + CNP per Design (values mapping: size map table, `readinessProbe.enabled: true`, auth block only when `spec.auth?.existingSecret`, `replica.*` when `replicas > 0` with `persistence.size or "4Gi"`, `dataStorage` when standalone AND `persistence?.size`, `metrics` + `serviceMonitor` + exporter securityContext/resources when `metrics != False`). Static-ready annotations on both resources. `kcl fmt` clean. (FR-001, FR-002, FR-003, FR-004, FR-008)
+- [ ] **T003**: `main_test.k` — TDD alongside T002: resource count (2 standalone / 2 replica), HelmRelease name/releaseName/`fullnameOverride` = `<name>-valkey`, chart version pin, no `bitnamilegacy` string anywhere in rendered values, auth block presence/absence, replica-mode `persistence.size` default, exporter securityContext fields, CNP selector labels + 9121 observability ingress + standalone-has-no-egress. Run `kcl test` → pass. (FR-009, SC-007)
+- [ ] **T004**: `kvstore-definition.yaml` (XRD: spec fields per Design API, CEL not required; defaults in schema) + `kvstore-composition.yaml` (copy `sql-instance-composition.yaml` pipeline shape; `source: oci://ghcr.io/smana/cloud-native-ref/crossplane-kvstore:0.1.0`) + register both in `configuration/kustomization.yaml` + `examples/kvstore-basic.yaml` (name only) and `examples/kvstore-complete.yaml` (all fields) + module `README.md` + `settings-example.yaml`. (FR-001, FR-009)
+- [ ] **T005**: Gates: `./scripts/validate-kcl-compositions.sh` exit 0; `./scripts/validate-manifests.sh` exit 0 with `Invalid: 0, Skipped: 0` (proves the new XRD schema-validates its examples). Open PR 1; after CI publishes `0.1.0-pr<N>`, pin it in `kvstore-composition.yaml`, verify anonymous pull (`crossplane xpkg pull` or `kcl mod pull`), run e2e on feature-branch cluster if available; strip to `0.1.0` in final pre-merge commit. (SC-001, SC-007)
+
+### Phase 2 — PR 2: consumers (FR-005, FR-006, FR-007)
+
+- [ ] **T006**: App module: replace kvStore HelmRelease block with a `KVStore` XR named `_managedName` (mirror the `sqlInstance` block; pass `size`; no auth); update `_cacheAutoEnv` to `redis://` + `_managedName` + `-valkey:6379`; `_npCache` matchLabels instance → `_managedName + "-valkey"`; delete `_kvSizeToPreset`, `_observedKVStore`, `_helmReleaseReady`; update SHARED CONTRACT comment; `kcl.mod` 0.4.0 → 0.5.0; update `app-composition.yaml` pin (same -pr<N> flow as T005); update `kcl/app/main_test.k` + `apps/base/complete/app.yaml` (`CACHE_ADDRESS`) + `configuration/examples/app-complete.yaml` if it names the old Service. (FR-005)
+- [ ] **T007**: Harbor: new `tooling/base/harbor/kvstore.yaml` claim (`xplane-harbor`, `size: nano`, auth `harbor-valkey-password`/`REDIS_PASSWORD`); delete `helmrelease-valkey.yaml`; kustomization entry swap; `helmrelease-harbor.yaml` → `redis.external.addr: "xplane-harbor-valkey:6379"`, **remove `username: "user"`** (classic AUTH = `default` ACL user). Confirm nothing references the old external-DNS name: `grep -rn "harbor-valkey-primary" .` → only the files being edited. (FR-006) <!-- pragma: allowlist secret -->
+- [ ] **T008**: OnCall: same as T007 with `observability/base/grafana-oncall/kvstore.yaml` (`xplane-oncall`, auth `oncall-valkey`/`password`), delete `helmrelease-valkey.yaml`, `externalRedis.host: xplane-oncall-valkey` (username `default` already correct). (FR-006)
+- [ ] **T009**: Sweep + docs: `grep -rn "bitnamilegacy\|valkey.*bitnami\|bitnami.*valkey" --include='*.yaml' --include='*.k' .` → zero Valkey hits (rabbitmq/event-exporter bitnami refs remain, FR-007 conditional); update `docs/apps-user-guide.md` kvStore section + `apps/platform/app-wizard/ui-hints.yaml` if they mention `-primary` or Bitnami; `./scripts/validate-manifests.sh` exit 0 `Invalid: 0, Skipped: 0` with zero `bitnamilegacy` in `.bundle/`. (FR-007, SC-001)
+
+### Phase 3 — post-merge
+
+- [ ] **T010**: `/verify-spec docs/specs/012-kvstore-composition-replace-bitnami` on the live cluster: SC-002 (XR Ready ≤5min, official image), SC-003 (app REDIS_URL + no Hubble drops app→valkey), SC-004 (Harbor jobservice + OnCall logs clean), SC-005 (exporter `up==1` ×3), SC-006 (cross-namespace 6379 attempt DROPPED in Hubble). Write `VERIFICATION.md`.
+
+### Deviations from plan
+
+<!-- Append as implementation surprises show up. Format:
+- <2026-07-20> T00N was [dropped|replaced|split]: <why>
+Keep short — detailed rationale goes in clarifications.md if it is a decision. -->
+
+---
+
+## Review Checklist
+
+Complete this before implementation begins. Each persona enforces non-negotiable rules — do not skip.
+
+### Project Manager
+
+- [x] Problem statement in spec.md is clear and specific (frozen bitnamilegacy supply chain, 3× duplication)
+- [x] User stories capture real user needs (platform engineer, app developer, platform components)
+- [x] Acceptance scenarios are testable (each has Given/When/Then with observable outcomes)
+- [x] Scope is well-defined (goals AND non-goals — failover/ElastiCache/operator explicitly out, CL-1..3)
+- [x] Success criteria are measurable (SC-001..007 all falsifiable with commands)
+
+### Platform Engineer
+
+- [x] Design follows existing patterns (`SQLInstance` nesting, `cloudnativepg` module layout, sql-instance pipeline shape)
+- [x] API is consistent with other compositions (size enums, optional blocks, namespaced XR)
+- [x] Resource naming follows `xplane-*` convention (claims `xplane-*`; App uses `_managedName`)
+- [x] KCL avoids mutation pattern (function-kcl #285 — inline conditionals mandated in Implementation Notes)
+- [x] Examples provided (basic + complete, T004)
+
+### Security & Compliance
+
+- [x] Zero-trust networking (CNP per instance: 6379 ns-local, 9121 observability, egress only in replica mode)
+- [x] Least-privilege RBAC (chart SA with `automount: false`, no RBAC objects; no new Crossplane grants needed)
+- [x] Secrets via External Secrets (existing ESO secrets reused via `auth.usersExistingSecret`; no inline passwords)
+- [x] Security context enforced (chart defaults restricted; exporter gap closed in T002)
+- [x] IAM policies scoped to `xplane-*` resources (n/a — no AWS resources in this composition)
+
+### SRE
+
+- [x] Health checks defined (startup + liveness chart defaults; readinessProbe enabled by composition)
+- [x] Observability configured (exporter + ServiceMonitor→VM operator; logs to stdout→VictoriaLogs)
+- [x] Resource requests + limits appropriate (size map, exporter included)
+- [x] Failure modes documented (Design → Failure modes & rollback)
+- [x] Recovery / rollback path clear (revert PR 2; PR 1 additive-inert; caches refill)
+
+---
+
+## References
+
+- Spec: [spec.md](spec.md)
+- Clarifications log: [clarifications.md](clarifications.md)
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- Phased specs: [docs/specs/PHASED.md](../PHASED.md)
+- Similar composition: `infrastructure/base/crossplane/configuration/kcl/cloudnativepg/` + `sql-instance-composition.yaml`
+- Chart source: <https://github.com/valkey-io/valkey-helm> (`valkey/` chart 0.10.0, appVersion 9.1.0)

--- a/docs/specs/012-kvstore-composition-replace-bitnami/spec.md
+++ b/docs/specs/012-kvstore-composition-replace-bitnami/spec.md
@@ -1,0 +1,178 @@
+# Spec: KVStore composition: replace Bitnami Valkey with official valkey-helm chart behind a cloud.ogenki.io XRD
+
+**ID**: SPEC-012
+**Issue**: [#1662](https://github.com/Smana/cloud-native-ref/issues/1662)
+**Status**: draft
+**Type**: composition
+**Created**: 2026-07-20
+**Last updated**: 2026-07-20
+
+> The **spec** is the contract: *WHAT* we are delivering and *why*. Freeze it once approved. How we build it lives in [`plan.md`](plan.md) (which also tracks tasks and the review checklist); decisions made during filling live append-only in [`clarifications.md`](clarifications.md).
+
+---
+
+## Summary
+
+Introduce a namespaced `KVStore` XRD (`cloud.ogenki.io/v1alpha1`) backed by the official
+[valkey-io/valkey-helm](https://github.com/valkey-io/valkey-helm) chart, and migrate all three
+Valkey consumers (App composition `kvStore`, Harbor, Grafana OnCall) onto it — removing every
+`bitnamilegacy` image and the Bitnami Helm repository from the platform.
+
+---
+
+## Problem
+
+All in-cluster Valkey today rides the Bitnami valkey chart 3.0.31 with `bitnamilegacy/valkey`
+and `bitnamilegacy/redis-exporter` images — a registry **frozen since Broadcom shut the free
+Bitnami catalog (Aug 2025)**: no updates, no CVE patches. Three consumers duplicate the same
+delivery path independently:
+
+1. `tooling/base/harbor/helmrelease-valkey.yaml` (auth via ExternalSecret)
+2. `observability/base/grafana-oncall/helmrelease-valkey.yaml` (auth via ExternalSecret)
+3. `infrastructure/base/crossplane/configuration/kcl/app/main.k` — a ~70-line inline
+   HelmRelease blob per app with `kvStore.enabled`
+
+Chart upgrades, image pins, and security posture must be maintained in three places; the
+standalone instances (Harbor, OnCall) have **no CiliumNetworkPolicy** despite the constitution's
+default-deny mandate; and the App composition latches kvStore readiness statically instead of
+reading real conditions.
+
+Decision context: in-cluster per [CL-1](clarifications.md), cache semantics per
+[CL-2](clarifications.md), XRD + official chart per [CL-3](clarifications.md).
+
+---
+
+## User Stories
+
+### US-1: Single maintained KV-store abstraction (Priority: P1)
+
+As a **platform engineer**, I want **one `KVStore` composition wrapping a maintained chart and
+official images**, so that **chart/image upgrades and security posture are managed in exactly
+one place and the `bitnamilegacy` supply chain is gone**.
+
+**Acceptance Scenarios**:
+1. **Given** the composition is installed, **When** a `KVStore` claim is applied, **Then** a
+   Valkey instance running official `valkey/valkey` images reaches Ready without any
+   Bitnami chart or `bitnamilegacy` image involved.
+2. **Given** the migration is complete, **When** the rendered bundle
+   (`./scripts/validate-manifests.sh`) is searched for `bitnamilegacy` or the `bitnami`
+   HelmRepository, **Then** there are zero references.
+
+### US-2: App composition keeps its API (Priority: P1)
+
+As an **application developer**, I want **`kvStore.enabled: true` in my App claim to keep
+working unchanged**, so that **the migration is invisible at the App API surface**.
+
+**Acceptance Scenarios**:
+1. **Given** an App with `kvStore.enabled: true`, **When** the composition renders, **Then** a
+   `KVStore` XR is created (mirroring the `sqlInstance` nesting pattern) and the workload still
+   receives a working `REDIS_URL` environment variable pointing at the new service.
+2. **Given** the same App claim used before the migration, **When** it is applied after the
+   migration, **Then** no change to the claim manifest is required.
+
+### US-3: Platform components as claims (Priority: P2)
+
+As a **platform engineer**, I want **Harbor and Grafana OnCall to consume Valkey via small
+`KVStore` claims with `auth.existingSecret`**, so that **their copy-pasted HelmReleases
+disappear and both gain a default-deny network policy they lack today**.
+
+**Acceptance Scenarios**:
+1. **Given** the Harbor `KVStore` claim references its existing ExternalSecret, **When** Harbor
+   reconciles, **Then** Harbor authenticates to the new Valkey and its UI/jobservice function.
+2. **Given** the OnCall `KVStore` claim, **When** OnCall reconciles, **Then** OnCall workers
+   connect with no Redis errors in logs.
+
+---
+
+## Requirements
+
+### Functional
+
+- **FR-001**: The platform MUST provide a namespaced XRD `KVStore` (`cloud.ogenki.io/v1alpha1`)
+  with spec fields: `size` (nano|small|medium|large → explicit requests/limits), `replicas`
+  (default 0 = standalone; N = read replicas, no auto-failover per CL-2), optional
+  `auth.existingSecret`/`auth.passwordKey` (omitted = auth disabled), optional
+  `persistence.size` (omitted = ephemeral per CL-4), `metrics` (default true).
+- **FR-002**: The composition MUST render a HelmRelease of the official `valkey-io/valkey-helm`
+  chart pinned to official `valkey/valkey` images, with the chart's HelmRepository defined
+  under `flux/sources` (unsharded, per the flux-controller-sharding constraint).
+- **FR-003**: Every `KVStore` instance MUST get a default-deny CiliumNetworkPolicy: ingress on
+  the Valkey and exporter ports from same-namespace pods only; egress limited to DNS (+
+  intra-instance replication traffic when `replicas > 0`).
+- **FR-004**: When `metrics` is enabled the instance MUST be scraped by VictoriaMetrics
+  (VMServiceScrape or chart-provided ServiceMonitor — whichever the plan verifies works).
+- **FR-005**: The App composition MUST replace its inline kvStore HelmRelease with a nested
+  `KVStore` XR, preserving the existing App API (`kvStore.enabled`, `type`, `size`) and the
+  `REDIS_URL` auto-env behavior (value updated to the new service DNS name).
+- **FR-006**: Harbor and Grafana OnCall MUST consume Valkey via `KVStore` claims wired to their
+  existing ExternalSecrets; their Bitnami HelmReleases are removed.
+- **FR-007**: After migration the `bitnami` HelmRepository and all `bitnamilegacy` image
+  references MUST be removed, provided a repo-wide search confirms no other consumer remains.
+- **FR-008**: Rendered workloads MUST satisfy the constitution's restricted-PSS security
+  context (non-root, read-only rootfs, no privilege escalation, drop ALL, RuntimeDefault
+  seccomp) and carry explicit resource requests and limits.
+- **FR-009**: The composition MUST ship the constitution's documentation set: `README.md`,
+  `settings-example.yaml`, `examples/` (basic + complete), `main_test.k` (resource counts,
+  naming, security context).
+
+### Non-Goals
+
+- Automatic failover / Sentinel / cluster mode (CL-2; the XRD boundary allows adding a backend
+  later without touching consumers).
+- An ElastiCache-backed tier (CL-1).
+- Data migration from the existing Bitnami instances — caches refill on redeploy; old PVCs are
+  deleted after cutover.
+- Adopting a Valkey operator (CL-3; revisit if failover requirements appear).
+- Changing Valkey major version or eviction/tuning defaults beyond what the chart ships.
+
+---
+
+## Success Criteria
+
+Each criterion must be **falsifiable** — a human or `/verify-spec` must be able to answer yes/no with cluster evidence.
+
+- **SC-001**: `./scripts/validate-manifests.sh` exits 0 with `Invalid: 0, Skipped: 0`, and the
+  rendered bundle contains zero occurrences of `bitnamilegacy` or the Bitnami valkey chart.
+- **SC-002**: A `KVStore` claim (basic example) reaches `Synced=True, Ready=True` and its
+  Valkey pod is Running/Ready on official `valkey/valkey` images within 5 minutes of apply.
+- **SC-003**: An App with `kvStore.enabled: true` has `REDIS_URL` injected and its workload
+  establishes a TCP connection to the Valkey service (no `DROPPED` verdicts between app and
+  KVStore pods in Hubble).
+- **SC-004**: Harbor and OnCall pods are Ready after cutover with no Redis/Valkey connection
+  errors in their logs; Harbor jobservice processes a job.
+- **SC-005**: `up == 1` for each instance's exporter target in VictoriaMetrics, for all three
+  migrated consumers.
+- **SC-006**: A connection attempt to a `KVStore` service from a pod in another namespace is
+  dropped (Hubble `Policy denied` evidence), demonstrating the default-deny CNP.
+- **SC-007**: `main_test.k` assertions pass via `./scripts/validate-kcl-compositions.sh`
+  (exit 0), covering resource counts, `xplane-*`-consistent naming, and security context.
+
+---
+
+## Open questions
+
+<!-- Mark unresolved decisions here. Use /clarify to walk through each one.
+Resolved decisions are appended to clarifications.md (never inlined here);
+reference them by ID (CL-1, CL-2, ...) once resolved. -->
+
+- CL-1 — In-cluster (CNPG precedent) over ElastiCache/hybrid
+- CL-2 — Cache semantics: standalone default, no auto-failover
+- CL-3 — `KVStore` XRD wrapping the official valkey-helm chart
+- CL-4 — Ephemeral storage by default; PVC opt-in
+
+Plan-time verifications (HOW-level, tracked in `plan.md`): official chart's Service DNS
+names/labels (feeds `REDIS_URL` + CNP selectors), ServiceMonitor vs VMServiceScrape choice,
+security-context value paths in the official chart, remaining consumers of the `bitnami`
+HelmRepository.
+
+---
+
+## References
+
+- Plan: [plan.md](plan.md) — design, tasks, review checklist
+- Clarifications: [clarifications.md](clarifications.md)
+- Constitution: [docs/specs/constitution.md](../constitution.md)
+- Official chart announcement: <https://valkey.io/blog/valkey-helm-chart/>
+- Official chart repo: <https://github.com/valkey-io/valkey-helm>
+- Nesting precedent: `kcl/app/main.k` `sqlInstance` block → `SQLInstance` XR
+- Related composition: `infrastructure/base/crossplane/configuration/kcl/cloudnativepg/`

--- a/flux/sources/helmrepo-valkey.yaml
+++ b/flux/sources/helmrepo-valkey.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: valkey
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://valkey.io/valkey-helm/

--- a/infrastructure/base/crossplane/configuration/examples/kvstore-basic.yaml
+++ b/infrastructure/base/crossplane/configuration/examples/kvstore-basic.yaml
@@ -1,0 +1,15 @@
+---
+# Basic KVStore Example
+#
+# Minimal Valkey cache: standalone, ephemeral, no auth, metrics on.
+# Reachable at <name>-valkey:6379 inside the namespace.
+#
+# For a complete example with all features, see kvstore-complete.yaml
+
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: KVStore
+metadata:
+  name: xplane-mycache
+  namespace: demo
+spec:
+  size: small # Options: nano, small, medium, large

--- a/infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml
+++ b/infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml
@@ -23,7 +23,7 @@ spec:
 
   # Password for the "default" ACL user, from an existing Secret
   auth:
-    existingSecret: mycache-valkey-password
+    existingSecret: mycache-valkey-password # checkov:skip=CKV_SECRET_6: secret name, not a value
     passwordKey: password # default
 
   # Replica mode always persists (defaults to 4Gi when omitted);

--- a/infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml
+++ b/infrastructure/base/crossplane/configuration/examples/kvstore-complete.yaml
@@ -1,0 +1,34 @@
+---
+# Complete KVStore Example
+#
+# Valkey with read replicas, persistence, ACL auth from an existing
+# Secret (ExternalSecret target), and metrics.
+#
+# Services rendered by the chart:
+#   xplane-mycache-valkey:6379          writes (primary)
+#   xplane-mycache-valkey-read:6379     reads (all pods, replica mode only)
+#   xplane-mycache-valkey-metrics:9121  Prometheus exporter
+#
+# No automatic failover — cache semantics (SPEC-012 CL-2). If the primary
+# pod is rescheduled the cache refills; durable data does not belong here.
+
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: KVStore
+metadata:
+  name: xplane-mycache
+  namespace: demo
+spec:
+  size: medium # Options: nano, small, medium, large
+  replicas: 2 # 0 = standalone (default)
+
+  # Password for the "default" ACL user, from an existing Secret
+  auth:
+    existingSecret: mycache-valkey-password
+    passwordKey: password # default
+
+  # Replica mode always persists (defaults to 4Gi when omitted);
+  # in standalone mode this opts out of the ephemeral default.
+  persistence:
+    size: 8Gi
+
+  metrics: true # default

--- a/infrastructure/base/crossplane/configuration/kcl/kvstore/README.md
+++ b/infrastructure/base/crossplane/configuration/kcl/kvstore/README.md
@@ -1,0 +1,62 @@
+# KVStore Composition
+
+Namespaced Valkey cache instances backed by the official
+[valkey-helm](https://github.com/valkey-io/valkey-helm) chart (SPEC-012).
+Replaces the frozen Bitnami/`bitnamilegacy` delivery path.
+
+Each `KVStore` XR renders exactly two resources:
+
+| Resource | Purpose |
+|----------|---------|
+| `HelmRelease <name>-valkey` | Official `valkey` chart 0.10.0 (image `docker.io/valkey/valkey`, appVersion 9.1.0) |
+| `CiliumNetworkPolicy <name>-valkey` | Default-deny: 6379 from same-namespace pods, 9121 from `observability` (vmagent); egress only in replica mode |
+
+Consumers connect to **`<name>-valkey:6379`** (namespace-local). With
+`replicas > 0` a `<name>-valkey-read` Service load-balances reads and
+`<name>-valkey-metrics:9121` exposes the Prometheus exporter.
+
+## API
+
+```yaml
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: KVStore
+metadata:
+  name: xplane-mycache
+  namespace: apps
+spec:
+  size: small            # nano|small|medium|large (default small)
+  replicas: 0            # 0 = standalone (default); N = read replicas, NO auto-failover (CL-2)
+  auth:                  # optional; omitted = auth disabled
+    existingSecret: mycache-valkey-password
+    passwordKey: password  # default
+  persistence:           # optional; omitted = ephemeral in standalone (CL-4)
+    size: 4Gi            # replica mode always persists (defaults 4Gi)
+  metrics: true          # default
+```
+
+- **Auth** creates the mandatory `default` ACL user (`~* &* +@all`) with its
+  password read from `existingSecret` — classic `AUTH <password>` works, so
+  Redis-client consumers need no username configuration.
+- **Cache semantics**: no Sentinel/failover — a rescheduled primary means a
+  cold cache. Durable data belongs in `SQLInstance`, not here.
+- **Sizes**: nano 100m/128Mi → large 1000m/1Gi requests (limits ×1.5).
+
+## Examples
+
+- [`examples/kvstore-basic.yaml`](../../examples/kvstore-basic.yaml) — standalone ephemeral cache
+- [`examples/kvstore-complete.yaml`](../../examples/kvstore-complete.yaml) — replicas + auth + persistence
+
+## Validation
+
+```bash
+kcl fmt . && kcl test . -Y settings-example.yaml   # 15 tests
+../../../../../../scripts/validate-kcl-compositions.sh  # full 4-stage gate
+```
+
+## Design decisions
+
+See [SPEC-012](../../../../../../docs/specs/012-kvstore-composition-replace-bitnami/spec.md)
+and its clarifications log: CL-1 in-cluster (CNPG precedent), CL-2 cache
+semantics, CL-3 official chart behind this XRD (operator swap stays possible
+without touching consumers), CL-4 ephemeral default, CL-5 App `kvStore.type`
+ignored (Valkey-only).

--- a/infrastructure/base/crossplane/configuration/kcl/kvstore/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/kvstore/kcl.mod
@@ -1,0 +1,5 @@
+[package]
+name = "kvstore"
+edition = "v0.11.3"
+version = "0.1.0"
+description = "KVStore composition (SPEC-012): Valkey cache via the official valkey-helm chart - HelmRelease + CiliumNetworkPolicy"

--- a/infrastructure/base/crossplane/configuration/kcl/kvstore/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/kvstore/main.k
@@ -1,0 +1,163 @@
+# KVStore composition (SPEC-012): Valkey via the official valkey-helm chart.
+# Renders exactly 2 resources per XR:
+#   1. HelmRelease <xr>-valkey  - chart valkey 0.10.0, HelmRepository valkey/flux-system
+#   2. CiliumNetworkPolicy <xr>-valkey - default-deny; 6379 ns-local, 9121 from
+#      observability (vmagent scrape); egress only in replica mode (DNS + sync)
+# Both are static-ready (krm.kcl.dev/ready=True) per repo convention; XR
+# readiness comes from function-auto-ready in the composition pipeline.
+# SHARED CONTRACT: consumers reach the instance at `<xr-name>-valkey:6379`
+# (fullnameOverride pins the Service name; the App module wires REDIS_URL to it).
+oxr = option("params").oxr
+
+# Size map (FR-008) - replaces the Bitnami `resourcesPreset`
+_sizeResources = {
+    nano = {requests = {cpu = "100m", memory = "128Mi"}, limits = {cpu = "150m", memory = "192Mi"}}
+    small = {requests = {cpu = "250m", memory = "256Mi"}, limits = {cpu = "375m", memory = "384Mi"}}
+    medium = {requests = {cpu = "500m", memory = "512Mi"}, limits = {cpu = "750m", memory = "768Mi"}}
+    large = {requests = {cpu = "1000m", memory = "1Gi"}, limits = {cpu = "1500m", memory = "1536Mi"}}
+}
+
+# All output is built in single dict literals with inline conditionals -
+# never mutated after creation (function-kcl issue #285).
+_render = lambda _oxr: any -> [any] {
+    _xrName = _oxr.metadata.name
+    _namespace = _oxr.metadata.namespace
+    _releaseName = _xrName + "-valkey"
+    _size = _oxr.spec?.size or "small"
+    _replicas = _oxr.spec?.replicas or 0
+    _auth = _oxr.spec?.auth
+    _persistenceSize = _oxr.spec?.persistence?.size
+    _metrics = _oxr.spec?.metrics
+
+    [
+        {
+            apiVersion = "helm.toolkit.fluxcd.io/v2"
+            kind = "HelmRelease"
+            metadata = {
+                name = _releaseName
+                namespace = _namespace
+                annotations = {
+                    "krm.kcl.dev/composition-resource-name" = _xrName + "-kvstore"
+                    "krm.kcl.dev/ready" = "True"
+                }
+            }
+            spec = {
+                releaseName = _releaseName
+                driftDetection = {
+                    mode = "enabled"
+                }
+                chart = {
+                    spec = {
+                        chart = "valkey"
+                        sourceRef = {
+                            kind = "HelmRepository"
+                            name = "valkey"
+                            namespace = "flux-system"
+                        }
+                        version = "0.10.0"
+                    }
+                }
+                interval = "10m0s"
+                install = {
+                    remediation = {
+                        retries = 3
+                    }
+                }
+                values = {
+                    fullnameOverride = _releaseName
+                    resources = _sizeResources[_size]
+                    # Chart default is off; startup+liveness are on by default
+                    readinessProbe = {enabled = True}
+                    if _auth?.existingSecret:
+                        # A `default` ACL user is mandatory when auth is on; classic
+                        # AUTH <password> authenticates as `default`, so existing
+                        # consumer password secrets work unchanged.
+                        auth = {
+                            enabled = True
+                            usersExistingSecret = _auth.existingSecret
+                            aclUsers = {
+                                "default" = {permissions = "~* &* +@all", passwordKey = _auth?.passwordKey or "password"}
+                            }
+                        }
+                    if _replicas > 0:
+                        # Chart `fail`s in replica mode without persistence.size
+                        replica = {
+                            enabled = True
+                            replicas = _replicas
+                            persistence = {size = _persistenceSize or "4Gi"}
+                        }
+                    if _replicas == 0 and _persistenceSize:
+                        dataStorage = {
+                            enabled = True
+                            requestedSize = _persistenceSize
+                        }
+                    if _metrics != False:
+                        # Chart defaults leave exporter securityContext/resources
+                        # empty - both must be set for PSS=restricted + constitution
+                        metrics = {
+                            enabled = True
+                            serviceMonitor = {enabled = True}
+                            exporter = {
+                                resources = {requests = {cpu = "50m", memory = "64Mi"}, limits = {cpu = "100m", memory = "128Mi"}}
+                                securityContext = {
+                                    runAsNonRoot = True
+                                    runAsUser = 1000
+                                    runAsGroup = 1000
+                                    allowPrivilegeEscalation = False
+                                    readOnlyRootFilesystem = True
+                                    capabilities = {drop = ["ALL"]}
+                                }
+                            }
+                        }
+                }
+            }
+        }
+        {
+            apiVersion = "cilium.io/v2"
+            kind = "CiliumNetworkPolicy"
+            metadata = {
+                name = _releaseName
+                namespace = _namespace
+                annotations = {
+                    "krm.kcl.dev/composition-resource-name" = _xrName + "-netpol"
+                    "krm.kcl.dev/ready" = "True"
+                }
+            }
+            spec = {
+                endpointSelector = {
+                    matchLabels = {"app.kubernetes.io/name" = "valkey", "app.kubernetes.io/instance" = _releaseName}
+                }
+                ingress = [
+                    {fromEndpoints = [{}], toPorts = [{ports = [{port = "6379", protocol = "TCP"}]}]}
+                    {
+                        fromEndpoints = [{
+                            matchLabels = {"io.kubernetes.pod.namespace" = "observability"}
+                        }]
+                        toPorts = [{ports = [{port = "9121", protocol = "TCP"}]}]
+                    }
+                ]
+                if _replicas > 0:
+                    # Replica mode only: resolve the headless Service + sync from
+                    # the primary. Standalone needs no egress at all.
+                    # L7 dns matchPattern "*" is mandatory so Cilium sees resolved
+                    # IPs - .claude/rules/cilium-network-policies.md.
+                    egress = [
+                        {
+                            toEndpoints = [{
+                                matchLabels = {"io.kubernetes.pod.namespace" = "kube-system", "k8s-app" = "kube-dns"}
+                            }]
+                            toPorts = [{ports = [{port = "53", protocol = "UDP"}, {port = "53", protocol = "TCP"}], rules = {dns = [{matchPattern = "*"}]}}]
+                        }
+                        {
+                            toEndpoints = [{
+                                matchLabels = {"app.kubernetes.io/name" = "valkey", "app.kubernetes.io/instance" = _releaseName}
+                            }]
+                            toPorts = [{ports = [{port = "6379", protocol = "TCP"}]}]
+                        }
+                    ]
+            }
+        }
+    ]
+}
+
+items = _render(oxr)

--- a/infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/kvstore/main_test.k
@@ -1,0 +1,186 @@
+# Tests for KVStore composition (SPEC-012)
+# Run: kcl test . -Y settings-example.yaml
+#
+# Variant coverage calls the module's _render lambda directly with synthetic
+# XRs, so one `kcl test` run exercises standalone/auth/replica/persistence/
+# metrics-off/size-map paths regardless of what settings-example.yaml contains.
+_mkOxr = lambda _spec: any -> any {
+    {metadata = {name = "xplane-test", namespace = "apps"}, spec = _spec}
+}
+
+_hrValues = lambda _res: [any] -> any {
+    [r for r in _res if r.kind == "HelmRelease"][0].spec.values
+}
+
+# ---- Test: standalone default renders exactly HelmRelease + CNP ----
+test_standalone_default_resources = lambda {
+    _res = _render(_mkOxr({}))
+    assert len(_res) == 2, "expected exactly 2 resources, got {}".format(len(_res))
+    _hrs = [r for r in _res if r.kind == "HelmRelease"]
+    _cnps = [r for r in _res if r.kind == "CiliumNetworkPolicy"]
+    assert len(_hrs) == 1, "expected 1 HelmRelease"
+    assert len(_cnps) == 1, "expected 1 CiliumNetworkPolicy"
+}
+
+# ---- Test: HelmRelease naming, chart pin, skeleton ----
+test_helmrelease_shape = lambda {
+    _hr = [r for r in _render(_mkOxr({})) if r.kind == "HelmRelease"][0]
+    assert _hr.metadata.name == "xplane-test-valkey", "HR name must be <xr>-valkey"
+    assert _hr.metadata.namespace == "apps"
+    assert _hr.metadata.annotations["krm.kcl.dev/composition-resource-name"] == "xplane-test-kvstore"
+    assert _hr.metadata.annotations["krm.kcl.dev/ready"] == "True", "HelmRelease is static-ready"
+    assert _hr.spec.releaseName == "xplane-test-valkey"
+    assert _hr.spec.chart.spec.chart == "valkey"
+    assert _hr.spec.chart.spec.version == "0.10.0", "chart version pin"
+    assert _hr.spec.chart.spec.sourceRef.kind == "HelmRepository"
+    assert _hr.spec.chart.spec.sourceRef.name == "valkey"
+    assert _hr.spec.chart.spec.sourceRef.namespace == "flux-system"
+    assert _hr.spec.driftDetection.mode == "enabled"
+    assert _hr.spec.interval == "10m0s"
+    assert _hr.spec.install.remediation.retries == 3
+}
+
+# ---- Test: standalone default values (small size, ephemeral, no auth) ----
+test_standalone_default_values = lambda {
+    _v = _hrValues(_render(_mkOxr({})))
+    assert _v.fullnameOverride == "xplane-test-valkey"
+    assert _v.readinessProbe.enabled == True, "readinessProbe must be enabled (chart default is off)"
+    assert _v.resources.requests.cpu == "250m", "default size is small"
+    assert _v.resources.requests.memory == "256Mi"
+    assert _v.resources.limits.cpu == "375m"
+    assert _v.resources.limits.memory == "384Mi"
+    assert "auth" not in _v, "no auth block unless auth.existingSecret set"
+    assert "replica" not in _v, "no replica block in standalone"
+    assert "dataStorage" not in _v, "ephemeral by default (CL-4)"
+}
+
+# ---- Test: metrics enabled by default with hardened exporter ----
+test_metrics_default = lambda {
+    _v = _hrValues(_render(_mkOxr({})))
+    assert _v.metrics.enabled == True
+    assert _v.metrics.serviceMonitor.enabled == True
+    _sc = _v.metrics.exporter.securityContext
+    assert _sc.runAsNonRoot == True
+    assert _sc.runAsUser == 1000
+    assert _sc.runAsGroup == 1000
+    assert _sc.allowPrivilegeEscalation == False
+    assert _sc.readOnlyRootFilesystem == True
+    assert "ALL" in _sc.capabilities.drop
+    _er = _v.metrics.exporter.resources
+    assert _er.requests.cpu == "50m" and _er.requests.memory == "64Mi"
+    assert _er.limits.cpu == "100m" and _er.limits.memory == "128Mi"
+}
+
+# ---- Test: metrics == false omits the metrics key entirely ----
+# Chart default is metrics.enabled=false, so omission == disabled.
+test_metrics_disabled = lambda {
+    _v = _hrValues(_render(_mkOxr({metrics = False})))
+    assert "metrics" not in _v, "metrics key must be absent when spec.metrics is false"
+}
+
+# ---- Test: auth variant (existingSecret + custom passwordKey) ----
+test_auth_variant = lambda {
+    _v = _hrValues(_render(_mkOxr({
+        auth = {existingSecret = "harbor-valkey-password", passwordKey = "REDIS_PASSWORD"}
+    })))
+    assert _v.auth.enabled == True
+    assert _v.auth.usersExistingSecret == "harbor-valkey-password"
+    assert _v.auth.aclUsers["default"].permissions == "~* &* +@all", "default ACL user is mandatory when auth is on"
+    assert _v.auth.aclUsers["default"].passwordKey == "REDIS_PASSWORD"
+}
+
+# ---- Test: auth passwordKey defaults to "password" ----
+test_auth_default_password_key = lambda {
+    _v = _hrValues(_render(_mkOxr({
+        auth = {existingSecret = "mysecret"}
+    })))
+    assert _v.auth.aclUsers["default"].passwordKey == "password"
+}
+
+# ---- Test: replica variant (replica block + persistence default 4Gi) ----
+test_replica_variant = lambda {
+    _v = _hrValues(_render(_mkOxr({replicas = 2})))
+    assert _v.replica.enabled == True
+    assert _v.replica.replicas == 2
+    assert _v.replica.persistence.size == "4Gi", "replica mode must always default persistence.size (chart fails without it)"
+    assert "dataStorage" not in _v, "dataStorage is standalone-only"
+}
+
+# ---- Test: replica variant honors explicit persistence.size ----
+test_replica_explicit_persistence = lambda {
+    _v = _hrValues(_render(_mkOxr({replicas = 1, persistence = {size = "10Gi"}})))
+    assert _v.replica.persistence.size == "10Gi"
+}
+
+# ---- Test: standalone persistence maps to dataStorage ----
+test_persistence_standalone = lambda {
+    _v = _hrValues(_render(_mkOxr({
+        persistence = {size = "8Gi"}
+    })))
+    assert _v.dataStorage.enabled == True
+    assert _v.dataStorage.requestedSize == "8Gi"
+    assert "replica" not in _v
+}
+
+# ---- Test: size map spot-checks (nano + large) ----
+test_size_map = lambda {
+    _nano = _hrValues(_render(_mkOxr({size = "nano"}))).resources
+    assert _nano.requests.cpu == "100m" and _nano.requests.memory == "128Mi"
+    assert _nano.limits.cpu == "150m" and _nano.limits.memory == "192Mi"
+    _large = _hrValues(_render(_mkOxr({size = "large"}))).resources
+    assert _large.requests.cpu == "1000m" and _large.requests.memory == "1Gi"
+    assert _large.limits.cpu == "1500m" and _large.limits.memory == "1536Mi"
+}
+
+# ---- Test: CNP selector, ingress rules, standalone has NO egress ----
+test_cnp_standalone = lambda {
+    _cnp = [r for r in _render(_mkOxr({})) if r.kind == "CiliumNetworkPolicy"][0]
+    assert _cnp.apiVersion == "cilium.io/v2"
+    assert _cnp.metadata.name == "xplane-test-valkey"
+    assert _cnp.metadata.namespace == "apps"
+    assert _cnp.metadata.annotations["krm.kcl.dev/composition-resource-name"] == "xplane-test-netpol"
+    assert _cnp.metadata.annotations["krm.kcl.dev/ready"] == "True", "CNP is static-ready"
+    _sel = _cnp.spec.endpointSelector.matchLabels
+    assert _sel["app.kubernetes.io/name"] == "valkey"
+    assert _sel["app.kubernetes.io/instance"] == "xplane-test-valkey"
+    assert len(_cnp.spec.ingress) == 2
+    assert len(_cnp.spec.ingress[0].fromEndpoints) == 1 and len(_cnp.spec.ingress[0].fromEndpoints[0]) == 0, "6379 open to all endpoints in the namespace"
+    assert _cnp.spec.ingress[0].toPorts[0].ports[0].port == "6379"
+    assert _cnp.spec.ingress[0].toPorts[0].ports[0].protocol == "TCP"
+    assert _cnp.spec.ingress[1].fromEndpoints[0].matchLabels["io.kubernetes.pod.namespace"] == "observability", "9121 restricted to observability (vmagent scrape)"
+    assert _cnp.spec.ingress[1].toPorts[0].ports[0].port == "9121"
+    assert "egress" not in _cnp.spec, "standalone must render no egress key at all"
+}
+
+# ---- Test: replica-mode CNP egress = DNS (L7 inspected) + intra-instance 6379 ----
+test_cnp_replica_egress = lambda {
+    _cnp = [r for r in _render(_mkOxr({replicas = 3})) if r.kind == "CiliumNetworkPolicy"][0]
+    assert len(_cnp.spec.egress) == 2
+    _dns = _cnp.spec.egress[0]
+    assert _dns.toEndpoints[0].matchLabels["io.kubernetes.pod.namespace"] == "kube-system"
+    assert _dns.toEndpoints[0].matchLabels["k8s-app"] == "kube-dns"
+    _dnsPorts = [p.port for p in _dns.toPorts[0].ports]
+    _dnsProtos = [p.protocol for p in _dns.toPorts[0].ports]
+    assert _dnsPorts == ["53", "53"] and "UDP" in _dnsProtos and "TCP" in _dnsProtos
+    assert _dns.toPorts[0].rules.dns[0].matchPattern == "*", "L7 dns matchPattern is mandatory for FQDN visibility"
+    _sync = _cnp.spec.egress[1]
+    assert _sync.toEndpoints[0].matchLabels["app.kubernetes.io/instance"] == "xplane-test-valkey"
+    assert _sync.toEndpoints[0].matchLabels["app.kubernetes.io/name"] == "valkey"
+    assert _sync.toPorts[0].ports[0].port == "6379"
+}
+
+# ---- Test: no Bitnami legacy artifacts anywhere in rendered output ----
+test_no_bitnami_legacy = lambda {
+    _full = _render(_mkOxr({size = "large", replicas = 2, auth = {existingSecret = "s"}, persistence = {size = "4Gi"}, metrics = True}))
+    assert "bitnamilegacy" not in str(_full), "bitnamilegacy must not appear in any variant"
+    assert "bitnamilegacy" not in str(items), "bitnamilegacy must not appear in the settings-rendered output"
+}
+
+# ---- Test: settings-example.yaml renders through the real option() path ----
+test_settings_render = lambda {
+    _oxr = option("params").oxr
+    assert len(items) == 2, "expected 2 resources from settings-example, got {}".format(len(items))
+    _hr = [r for r in items if r.kind == "HelmRelease"][0]
+    assert _hr.metadata.name == _oxr.metadata.name + "-valkey"
+    assert _hr.spec.values.fullnameOverride == _oxr.metadata.name + "-valkey"
+}

--- a/infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml
+++ b/infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml
@@ -9,7 +9,7 @@ kcl_options:
           size: "small"
           replicas: 2
           auth:
-            existingSecret: "mycache-valkey-password"
+            existingSecret: "mycache-valkey-password" # checkov:skip=CKV_SECRET_6: secret name, not a value
             passwordKey: "password"
           persistence:
             size: "4Gi"

--- a/infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml
+++ b/infrastructure/base/crossplane/configuration/kcl/kvstore/settings-example.yaml
@@ -1,0 +1,17 @@
+kcl_options:
+  - key: params
+    value:
+      oxr:
+        metadata:
+          name: "xplane-mycache"
+          namespace: "apps"
+        spec:
+          size: "small"
+          replicas: 2
+          auth:
+            existingSecret: "mycache-valkey-password"
+            passwordKey: "password"
+          persistence:
+            size: "4Gi"
+          metrics: true
+      ocds: {}

--- a/infrastructure/base/crossplane/configuration/kustomization.yaml
+++ b/infrastructure/base/crossplane/configuration/kustomization.yaml
@@ -12,5 +12,7 @@ resources:
   - functions.yaml
   - inference-service-composition.yaml
   - inference-service-definition.yaml
+  - kvstore-composition.yaml
+  - kvstore-definition.yaml
   - sql-instance-composition.yaml
   - sql-instance-definition.yaml

--- a/infrastructure/base/crossplane/configuration/kvstore-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/kvstore-composition.yaml
@@ -18,7 +18,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-kvstore:0.1.0
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-kvstore:0.1.0-pr1664
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/kvstore-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/kvstore-composition.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+    name: xkvstores.cloud.ogenki.io
+    labels:
+        provider: kubernetes
+spec:
+    compositeTypeRef:
+        apiVersion: cloud.ogenki.io/v1alpha1
+        kind: KVStore
+    mode: Pipeline
+    pipeline:
+        - step: kvstore
+          functionRef:
+              name: function-kcl
+          input:
+              apiVersion: krm.kcl.dev/v1alpha1
+              kind: KCLRun
+              spec:
+                  target: Resources
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-kvstore:0.1.0
+
+        - step: ready
+          functionRef:
+              name: function-auto-ready

--- a/infrastructure/base/crossplane/configuration/kvstore-definition.yaml
+++ b/infrastructure/base/crossplane/configuration/kvstore-definition.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: kvstores.cloud.ogenki.io
+spec:
+  group: cloud.ogenki.io
+  scope: Namespaced
+  names:
+    kind: KVStore
+    plural: kvstores
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                size:
+                  description: Instance size, maps to CPU/memory requests and limits.
+                  type: string
+                  enum:
+                    - nano
+                    - small
+                    - medium
+                    - large
+                  default: small
+                replicas:
+                  description: |
+                    Number of read replicas. 0 (default) = standalone Deployment.
+                    N > 0 = StatefulSet with N replicas and a read Service.
+                    No automatic failover — cache semantics (SPEC-012 CL-2).
+                  type: integer
+                  default: 0
+                  minimum: 0
+                  maximum: 5
+                auth:
+                  description: |
+                    Optional ACL authentication for the "default" user. Omitted = auth
+                    disabled. The password comes from an existing Secret (typically an
+                    ExternalSecret target) — never inline.
+                  type: object
+                  properties:
+                    existingSecret:
+                      description: Name of the Secret holding the password.
+                      type: string
+                    passwordKey:
+                      description: Key inside existingSecret holding the password.
+                      type: string
+                      default: password
+                  required:
+                    - existingSecret
+                persistence:
+                  description: |
+                    Optional persistent storage. Omitted = ephemeral in standalone mode
+                    (cache semantics, SPEC-012 CL-4). Replica mode always persists and
+                    defaults to 4Gi when this block is omitted.
+                  type: object
+                  properties:
+                    size:
+                      description: PVC size, e.g. 4Gi.
+                      type: string
+                  required:
+                    - size
+                metrics:
+                  description: |
+                    Prometheus exporter sidecar + ServiceMonitor (converted and scraped
+                    by the VictoriaMetrics operator).
+                  type: boolean
+                  default: true
+          required:
+            - spec

--- a/scripts/validate-kcl-compositions.sh
+++ b/scripts/validate-kcl-compositions.sh
@@ -57,6 +57,7 @@ declare -a COMPOSITIONS=(
     "cloudnativepg:sql-instance-composition.yaml:sqlinstance-basic.yaml,sqlinstance-complete.yaml"
     "eks-pod-identity:epi-composition.yaml:epi.yaml"
     "inference-service:inference-service-composition.yaml:inferenceservice-basic.yaml,inferenceservice-complete.yaml"
+    "kvstore:kvstore-composition.yaml:kvstore-basic.yaml,kvstore-complete.yaml"
 )
 
 # Validate a single composition


### PR DESCRIPTION
Part of #1662 (SPEC-012, phase 1 of 2 — phase 2 migrates the three consumers).

## What

New namespaced \`KVStore\` XRD (\`cloud.ogenki.io/v1alpha1\`) + KCL composition wrapping the **official [valkey-helm](https://github.com/valkey-io/valkey-helm) chart** (0.10.0, image \`docker.io/valkey/valkey\` 9.1.0) — the platform's exit path from the frozen \`bitnamilegacy\` supply chain.

Each XR renders:
- **HelmRelease \`<name>-valkey\`** — size→resources map, readiness probe enabled, optional ACL auth from an existing Secret, ephemeral by default (PVC opt-in; replica mode always persists), hardened metrics exporter + ServiceMonitor
- **CiliumNetworkPolicy** — default-deny: 6379 ns-local, 9121 from \`observability\` (vmagent), egress only in replica mode (DNS + replication)

Also adds the official \`valkey\` HelmRepository under \`flux/sources\` and registers the module in \`validate-kcl-compositions.sh\`.

## Design

Spec/plan/clarifications: \`docs/specs/012-kvstore-composition-replace-bitnami/\` (CL-1 in-cluster over ElastiCache, CL-2 cache semantics — no failover, CL-3 official chart over operator, CL-4 ephemeral default).

## Validation

- \`kcl test\`: **15/15 PASS**
- \`./scripts/validate-kcl-compositions.sh\`: fmt + syntax green; **render gate pending OCI publish** — will pin \`0.1.0-pr<N>\` once this PR's CI publishes it, re-run, then strip to \`0.1.0\` pre-merge (repo convention)
- \`./scripts/validate-manifests.sh\`: **Valid: 1221, Invalid: 0, Skipped: 0**, Polaris 88, all gates passed