### PR TITLE
fix(runlore): align image.tag with the chart ref on the branch the cluster reconciles

### DIFF
--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,13 +6,16 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # Pinned to the v0.9.2 release: the chart and the signed, multi-arch release image in
-  # observability/base/runlore/helmrelease.yaml (image.tag "0.9.2") come from the same
-  # tag, so the two cannot drift apart. Keep them in lockstep on every bump.
+  # Pinned to the v0.11.0 release: the chart is rendered from THIS tag, and the signed,
+  # multi-arch release image in observability/base/runlore/helmrelease.yaml
+  # (image.tag "0.11.0") must come from the same one. Keep them in lockstep on every
+  # bump — bumping one alone is not a partial upgrade, it is an outage.
   #
-  # v0.9.2 is the release that carries #320 (a standing 👎 bypasses the coalesce
-  # cooldown), #321 (Hubble Relay TLS floor pinned to 1.2) and #322 (Secret data values
-  # decoded and scrubbed payload-wide) — all three validated against a live cluster this
-  # session (load-bearing unit tests, k3d e2e 54/0, healthy in cluster).
+  # This comment previously claimed a v0.9.2 lockstep while this tag already read
+  # v0.11.0: the chart was bumped and image.tag was left behind. RunLore parses its
+  # config with KnownFields(true), so the v0.11.0 chart's `curate.sweeps` key was
+  # rejected by the v0.9.2 binary and `serve` failed closed on startup —
+  # `field sweeps not found in type config.Curate` — crashlooping both replicas
+  # for as long as the drift lasted.
   ref:
     tag: v0.11.0

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -62,7 +62,13 @@ spec:
       # the StatefulSet lands in ImagePullBackOff. This is the signed, multi-arch,
       # SBOM-attested release image; the rolling `:main` tag from build-image.yml is a
       # single-arch validation build and must not be used here.
-      tag: "0.9.2"
+      #
+      # KEEP THIS IN LOCKSTEP WITH the GitRepository tag in
+      # flux/sources/gitrepo-runlore.yaml. The chart is rendered from that ref, so a
+      # chart newer than the image emits config keys the older binary rejects:
+      # config parsing uses KnownFields(true), and 0.9.2 against the v0.11.0 chart
+      # crashlooped on `field sweeps not found in type config.Curate`.
+      tag: "0.11.0"
       pullPolicy: IfNotPresent
     serviceAccount:
       create: true


### PR DESCRIPTION
## Why a second PR

The same fix was merged to `main` in #1694 — but **`mycluster-0` does not follow `main`**. Its `flux-system` GitRepository tracks `refs/heads/chore/runlore-v0.12.0`:

```
$ kubectl -n flux-system get gitrepository flux-system -o jsonpath='{.spec.ref}'
{"name":"refs/heads/chore/runlore-v0.12.0"}
```

So the merge had no effect on the cluster, and `image.tag` on this branch is still `"0.9.2"`. This is a straight cherry-pick of `21dc4d0c` onto the ref that is actually reconciled.

## Impact (unchanged, still live)

Both RunLore replicas have been in `CrashLoopBackOff` since the cluster came up — 22 restarts each, no agent running, no investigations.

```
serve: parse config: yaml: unmarshal errors:
  line 18: field sweeps not found in type config.Curate
```

## Cause

The GitRepository for RunLore is pinned to `v0.11.0` and the chart renders from that ref, while `image.tag` stayed at `"0.9.2"`. The v0.11.0 chart emits `curate.sweeps`; RunLore parses config with `KnownFields(true)`, so the v0.9.2 binary rejected it and `serve` failed closed.

The lockstep rule was already documented in `gitrepo-runlore.yaml` — while the tag beneath it read `v0.11.0` and the image read `0.9.2`. The rule outlived the pairing it described, so this also corrects that comment and records the failure mode next to the knob.

## Verification

`ghcr.io/smana/runlore:0.11.0` confirmed present in GHCR (HTTP 200), multi-arch (`linux/amd64`, `linux/arm64`), with two attestation manifests — the signed release image the HelmRelease comment requires, not the rolling `:main` validation build.