### PR TITLE
fix(homepage): match PEV2 on its actual xplane-pev2 label

### DIFF
--- a/tooling/base/homepage/helmrelease.yaml
+++ b/tooling/base/homepage/helmrelease.yaml
@@ -153,7 +153,13 @@ spec:
                 description: PostgreSQL Execution Plan Visualizer
                 icon: postgres.png
                 namespace: tooling
-                app: pev2
+                # Homepage matches on `app.kubernetes.io/name`, which the App
+                # composition sets to the CLAIM name — and this claim is
+                # `xplane-pev2`. Plain `pev2` matches 0 pods, so the card showed
+                # an unknown/degraded status while the workload was perfectly
+                # healthy. Entries whose claim carries the prefix must repeat it
+                # here (cf. xplane-podinfo, xplane-image-gallery below).
+                app: xplane-pev2
 
         - Observability:
             - Grafana:


### PR DESCRIPTION
The PEV2 card showed a degraded/unknown status while the workload was healthy the entire time.

Homepage resolves a card's `app:` against the `app.kubernetes.io/name` label. The App composition sets that label to the **claim** name, and this claim is `xplane-pev2` — so the configured `app: pev2` matched nothing:

```
ns=tooling app=pev2         -> 0 pods      ← the card had nothing to report
ns=tooling app=xplane-pev2  -> 1 pod, running
ns=tooling app=headlamp     -> 1 pod, running   ← why Headlamp was green
```

Meanwhile `Deployment xplane-pev2` was `1/1` and the XR `Synced=True Ready=True`. A dashboard that cries wolf is worse than no dashboard, so this is worth fixing rather than living with.

## Audited the rest

Checked all 14 `namespace`/`app` pairs in the config against the live cluster. This was the **only** genuine mismatch. `xplane-openwebui` also resolves to 0 pods, but that is correct — it belongs to the LLM platform, whose umbrella Kustomization is suspended by design (`suspended=true`), so it will resolve once that is enabled.

Added a comment on the entry explaining the prefix rule, since `xplane-podinfo` and `xplane-image-gallery` already get it right and the inconsistency is what made this easy to miss.

## Verification

`./scripts/validate-manifests.sh` → `Valid: 1189, Invalid: 0, Skipped: 0`, all gates passed, exit 0.