### PR TITLE
fix: platform deploy failures from 2026-07-21 (OpenBao 2.6.0 deadlock, state locking, barman RBAC)

### DIFF
--- a/infrastructure/base/cloudnative-pg-barman-plugin/barman-cloud-plugin.yaml
+++ b/infrastructure/base/cloudnative-pg-barman-plugin/barman-cloud-plugin.yaml
@@ -76,9 +76,13 @@ spec:
     # gotcha) — upstream hardcodes `cnpg-system`, so the plugin SA (now in
     # `infrastructure`) gets "forbidden" on leases (leader election) and
     # objectstores (controller). Repoint every binding's subject.
+    # Binding names carry upstream's `barman-plugin-` prefix since v0.13.0 —
+    # an unmatched target silently no-ops, leaving the subject on `cnpg-system`
+    # (symptom: SA forbidden on leases, plugin never Ready). Re-check names on
+    # every tag bump.
     - target:
         kind: RoleBinding
-        name: leader-election-rolebinding
+        name: barman-plugin-leader-election-rolebinding
       patch: |
         - op: replace
           path: /subjects/0/namespace
@@ -92,7 +96,7 @@ spec:
           value: infrastructure
     - target:
         kind: ClusterRoleBinding
-        name: metrics-auth-rolebinding
+        name: barman-plugin-metrics-auth-rolebinding
       patch: |
         - op: replace
           path: /subjects/0/namespace

--- a/opentofu/eks/configure/backend.tf
+++ b/opentofu/eks/configure/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "demo-smana-remote-backend"
-    key     = "cloud-native-ref/eks/configure/opentofu.tfstate"
-    region  = "eu-west-3"
-    encrypt = true
+    bucket       = "demo-smana-remote-backend"
+    key          = "cloud-native-ref/eks/configure/opentofu.tfstate"
+    region       = "eu-west-3"
+    encrypt      = true
+    use_lockfile = true # native S3 locking (.tflock object, no DynamoDB)
   }
 }

--- a/opentofu/eks/init/backend.tf
+++ b/opentofu/eks/init/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "demo-smana-remote-backend"
-    key     = "cloud-native-ref/eks/init/opentofu.tfstate"
-    region  = "eu-west-3"
-    encrypt = true
+    bucket       = "demo-smana-remote-backend"
+    key          = "cloud-native-ref/eks/init/opentofu.tfstate"
+    region       = "eu-west-3"
+    encrypt      = true
+    use_lockfile = true # native S3 locking (.tflock object, no DynamoDB)
   }
 }

--- a/opentofu/llm-platform/backend.tf
+++ b/opentofu/llm-platform/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "demo-smana-remote-backend"
-    key     = "cloud-native-ref/llm-platform/opentofu.tfstate"
-    region  = "eu-west-3"
-    encrypt = true
+    bucket       = "demo-smana-remote-backend"
+    key          = "cloud-native-ref/llm-platform/opentofu.tfstate"
+    region       = "eu-west-3"
+    encrypt      = true
+    use_lockfile = true # native S3 locking (.tflock object, no DynamoDB)
   }
 }

--- a/opentofu/network/backend.tf
+++ b/opentofu/network/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "demo-smana-remote-backend"
-    key     = "cloud-native-ref/network/opentofu.tfstate"
-    region  = "eu-west-3"
-    encrypt = true
+    bucket       = "demo-smana-remote-backend"
+    key          = "cloud-native-ref/network/opentofu.tfstate"
+    region       = "eu-west-3"
+    encrypt      = true
+    use_lockfile = true # native S3 locking (.tflock object, no DynamoDB)
   }
 }

--- a/opentofu/openbao/cluster/autoscaling_group.tf
+++ b/opentofu/openbao/cluster/autoscaling_group.tf
@@ -6,6 +6,9 @@ resource "aws_launch_template" "dev" {
   vpc_security_group_ids = [aws_security_group.openbao.id]
   user_data              = base64encode(data.cloudinit_config.openbao_cloud_init.rendered)
   ebs_optimized          = true
+  # The ASG launches from the template's default version; without this, user_data
+  # or AMI changes only bump the latest version and never reach new instances.
+  update_default_version = true
   monitoring {
     enabled = true
   }
@@ -38,6 +41,7 @@ resource "aws_launch_template" "ha" {
   vpc_security_group_ids = [aws_security_group.openbao.id]
   user_data              = base64encode(data.cloudinit_config.openbao_cloud_init.rendered)
   ebs_optimized          = true
+  update_default_version = true
   monitoring {
     enabled = true
   }

--- a/opentofu/openbao/cluster/backend.tf
+++ b/opentofu/openbao/cluster/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "demo-smana-remote-backend"
-    key     = "cloud-native-ref/openbao/cluster/opentofu.tfstate"
-    region  = "eu-west-3"
-    encrypt = true
+    bucket       = "demo-smana-remote-backend"
+    key          = "cloud-native-ref/openbao/cluster/opentofu.tfstate"
+    region       = "eu-west-3"
+    encrypt      = true
+    use_lockfile = true # native S3 locking (.tflock object, no DynamoDB)
   }
 }

--- a/opentofu/openbao/cluster/variables.tf
+++ b/opentofu/openbao/cluster/variables.tf
@@ -22,7 +22,10 @@ variable "mode" {
 variable "openbao_version" {
   description = "OpenBao version to install"
   type        = string
-  default     = "2.6.0"
+  # 2.6.0 deadlocks on concurrent namespace creation (openbao/openbao#3411):
+  # the management stack's parallel vault_namespace resources wedge the core
+  # and every subsequent request hangs. Stay on 2.5.5 until a fixed release.
+  default = "2.5.5"
 }
 
 variable "openbao_data_path" {

--- a/opentofu/openbao/management/backend.tf
+++ b/opentofu/openbao/management/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "demo-smana-remote-backend"
-    key     = "cloud-native-ref/openbao/management/opentofu.tfstate"
-    region  = "eu-west-3"
-    encrypt = true
+    bucket       = "demo-smana-remote-backend"
+    key          = "cloud-native-ref/openbao/management/opentofu.tfstate"
+    region       = "eu-west-3"
+    encrypt      = true
+    use_lockfile = true # native S3 locking (.tflock object, no DynamoDB)
   }
 }


### PR DESCRIPTION
## Summary

Full-platform redeploy on 2026-07-21 failed with what looked like a Tailscale connectivity break after the subnet-router module bump to 1.3.0 (#1663). Root-causing exonerated the module: three independent platform defects surfaced in the same deploy window. Each is fixed here; the module stays on 1.3.0.

## Fixes

1. **OpenBao: pin 2.5.5 and roll launch-template default version** — OpenBao 2.6.0 (bumped in #1640) deadlocks permanently when the management stack creates its `vault_namespace` resources concurrently (upstream openbao/openbao#3411, fix PR #3446 still open). TCP and TLS handshakes keep succeeding while every HTTP request hangs, which mimics a network failure (the NLB TCP health check stays green). Also sets `update_default_version = true` on both launch templates — without it the ASG keeps launching instances from the stale default version, so the pin never reached replacements.

2. **OpenTofu: native S3 state locking on all six backends** — two concurrent applies raced during the incident (no locking configured), producing `AlreadyExists` errors and an orphan IAM policy. `use_lockfile = true` (OpenTofu ≥ 1.10 conditional-write `.tflock`, no DynamoDB). Verified: a second concurrent plan now fails with `Error acquiring the state lock` (412 PreconditionFailed).

3. **CNPG barman plugin: repoint RBAC patches to v0.13.0 names** — upstream renamed `leader-election-rolebinding` and `metrics-auth-rolebinding` with a `barman-plugin-` prefix; the repo's subject-namespace patches targeted the old names and silently no-op'd, leaving subjects on the nonexistent `cnpg-system`. The plugin SA was forbidden on leases, leader election never completed, and the Kustomization stalled — this also gated zitadel's CNPG `full-recovery` bootstrap (the recovery job runs a `plugin-barman-cloud` sidecar).

## Verification

- Fresh deploy from scratch completed end-to-end after these fixes (`terramate script run deploy` exit 0: network/openbao no-op, management 21 added, EKS stage 1 85 added, stage 2 20 added).
- OpenBao 2.5.5 initialized, unsealed, active through the previously-blamed Tailscale path; the management namespace step that deadlocked 2.6.0 applied cleanly.
- `barman-cloud` Deployment 1/1 Available after the RBAC repoint; zitadel CNPG full-recovery completed; all Flux kustomizations converged (`llm-platform` suspended by design).
- `./scripts/validate-manifests.sh`: all gates passed, exit 0.