### PR TITLE
feat(apps): deploy wizard-e2e-platform to platform

### DIFF
--- a/apps/platform/wizard-e2e-platform/app.yaml
+++ b/apps/platform/wizard-e2e-platform/app.yaml
@@ -1,0 +1,19 @@
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: App
+metadata:
+  name: wizard-e2e-platform
+  namespace: apps
+spec:
+  image:
+    repository: ghcr.io/stefanprodan/podinfo
+    tag: 6.9.2
+  route:
+    enabled: true
+    hostname: wizard-1
+    internetFacing: false
+    rules:
+    - backendPort: 9898
+      pathPrefix: /
+  service:
+    port: 9898
+  type: web

--- a/apps/platform/wizard-e2e-platform/kustomization.yaml
+++ b/apps/platform/wizard-e2e-platform/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- app-wizard
-- ./wizard-e2e-platform
+- app.yaml


### PR DESCRIPTION
## App: `wizard-e2e-platform`

Opened via the App Wizard.

- **Stack**: `platform` (namespace `apps`, owner `platform-engineering`)
