### PR TITLE
chore(validation): pin schema catalogs to cluster versions and CI action refs

### DIFF
--- a/.fluxschema.yml
+++ b/.fluxschema.yml
@@ -2,10 +2,15 @@
 apiVersion: schema.plugin.fluxcd.io/v1beta1
 kind: Config
 validate:
-  # Order matters: our generated catalog wins, then Flux's built-in, then the
-  # hosted CNCF ecosystem catalog (rebuilt daily from upstream releases).
+  # Order matters: our generated catalog wins, then version-pinned catalogs
+  # matching what the cluster actually runs (bump alongside the EKS
+  # kubernetes_version in opentofu/eks/init and the Flux minor), then Flux's
+  # built-in (Gateway API, Flagger, flux-operator), then the hosted CNCF
+  # ecosystem catalog (rebuilt daily from upstream releases).
   schemaLocation:
     - ./.schemas
+    - https://schemas.fluxoperator.dev/catalog/versions/kubernetes/v1.36
+    - https://schemas.fluxoperator.dev/catalog/versions/flux/v2.9
     - default
     - ecosystem
   # The entire point of SPEC-007: an unknown kind fails the build instead of

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,10 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Checkov static analysis
-        uses: bridgecrewio/checkov-action@v12.1347.0
+        # Latest TAG, not latest RELEASE — the repo stopped cutting releases at
+        # v12.1347.0 (whose old action.yml breaks on comma-separated framework)
+        # but still tags every checkov bump.
+        uses: bridgecrewio/checkov-action@v12.3114.0
         with:
           directory: .
           quiet: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -59,7 +59,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Checkov static analysis
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12.1347.0
         with:
           directory: .
           quiet: true
@@ -75,7 +75,7 @@ jobs:
           sarif_file: checkov-results.sarif
 
       - name: Detect secrets with TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.9
         with:
           path: ./
           base: main
@@ -92,8 +92,10 @@ jobs:
       - name: Install tools
         uses: jdx/mise-action@v4
 
+      # Pinned: preflight.sh only enforces a version floor (>=0.10), so an
+      # unpinned install silently floats to whatever upstream released.
       - name: Install the flux-schema plugin
-        run: flux plugin install schema
+        run: flux plugin install schema@0.11.0
 
       # render-bundle.py parses every rendered document; PyYAML happens to ship
       # in the runner image today, but that is not a dependency declaration.
@@ -101,7 +103,7 @@ jobs:
         run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
 
       - name: Install Polaris
-        uses: fairwindsops/polaris/.github/actions/setup-polaris@master
+        uses: fairwindsops/polaris/.github/actions/setup-polaris@v10.2.1
         with:
           version: '8.5.0'
 


### PR DESCRIPTION
## What

Two hardening changes that fell out of reviewing the [Kubernetes Schema Catalog for AI Agents](https://medium.com/@stefanprodan/kubernetes-schema-catalog-for-ai-agents-1426aeb3936a) post and the latest flux-schema/agent-skills releases.

### 1. Version-pinned schema catalogs (`.fluxschema.yml`)

`schemaLocation` now resolves Kubernetes and Flux schemas from the version-pinned catalogs on `schemas.fluxoperator.dev`, matching what the cluster actually runs (EKS `kubernetes_version=1.36`, Flux v2.9), before falling back to `default` and `ecosystem`:

```yaml
- ./.schemas
- https://schemas.fluxoperator.dev/catalog/versions/kubernetes/v1.36
- https://schemas.fluxoperator.dev/catalog/versions/flux/v2.9
- default
- ecosystem
```

This is a no-op today — the floating `default` catalog is currently built from k8s 1.36.2 + Flux 2.9.2 — but it stops validation from drifting ahead of cluster reality when upstream moves to 1.37 / 2.10. The two URLs must be bumped alongside EKS/Flux upgrades (comment in the file says so).

`default` stays in the chain: it still supplies Gateway API, Flagger and flux-operator schemas that the pinned catalogs don't cover.

### 2. CI supply-chain pins (`.github/workflows/ci.yaml`)

Five refs were floating and are now tag-pinned:

| Ref | Before | After |
|---|---|---|
| aquasecurity/trivy-action | `@master` | `@v0.36.0` |
| bridgecrewio/checkov-action | `@master` | `@v12.1347.0` |
| trufflesecurity/trufflehog | `@main` | `@v3.95.9` |
| fairwindsops/polaris setup action | `@master` | `@v10.2.1` (binary stays pinned at 8.5.0) |
| flux-schema plugin | latest | `schema@0.11.0` |

The plugin pin matters because `scripts/flux-schema/preflight.sh` only enforces a version *floor* (>=0.10) — an unpinned install silently floats to whatever upstream released.

## Evidence

- `./scripts/validate-manifests.sh` with the new config: exit 0, all gates passed
- Schema gate on the rendered bundle: **1191 resources — Valid: 1191, Invalid: 0, Skipped: 0**
- Pinned-catalogs-only smoke test (Deployment + Flux Kustomization): Valid: 2, Invalid: 0, Skipped: 0
- `actionlint` on the workflow: clean