### PR TITLE
chore(crossplane): pin crossplane-app to 0.5.0

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.5.0-pr1665
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.5.0
 
         - step: ready
           functionRef:


### PR DESCRIPTION
SPEC-012 wrap-up: strips the PR-validation pin `0.5.0-pr1665` to the bare `0.5.0` published by the main-branch run after #1665 merged (anonymous pull verified, HTTP 200). Clears the red `validate-composition-versions` gate on main. Part of #1662.