### PR TITLE
fix(app): gate the workload on EKS Pod Identity readiness

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,10 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.5.0
+                  # PR-preview tag (#1703). MUST become `0.6.0` at merge —
+                  # validate-composition-versions expects the -prN tag on a PR
+                  # and the bare module version on main.
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.0-pr1703
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 edition = "v0.11."
-version = "0.5.0"
+version = "0.6.0"
 description = "Crossplane composition function for deploying applications with infrastructure"
 
 [dependencies]

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -520,11 +520,50 @@ _observedPDB = ocds[_name + "-pdb"]?.Resource if _name + "-pdb" in ocds else Non
 _observedGateway = ocds[_name + "-gateway"]?.Resource if _name + "-gateway" in ocds else None
 _observedNetworkPolicy = ocds[_name + "-cilium-netpol"]?.Resource if _name + "-cilium-netpol" in ocds else None
 _observedServiceAccount = ocds[_name + "-serviceaccount"]?.Resource if _name + "-serviceaccount" in ocds else None
+# The EPI is rendered under the xplane-* managed name, not the claim name.
+_observedS3PodIdentity = ocds[_managedName + "-s3-pod-identity"]?.Resource if _managedName + "-s3-pod-identity" in ocds else None
 
 # Check if Deployment is actually Available (not just created)
 # Looks for Deployment.status.conditions[type=Available, status=True]
 # Use direct field access (c?.type) instead of c.get() to avoid UndefinedType
 _deploymentReady = any_true([c?.type == "Available" and c?.status == "True" for c in _observedDeployment?.status?.conditions or []])
+
+# EKS Pod Identity admission gate (#1700)
+# ======================================
+# Pod Identity credentials (AWS_CONTAINER_CREDENTIALS_FULL_URI + the projected
+# eks-pod-identity-token volume) are injected by the EKS webhook at pod
+# ADMISSION. A pod admitted before its PodIdentityAssociation has propagated
+# gets nothing, and because the pod spec is fixed at admission NO restart ever
+# recovers it — it crashloops indefinitely against a perfectly good IAM role,
+# failing with an application-level "Access Denied" that points the investigation
+# at AWS instead of at scheduling order.
+#
+# Observed on xplane-image-gallery (2026-08-02): the composition rendered the
+# Deployment and the EPI concurrently, one replica was admitted 2s BEFORE the
+# PodIdentityAssociation object even existed and the other 1s after it reported
+# Ready (still inside webhook propagation lag). Both crashlooped for ~3h / 36
+# restarts. It reproduces on every cluster rebuild and is invisible on
+# steady-state clusters where the association long predates any pod.
+#
+# So: withhold the pod-bearing resource until the EPI reports Ready. The
+# ServiceAccount and Service are deliberately NOT gated — the
+# PodIdentityAssociation binds to the ServiceAccount, so gating it would
+# deadlock the very readiness we wait on.
+_s3PodIdentityReady = any_true([c?.type == "Ready" and c?.status == "True" for c in _observedS3PodIdentity?.status?.conditions or []])
+
+# Tracks the SAME condition that renders the EPI (see the s3Bucket block). If
+# these two ever drift the workload is either gated on an EPI that is never
+# created, or not gated when it should be.
+_podIdentityRequired = oxr.spec.s3Bucket?.enabled or False
+
+# Render when no EPI is required, OR the EPI is Ready, OR the workload is
+# already observed. The last clause is a latch: once the workload exists it is
+# never withdrawn, so a transient EPI blip cannot delete a running app. Takes
+# the raw ocds so tests exercise the exact key construction main.k relies on
+# rather than a re-implementation of it.
+_workloadShouldRender = lambda name: str, ocdsState: any, suffix: str, podIdentityRequired: bool, podIdentityReady: bool -> bool {
+    not podIdentityRequired or podIdentityReady or (name + "-" + suffix) in ocdsState
+}
 
 # Check if Service has ClusterIP assigned
 # Services are ready when they have a ClusterIP (can route traffic)
@@ -728,12 +767,22 @@ if _persistenceEnabled:
 # - worker: Deployment + ServiceAccount (no Service)
 # - cron:   CronJob + ServiceAccount (no Service)
 # The ServiceAccount is created for all types (IAM/EPI integration).
+#
+# The pod-bearing resource is additionally gated on EKS Pod Identity readiness
+# (#1700) — see _workloadShouldRender. The ServiceAccount always renders: the
+# PodIdentityAssociation binds to it, so gating it would deadlock the readiness
+# this gate waits on. The Service always renders too — it selects on labels and
+# is valid with zero endpoints, so the HTTPRoute chain stays intact.
+_workloadSuffix = "cronjob" if _isCron else "deployment"
+_renderWorkload = _workloadShouldRender(_name, ocds, _workloadSuffix, _podIdentityRequired, _s3PodIdentityReady)
+_gatedCronJob = [_cronjob] if _renderWorkload else []
+_gatedDeployment = [_deployment] if _renderWorkload else []
 if _isCron:
-    _items += [_cronjob, _serviceAccount]
+    _items += _gatedCronJob + [_serviceAccount]
 elif _isWeb:
-    _items += [_deployment, _service, _serviceAccount]
+    _items += _gatedDeployment + [_service, _serviceAccount]
 else:
-    _items += [_deployment, _serviceAccount]
+    _items += _gatedDeployment + [_serviceAccount]
 # HorizontalPodAutoscaler (Deployment-backed types only; CEL forbids on cron)
 # NOTE: Using intermediate variable to avoid function-kcl duplicate detection bug
 # See: https://github.com/crossplane-contrib/function-kcl/issues/285

--- a/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
@@ -445,3 +445,67 @@ test_container_security_defaults = lambda {
     assert _ovr.runAsNonRoot == True, "un-overridden fields keep defaults"
     assert True
 }
+
+# ---- Test: workload withheld until the S3 EKS Pod Identity is Ready (#1700) ----
+# EKS Pod Identity credentials are injected at pod ADMISSION. A pod admitted
+# before its PodIdentityAssociation has propagated gets none, and no restart ever
+# fixes it — it crashloops forever against a correctly-configured IAM role
+# (observed on xplane-image-gallery: 36 restarts, fatal "Access Denied.").
+#
+# Drives the ACTUAL decision function main.k calls, with synthetic ocds keyed
+# under the REAL composition-resource-name, so the latch branch exercises the
+# exact `<claim>-deployment` key construction rather than a re-implementation.
+# The withheld case cannot be reached through `items` because KCL's single
+# global fixture already carries `myname-deployment` in ocds (which is itself
+# the latch case, covered end-to-end by test_core_resources).
+test_workload_pod_identity_latch = lambda {
+    _n = option("params").oxr.metadata.name
+    _emptyOcds = {}
+    _ocdsWithWorkload = {k: {
+        Resource = {kind = "Deployment"}
+    } for k in [_n + "-deployment"]}
+
+    # No EPI declared ⇒ render immediately. Unchanged behaviour for every App
+    # that does not ask for AWS credentials.
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", False, False) == True, "an App without an EPI must never be gated"
+
+    # EPI declared, not yet Ready, workload never created ⇒ withhold. This is the
+    # bug: rendering here admits pods into the credential gap.
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, False) == False, "workload must be withheld until the EPI is Ready"
+
+    # EPI Ready ⇒ render.
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, True) == True, "workload renders once the EPI is Ready"
+
+    # Latch: already observed ⇒ keep rendering even if the EPI reports not-ready.
+    # A transient EPI blip must never delete a running workload.
+    assert _workloadShouldRender(_n, _ocdsWithWorkload, "deployment", True, False) == True, "an observed workload latches — never withdrawn on an EPI blip"
+
+    # Guard: an unrelated observed resource must NOT satisfy the latch (proves
+    # the suffix is load-bearing, not incidental).
+    _wrongKeyOcds = {k: {} for k in [_n + "-service"]}
+    assert _workloadShouldRender(_n, _wrongKeyOcds, "deployment", True, False) == False, "an unrelated observed resource must not latch the workload"
+
+    # The cron fork uses its own suffix and must latch on that, not on Deployment.
+    _ocdsWithCron = {k: {
+        Resource = {kind = "CronJob"}
+    } for k in [_n + "-cronjob"]}
+    assert _workloadShouldRender(_n, _ocdsWithCron, "cronjob", True, False) == True, "an observed CronJob latches under its own suffix"
+    assert _workloadShouldRender(_n, _ocdsWithCron, "deployment", True, False) == False, "a CronJob in ocds must not latch a Deployment"
+}
+
+# ---- Test: the EPI gate is driven by s3Bucket.enabled (#1700) ----
+# _podIdentityRequired must track the SAME condition that renders the EPI
+# (`oxr.spec.s3Bucket?.enabled`). If the two ever drift, either the workload is
+# gated on an EPI that is never created (permanent withhold) or it is not gated
+# when it should be (the original race).
+test_pod_identity_required_tracks_s3bucket = lambda {
+    _oxr = option("params").oxr
+    _epis = [r for r in items if r.kind == "EPI"]
+    if _oxr.spec.s3Bucket?.enabled:
+        assert _podIdentityRequired == True, "s3Bucket.enabled ⇒ pod identity required"
+        assert len(_epis) == 1, "s3Bucket.enabled must render exactly 1 EPI, got {}".format(len(_epis))
+    else:
+        assert _podIdentityRequired == False, "no s3Bucket ⇒ pod identity not required"
+        assert len(_epis) == 0, "no s3Bucket must render no EPI"
+    assert True
+}


### PR DESCRIPTION
Closes #1700.

## The bug

EKS Pod Identity credentials — `AWS_CONTAINER_CREDENTIALS_FULL_URI` and the projected `eks-pod-identity-token` volume — are injected by the EKS webhook at pod **admission**. The composition rendered the `Deployment` and the `EPI` concurrently with nothing ordering them, so a pod admitted before its `PodIdentityAssociation` had propagated received no credentials at all. The pod spec is fixed at admission, so **no restart ever recovers it**.

Observed on `xplane-image-gallery` on the freshly rebuilt cluster:

| Event | Timestamp |
|---|---|
| `PodIdentityAssociation` object created | `07:35:51Z` |
| Pod `…-xbmpv` admitted | **`07:35:49Z`** — 2s *before* the PIA existed |
| PIA `Ready=True` | `07:35:59Z` |
| Pod `…-67lg9` admitted | **`07:36:00Z`** — 1s after Ready, inside webhook propagation lag |

Both replicas crashlooped for ~3 hours / 36 restarts on:

```
{"level":"fatal","error":"Access Denied.","message":"Failed to connect to storage"}
```

…while the `EPI`, the `PodIdentityAssociation`, the IAM policy and the `Bucket` all reported healthy and correctly scoped. **Every signal pointed at AWS; the fault was scheduling order.** It reproduces on every cluster rebuild and is invisible on steady-state clusters where the association long predates any pod.

`automountServiceAccountToken: false` was ruled out with a controlled admission test — same ServiceAccount, same namespace, injection happens either way. The only variable that mattered was *when* the pod was admitted.

## The fix

Withhold the pod-bearing resource until the EPI reports `Ready`, and **latch** once it exists so a transient EPI blip can never delete a running workload:

```kcl
_workloadShouldRender = lambda name: str, ocdsState: any, suffix: str, podIdentityRequired: bool, podIdentityReady: bool -> bool {
    not podIdentityRequired or podIdentityReady or (name + "-" + suffix) in ocdsState
}
```

Same shape as the `AIGatewayRoute` latch in the `inference-service` composition (SPEC-002 FR-002), including taking the raw `ocds` so tests exercise the real key construction rather than a re-implementation.

Two things are deliberately **not** gated:

- **ServiceAccount** — the `PodIdentityAssociation` binds to it. Gating it would deadlock the very readiness the gate waits on.
- **Service** — it selects on labels and is valid with zero endpoints, so the HTTPRoute chain stays intact.

Apps without `s3Bucket.enabled` are entirely unaffected: `_podIdentityRequired` is false and the gate short-circuits on the first clause.

## Verification

**`kcl test` → 32/32** (30 pre-existing + 2 new). Both new tests were written first and watched fail (`name '_podIdentityRequired' is not defined`) before any implementation.

`test_workload_pod_identity_latch` drives the real decision function and covers: no-EPI passthrough, withhold-until-ready, render-on-ready, the latch, a wrong-key guard proving the suffix is load-bearing, and the cron fork latching on its own suffix.

`test_pod_identity_required_tracks_s3bucket` pins `_podIdentityRequired` to the same condition that renders the EPI, so the two cannot silently drift.

**Withhold path proven end-to-end** through `kcl run` against a fixture with the observed Deployment removed from `ocds`:

| Fixture | Top-level `Deployment` rendered? |
|---|---|
| stock (`myname-deployment` in `ocds`) | ✅ present — latch |
| no observed Deployment, EPI not ready | ❌ **absent** — withheld |

`ServiceAccount`, `Service` and `EPI` render in both, confirming the gate is scoped to the pod-bearing resource only.

**`./scripts/validate-kcl-compositions.sh` → exit 0**, formatting correct and syntax valid across all 5 compositions. Its `crossplane render` stage was skipped locally (Docker not running — it skips for all 5 modules equally, unrelated to this change); CI covers it.

## Merge sequence

`kcl.mod` is bumped `0.5.0` → `0.6.0`. Per the usual flow, CI on this PR publishes `0.6.0-pr<N>`; `app-composition.yaml` still points at `0.5.0` and needs repointing to the PR tag to exercise this on a cluster, then to `0.6.0` on merge.

## Note

During the withhold window an `HorizontalPodAutoscaler`/`PodDisruptionBudget` may briefly reference a Deployment that does not exist yet. Both self-heal on the next reconcile once the workload renders, and gating them too would widen this change beyond the credential fault — left alone deliberately.
