### PR TITLE
fix(gapi): allow HTTPRoutes from the demo namespace

### DIFF
--- a/infrastructure/base/gapi/platform-tailscale-general-gateway.yaml
+++ b/infrastructure/base/gapi/platform-tailscale-general-gateway.yaml
@@ -25,8 +25,14 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
+                # Every namespace an App claim can target must be listed here, or
+                # its HTTPRoute is rejected `NotAllowedByListeners` and the App XR
+                # never goes Ready — the workload runs fine, only the route is
+                # refused, so it reads as a broken app rather than a gateway ACL.
+                # Keep in lockstep with the stacks in apps/stacks.yaml.
                 values:
                   - apps
+                  - demo
                   - envoy-ai-gateway-system
                   - envoy-gateway-system
                   - observability


### PR DESCRIPTION
Found closing out #1590 — creating an app through the App Wizard on **each** stack. The `platform` one went Ready; the `demo` one did not.

## What is broken

The wizard offers `demo` as a stack (`apps/stacks.yaml`: *"Sandbox stack for demos and first-app onboarding"*), but the general Tailscale gateway's listener allow-list omits that namespace:

```
listener https allows: apps, envoy-ai-gateway-system, envoy-gateway-system, observability, tooling
```

So any demo app requesting external access has its route refused:

```
Accepted=False [NotAllowedByListeners]:
  HTTPRoute is not allowed to attach to this Gateway due to namespace selector restrictions
```

## Why it is worse than it looks

The Deployment, Service and ServiceAccount all come up **healthy** — only the HTTPRoute is rejected. But the App XR gates readiness on the route, so the claim sits at:

```
Ready=False [Creating]: Unready resources: wizard-e2e-demo-httproute
```

…indefinitely, while `kubectl get deploy` shows `1/1`. It reads as a broken app; the cause is a gateway ACL two layers away. A developer onboarding via the sandbox stack — the exact audience the stack exists for — hits this on their first app and has no way to tell why.

## Why it was never caught

The one pre-existing demo app (`apps/demo/podinfo`) declares **no route block**, so nothing had ever asked this gateway to attach a demo route. This is precisely the gap #1590 was written to find:

> Repeat for **both** stacks (`platform` and `demo`) — `demo` has never had an app in it

## The change

Adds `demo` to the allow-list, plus a comment tying it to `apps/stacks.yaml` — the invariant is non-obvious and silent when violated: **every namespace an App claim can target must appear here.**

Access scope is unchanged in kind. This gateway is `tag:k8s` (all tailnet members, per the Tailscale ACL split in CLAUDE.md) and `demo` is explicitly the lower-review-bar sandbox stack, so its apps being privately reachable is the intent — not a widening of exposure. Nothing is made internet-facing.

## Verification

`./scripts/validate-manifests.sh` → `Valid: 1193, Invalid: 0, Skipped: 0`, all gates passed, exit 0.

Post-merge I will confirm the demo app's HTTPRoute flips to `Accepted=True` and its XR to `Ready=True` on the live cluster — the last open box on #1590.