### PR TITLE
⬆️ chore(cilium): upgrade to 1.20.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,10 @@ Two-stage OpenTofu deployment: Stage 1 creates the EKS cluster with temporary CN
 - `opentofu/eks/configure/main.tf` - Cilium and Flux helm_releases
 - `opentofu/eks/init/helm_values/cilium.yaml` - Cilium Helm values
 
-**Cilium Prefix Delegation (DISABLED):**
-Secondary CIDR (100.64.0.0/16) is disabled due to Cilium bug #43493 causing Gateway API L7 proxy failures on cross-node traffic. When fixed, uncomment `cilium-cni-config.tf` and related settings in `cilium.yaml`.
+**Cilium Prefix Delegation (ENABLED — WireGuard is load-bearing):**
+Pods get IPs from the secondary CIDR (100.64.0.0/16) via prefix delegation, configured by the custom CNI ConfigMap in `opentofu/eks/configure/cilium-cni-config.tf`. Cilium bug #43493 (still open) breaks the Gateway API L7 proxy on cross-node traffic in this mode: the BPF ipcache sets `hastunnel` incorrectly for remote pods under native routing. **The workaround is `encryption.type: wireguard`** — node-to-node tunnels bypass the faulty routing logic. Do not disable WireGuard, and do not swap it for ztunnel transparent encryption, while #43493 is open.
+
+`cniVersion` in `cilium-cni-config.tf` must track the CNI standard version Cilium defaults to (1.20 moved it 0.3.1 → 1.0.0). Because we set `cni.configMap`, the chart default never applies — bump it manually on every Cilium minor upgrade.
 
 **Pod Subnet Tagging (IMPORTANT):**
 The pod subnets (100.64.x.x) must NOT have the `kubernetes.io/role/cni` tag. VPC-CNI uses this tag to discover subnets during Stage 1 bootstrap, which creates orphan ENIs when Cilium takes over in Stage 2. Only use `cilium.io/pod-subnet=true` for these subnets.

--- a/infrastructure/base/cilium/vmrules.yaml
+++ b/infrastructure/base/cilium/vmrules.yaml
@@ -56,8 +56,11 @@ spec:
             runbook_url: "https://docs.cilium.io/en/stable/operations/troubleshooting/"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
 
+        # cilium_policy_import_errors_total was removed from Cilium's metrics
+        # registry several minors ago; this alert silently never fired. The
+        # replacement is cilium_policy_change_total{source,operation,outcome}.
         - alert: CiliumAgentPolicyImportErrors
-          expr: sum by (namespace, pod) (rate(cilium_policy_import_errors_total[2m]) > 0)
+          expr: sum by (namespace, pod) (rate(cilium_policy_change_total{outcome="fail"}[2m])) > 0
           for: 5m
           labels:
             severity: critical

--- a/opentofu/config.tm.hcl
+++ b/opentofu/config.tm.hcl
@@ -12,7 +12,7 @@ globals {
   cert_manager_approle             = "cert-manager"
 
   # Helm chart versions for EKS bootstrap
-  cilium_version        = "1.19.6"
+  cilium_version        = "1.20.0"
   flux_operator_version = "0.55.0"
   flux_instance_version = "0.55.0"
 

--- a/opentofu/eks/configure/cilium-cni-config.tf
+++ b/opentofu/eks/configure/cilium-cni-config.tf
@@ -9,6 +9,10 @@
 #   - first-interface-index: 1 (skip eth0, use secondary ENIs only for pods)
 #   - subnet-tags: select subnets tagged with cilium.io/pod-subnet=true (100.64.0.0/16)
 #   - disable-prefix-delegation: false (enable prefix delegation)
+#
+# cniVersion tracks the CNI standard version Cilium defaults to: 1.20 moved it
+# from 0.3.1 to 1.0.0. The chart default does not apply here — cni.configMap
+# means we own this file, so the bump is manual on every Cilium minor upgrade.
 resource "kubectl_manifest" "cilium_cni_config" {
   yaml_body = yamlencode({
     apiVersion = "v1"
@@ -19,10 +23,10 @@ resource "kubectl_manifest" "cilium_cni_config" {
     }
     data = {
       "cni-config" = jsonencode({
-        cniVersion = "0.3.1"
+        cniVersion = "1.0.0"
         name       = "cilium"
         plugins = [{
-          cniVersion = "0.3.1"
+          cniVersion = "1.0.0"
           type       = "cilium-cni"
           eni = {
             "first-interface-index"     = 1

--- a/opentofu/eks/init/helm_values/cilium.yaml
+++ b/opentofu/eks/init/helm_values/cilium.yaml
@@ -86,6 +86,14 @@ encryption:
 envoy:
   # Explicitly enable Envoy DaemonSet for Gateway API L7 proxy
   enabled: true
+  # xdsMode is deliberately left unset so Cilium >= 1.20 picks its new default,
+  # "ads" (Aggregated Discovery Service), instead of the legacy "split" mode.
+  # Setting `upgradeCompatibility: "1.19"` anywhere would silently pin us back to
+  # "split". ADS delivers Envoy config consistently in one stream — lower CPU and
+  # lower policy-update latency on the surface this cluster leans on: the two
+  # Tailscale Gateways plus the CiliumEnvoyConfig ext_proc hop to
+  # vllm-semantic-router. Verify with:
+  #   kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.envoy-xds-mode}'
   resources:
     limits:
       memory: 300Mi


### PR DESCRIPTION
## Summary

Upgrades Cilium `1.19.6` → `1.20.0`, plus two pre-existing defects the upgrade audit surfaced.

Audited by rendering **both** chart versions against this repo's own values file and diffing the resulting `cilium-config` ConfigMap — release notes say what changed upstream, the rendered diff says what changes on *our* cluster. Result: object inventory unchanged, no Helm key dropped, `helm template` passes the chart's `values.schema.json`. Nine config keys added, one flipped.

## Changes beyond the version pin

**`cniVersion` `0.3.1` → `1.0.0`** — Cilium 1.20 moved the CNI standard default. Because we set `cni.configMap` for the ENI settings (`first-interface-index`, `subnet-tags`), the chart default never reaches that file: we own it, so the bump is manual on every Cilium minor. Now documented in `CLAUDE.md` so the next one doesn't miss it.

**`envoy.xdsMode` left unset on purpose** — the agent takes 1.20's new default `ads` instead of legacy `split`. This is the release's headline perf change (aggregated, consistent Envoy config delivery → lower CPU and policy-update latency) and it lands squarely on the surface this cluster leans on: the two Tailscale Gateways plus the `CiliumEnvoyConfig` ext_proc hop to `vllm-semantic-router`. Setting `upgradeCompatibility: "1.19"` anywhere would silently pin it back to `split`, so the values file now says so with a verify command.

Full rendered-config delta:

```
+ envoy-xds-mode = ads                       ← the one with real blast radius
+ envoy-access-log-enabled = true            ← matches CGCC telemetry.accessLogs already in use
+ gateway-api-use-remote-address = true      ← preserves 1.19 hardcoded behavior
+ proxy-cluster-max-pending-requests = 1024  ← now a knob (envoy.clusterMaxPendingRequests)
+ envoy-node-locality-enabled = false
+ enable-datapath-plugins = false            ← new CiliumDatapathPlugin CRD (v2alpha1)
+ enable-dynamic-source-lookup-nodeport = false
+ clustermesh-default-global-namespace = true
+ datapath-plugins-state-dir = /var/run/cilium/plugins
~ bpf-lb-algorithm-annotation: false → true  ← enables per-Service lb-algorithm annotation
```

## Gateway API: no change needed

`v1.6.1` is both the latest release (2026-07-16) and exactly what Cilium 1.20.0 vendors (`go.mod: sigs.k8s.io/gateway-api v1.6.1`). Both repo pins already match, so 1.20's raised minimum is a non-issue. What *does* change is that Cilium now implements v1.6 conformance — `ListenerSet` stops being installable-but-inert, which is worth a follow-up spec for the platform/app Gateway split.

## Two pre-existing defects fixed

**Dead alert.** `CiliumAgentPolicyImportErrors` queried `cilium_policy_import_errors_total`, which is absent from Cilium's metrics registry — and has been for several minors, **including 1.19.6**. An alert on a nonexistent metric evaluates to an empty vector, which reads as "not firing", not "broken". It stayed green for the life of the repo while providing zero coverage. Replaced with `cilium_policy_change_total{outcome="fail"}`.

**Stale docs.** `CLAUDE.md` claimed prefix delegation was disabled pending cilium#43493. Commit `ecb11e8a` enabled it and works around the bug with WireGuard node-to-node encryption instead. Corrected, and WireGuard is now marked load-bearing so it doesn't get swapped for 1.20's ztunnel transparent encryption (beta) while #43493 is open.

## Upgrade notes checked, all clear

| 1.20 breaking change | Repo status |
|---|---|
| Gateway API min v1.6.1 | ✅ already pinned in both places |
| `CiliumNodeConfig` v2alpha1 removed | ✅ not used |
| `CiliumGatewayClassConfig` | ✅ still `v2alpha1` in the 1.20 chart — no manifest change |
| Envoy Go extensions / kafka / `l7proto` in CNPs | ✅ zero matches repo-wide |
| Empty CNP/CCNP rejected at admission | ✅ scanned all — none empty |
| Removed `eni` CRD fields, `encryption.strictMode.*`, clustermesh TLS-as-values, MCS API, `preferIpv6`, `dnsProxy.preCache`, `--node-port-algorithm/mode` | ✅ none used |
| `bpf.tproxy` × netkit incompatibility | ✅ neither set |
| cilium#43493 | ⚠️ still open, no milestone — WireGuard workaround stays |

## Verification

```
./scripts/validate-manifests.sh  → exit 0
   Summary: 1189 resources found in 182 files - Valid: 1189, Invalid: 0, Skipped: 0
   Gate 1 flux schema validate ✅   Gate 2 polaris audit ✅   All gates passed
tofu fmt -check / tofu validate  → exit 0 / "Success! The configuration is valid."
trivy config opentofu/           → exit 0
helm template @1.20.0            → exit 0, envoy-xds-mode = ads
   images: cilium:v1.20.0, cilium-envoy:v1.37.5, operator-aws:v1.20.0, hubble-relay:v1.20.0
```

## Deploy + the check that matters

```bash
cd opentofu/eks/init && terramate script run deploy
```

**#43493 is the regression surface.** Beyond `cilium status`, the meaningful post-deploy check is a **cross-node** request through a Tailscale Gateway HTTPRoute — that's the path the WireGuard workaround protects and the path ADS changes config delivery for.

## Follow-ups (not in this PR)

- Renovate can't see `cilium_version`: `.github/renovate.json` sets `ignorePaths: ["opentofu"]`, so this bump is manual by design. A `customManagers` regex on `config.tm.hcl` would close the gap.
- `infrastructure/base/cilium/grafana-dashboards.yaml` pulls dashboards from `cilium/cilium@main` (i.e. the *next* release's panels) — worth pinning to the deployed tag.
- Gateway API `ListenerSet` adoption — spec-worthy.
