### PR TITLE
fix(runlore): align image.tag with the chart ref — both replicas are crashlooping

### DIFF
--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,13 +6,16 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # Pinned to the v0.9.2 release: the chart and the signed, multi-arch release image in
-  # observability/base/runlore/helmrelease.yaml (image.tag "0.9.2") come from the same
-  # tag, so the two cannot drift apart. Keep them in lockstep on every bump.
+  # Pinned to the v0.11.0 release: the chart is rendered from THIS tag, and the signed,
+  # multi-arch release image in observability/base/runlore/helmrelease.yaml
+  # (image.tag "0.11.0") must come from the same one. Keep them in lockstep on every
+  # bump — bumping one alone is not a partial upgrade, it is an outage.
   #
-  # v0.9.2 is the release that carries #320 (a standing 👎 bypasses the coalesce
-  # cooldown), #321 (Hubble Relay TLS floor pinned to 1.2) and #322 (Secret data values
-  # decoded and scrubbed payload-wide) — all three validated against a live cluster this
-  # session (load-bearing unit tests, k3d e2e 54/0, healthy in cluster).
+  # This comment previously claimed a v0.9.2 lockstep while this tag already read
+  # v0.11.0: the chart was bumped and image.tag was left behind. RunLore parses its
+  # config with KnownFields(true), so the v0.11.0 chart's `curate.sweeps` key was
+  # rejected by the v0.9.2 binary and `serve` failed closed on startup —
+  # `field sweeps not found in type config.Curate` — crashlooping both replicas
+  # for as long as the drift lasted.
   ref:
     tag: v0.11.0

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -62,7 +62,13 @@ spec:
       # the StatefulSet lands in ImagePullBackOff. This is the signed, multi-arch,
       # SBOM-attested release image; the rolling `:main` tag from build-image.yml is a
       # single-arch validation build and must not be used here.
-      tag: "0.9.2"
+      #
+      # KEEP THIS IN LOCKSTEP WITH the GitRepository tag in
+      # flux/sources/gitrepo-runlore.yaml. The chart is rendered from that ref, so a
+      # chart newer than the image emits config keys the older binary rejects:
+      # config parsing uses KnownFields(true), and 0.9.2 against the v0.11.0 chart
+      # crashlooped on `field sweeps not found in type config.Curate`.
+      tag: "0.11.0"
       pullPolicy: IfNotPresent
     serviceAccount:
       create: true


### PR DESCRIPTION
## Impact

RunLore has **not been running on `mycluster-0` since the cluster came up**. Both replicas are in `CrashLoopBackOff` with 22 restarts each. No agent process means no webhook listener and no investigations — nothing was filtered or dropped, the agent was never up to receive anything.

```
runlore-0   0/1   CrashLoopBackOff   22 (4m14s ago)   93m
runlore-1   0/1   CrashLoopBackOff   22 (4m23s ago)   93m

serve: parse config: yaml: unmarshal errors:
  line 18: field sweeps not found in type config.Curate
```

## Cause

`flux/sources/gitrepo-runlore.yaml` pins the GitRepository to `v0.11.0` — and the chart is rendered from that ref — while `observability/base/runlore/helmrelease.yaml` still pinned `image.tag: "0.9.2"`.

The v0.11.0 chart's ConfigMap template emits `curate.sweeps`. RunLore parses its config with `KnownFields(true)`, so an unknown key is a hard startup failure. The v0.9.2 binary has no `Sweeps` field, so `serve` failed closed every time.

The strict parsing is correct and should stay — a typo in a safety-critical field must fail loudly. It just means a chart newer than its binary is an outage, not a partial upgrade.

## What makes this worth reading twice

**The invariant was already documented.** `gitrepo-runlore.yaml` said:

> *"Pinned to the v0.9.2 release: the chart and the signed, multi-arch release image … come from the same tag, so the two cannot drift apart. Keep them in lockstep on every bump."*

…while the tag directly beneath it read `v0.11.0`. The chart was bumped, `image.tag` was left behind, and the comment asserting they were paired was never updated. The rule survived; the pairing didn't.

## The fix

- `image.tag: "0.9.2"` → `"0.11.0"`, matching the chart ref.
- Corrected the stale comment in `gitrepo-runlore.yaml`, and recorded the failure mode next to the knob so the next bump carries the reason rather than just the rule.

Verified the target image before pointing at it — `ghcr.io/smana/runlore:0.11.0` returns HTTP 200 from GHCR, is genuinely multi-arch (`linux/amd64`, `linux/arm64`), and carries two attestation manifests. That satisfies the existing policy in the HelmRelease comment: the signed, multi-arch, SBOM-attested release image, **not** the rolling `:main` validation build.

## Why not `:main`

`:main` would carry today's fixes, but the HelmRelease comment forbids it for this cluster — single-arch, unsigned, unattested — and pinning it would re-create the same chart/binary drift this PR exists to close. Newer work lands here when `v0.12.0` is cut.