### PR TITLE
chore(app): pin the composition to the released 0.6.0 module

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,10 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  # PR-preview tag (#1703). MUST become `0.6.0` at merge —
-                  # validate-composition-versions expects the -prN tag on a PR
-                  # and the bare module version on main.
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.0-pr1703
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.0
 
         - step: ready
           functionRef:


### PR DESCRIPTION
Follow-up to #1703.

That PR had to merge with the PR-preview tag `0.6.0-pr1703` in place — `validate-composition-versions` requires the `-prN` tag while a PR is open, and the bare `0.6.0` did not exist yet (it is published by the workflow run on `main`, which the merge itself triggers). On `main` the same check flips to expecting the bare version, so it went red on the merge commit. This flips the pin and turns it green.

Sequencing was deliberate rather than an oversight: pinning `0.6.0` before the merge would have pointed the composition at a tag that did not exist.

**Verified the tag is real and anonymously pullable** — `function-kcl` pulls without credentials, so this is the check that matters:

```
GET ghcr.io/v2/smana/cloud-native-ref/crossplane-app/manifests/0.6.0  ->  HTTP 200
```

Also drops the now-stale PR-preview comment. Preview tags are overwritten by subsequent pushes, so `main` must never keep one.

No behaviour change — `0.6.0` and `0.6.0-pr1703` are the same module content.