### PR TITLE
feat(runlore): track main so the cluster exercises unreleased work

### DIFF
--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,16 +6,15 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # Pinned to the v0.11.0 release: the chart is rendered from THIS tag, and the signed,
-  # multi-arch release image in observability/base/runlore/helmrelease.yaml
-  # (image.tag "0.11.0") must come from the same one. Keep them in lockstep on every
-  # bump — bumping one alone is not a partial upgrade, it is an outage.
+  # TRACKING main, deliberately: this cluster is where the latest RunLore work is
+  # exercised before a release is cut. The chart is rendered from this ref and the
+  # image below is the matching rolling :main build, so the two still move together —
+  # which is the invariant that matters. Bumping one alone is not a partial upgrade,
+  # it is an outage: RunLore parses config with KnownFields(true), so a chart newer
+  # than its binary emits keys the binary rejects and `serve` fails closed. That is
+  # exactly what a v0.11.0 chart against a 0.9.2 image did — crashlooping both
+  # replicas on `field sweeps not found in type config.Curate`.
   #
-  # This comment previously claimed a v0.9.2 lockstep while this tag already read
-  # v0.11.0: the chart was bumped and image.tag was left behind. RunLore parses its
-  # config with KnownFields(true), so the v0.11.0 chart's `curate.sweeps` key was
-  # rejected by the v0.9.2 binary and `serve` failed closed on startup —
-  # `field sweeps not found in type config.Curate` — crashlooping both replicas
-  # for as long as the drift lasted.
+  # Pin both back to a release tag when this cluster should mirror production.
   ref:
-    tag: v0.11.0
+    branch: main

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -57,19 +57,22 @@ spec:
       # the 0.9.0 binary behind the 0.9.1 chart — none of that release's fixes were live,
       # and nothing failed to say so. Move the two together, always.
       #
-      # NO leading "v". GoReleaser (Smana/runlore release-binaries.yml) publishes the
-      # release image as `{{ .Version }}` — 0.9.2, not v0.9.2 — so a `v` prefix 404s and
-      # the StatefulSet lands in ImagePullBackOff. This is the signed, multi-arch,
-      # SBOM-attested release image; the rolling `:main` tag from build-image.yml is a
-      # single-arch validation build and must not be used here.
+      # The rolling :main build from build-image.yml, matching the GitRepository ref
+      # in flux/sources/gitrepo-runlore.yaml — the two MUST move together.
       #
-      # KEEP THIS IN LOCKSTEP WITH the GitRepository tag in
-      # flux/sources/gitrepo-runlore.yaml. The chart is rendered from that ref, so a
-      # chart newer than the image emits config keys the older binary rejects:
-      # config parsing uses KnownFields(true), and 0.9.2 against the v0.11.0 chart
-      # crashlooped on `field sweeps not found in type config.Curate`.
-      tag: "0.11.0"
-      pullPolicy: IfNotPresent
+      # This is a deliberate exception to the usual rule, and the trade is worth
+      # stating: :main is single-arch (linux/amd64 only — fine for these c7i-flex
+      # nodes) and carries neither the cosign signature nor the SBOM attestation that
+      # the tagged release images do. It is here because this cluster exercises
+      # unreleased work; a cluster mirroring production should pin a release tag.
+      #
+      # Release tags carry NO leading "v" — GoReleaser publishes `{{ .Version }}`,
+      # so 0.11.0 not v0.11.0, and a `v` prefix 404s into ImagePullBackOff.
+      #
+      # pullPolicy MUST be Always with a rolling tag, or a restarted pod keeps
+      # whatever layer the node already cached and silently runs stale code.
+      tag: "main"
+      pullPolicy: Always
     serviceAccount:
       create: true
       # Must match the SA bound by the xplane-runlore EKS Pod Identity (security/base/epis/runlore.yaml).


### PR DESCRIPTION
## What

Points **both** the GitRepository ref and `image.tag` at `main`, so `mycluster-0` runs the latest RunLore without a release being cut.

| | before | after |
|---|---|---|
| `flux/sources/gitrepo-runlore.yaml` | `tag: v0.11.0` | `branch: main` |
| `helmrelease.yaml` `image.tag` | `"0.11.0"` | `"main"` |
| `image.pullPolicy` | `IfNotPresent` | `Always` |

Based on `chore/runlore-v0.12.0` — the ref this cluster actually reconciles, not `main` of this repo. (A fix merged to this repo's `main` earlier today had no effect on the cluster for exactly that reason.)

## Why both refs move together

The chart is rendered from the GitRepository ref and the binary comes from `image.tag`. Bumping one alone is **not a partial upgrade, it is an outage**: RunLore parses config with `KnownFields(true)`, so a chart newer than its binary emits keys the binary rejects and `serve` fails closed.

That is not hypothetical — it is what happened on this cluster this morning. The GitRepository had been bumped to `v0.11.0` while `image.tag` stayed at `0.9.2`, and both replicas sat in `CrashLoopBackOff` for 93 minutes on:

```
serve: parse config: yaml: unmarshal errors:
  line 18: field sweeps not found in type config.Curate
```

Tracking `main` on both sides keeps them in lockstep by construction.

## `pullPolicy: Always` is not optional here

With a rolling tag, `IfNotPresent` means a restarted pod keeps whatever layer the node already cached and silently runs stale code — the failure mode being fixed, in a form that is harder to see.

## The trade, stated plainly

This is a **deliberate exception** to the release-image policy, and the comment in `helmrelease.yaml` previously said the opposite (`the rolling :main tag … must not be used here`). Rather than leave the file contradicting itself, the comment is rewritten to say what is now true:

- `:main` is **single-arch** (`linux/amd64` only — verified against GHCR; fine for these `c7i-flex` nodes).
- It carries **neither the cosign signature nor the SBOM attestation** that tagged release images do.
- It is here because this cluster exercises unreleased work. **A cluster mirroring production should pin both refs back to a release tag** — the comment says so.

## What lands on the cluster

Everything merged to RunLore's `main` today, including:

- the recall trust gate failing closed when the adversarial verify pass cannot run (#395) — previously a poisoned KB entry could be served as a confident answer during a model outage
- the keyless demo and zero-config `lore investigate` (#396)
- the published cost-per-investigation table and the honest recall scorecard (#397)