### PR TITLE
fix(app): do not gate the workload during crossplane render

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.0
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.1-pr1713
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 edition = "v0.11."
-version = "0.6.0"
+version = "0.6.1"
 description = "Crossplane composition function for deploying applications with infrastructure"
 
 [dependencies]

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -556,13 +556,31 @@ _s3PodIdentityReady = any_true([c?.type == "Ready" and c?.status == "True" for c
 # created, or not gated when it should be.
 _podIdentityRequired = oxr.spec.s3Bucket?.enabled or False
 
-# Render when no EPI is required, OR the EPI is Ready, OR the workload is
-# already observed. The last clause is a latch: once the workload exists it is
-# never withdrawn, so a transient EPI blip cannot delete a running app. Takes
-# the raw ocds so tests exercise the exact key construction main.k relies on
-# rather than a re-implementation of it.
-_workloadShouldRender = lambda name: str, ocdsState: any, suffix: str, podIdentityRequired: bool, podIdentityReady: bool -> bool {
-    not podIdentityRequired or podIdentityReady or (name + "-" + suffix) in ocdsState
+# Is there a cluster behind this render at all?
+#
+# `crossplane render` — which the App Wizard's preview shells out to — is
+# offline: ocds is empty and no EPI will EVER report Ready. From inside KCL that
+# is indistinguishable from "first reconcile on a live cluster", which is
+# precisely the case the gate below exists to catch. Without a discriminator the
+# gate withholds the Deployment from every preview of an s3Bucket app, so the
+# wizard tells developers their claim creates no workload.
+#
+# The tell is provenance, not state: `crossplane render` is handed a
+# hand-authored XR the API server has never persisted, so it carries no
+# metadata.uid. Every XR read back from a cluster has one.
+# Membership test, not `oxr.metadata?.uid != None`: KCL's optional access yields
+# Undefined for a missing key, and `Undefined == None` is False — so the `!= None`
+# form reports EVERY render as live and silently disables this escape hatch.
+_isLiveReconcile = "uid" in oxr.metadata and (oxr.metadata.uid or "") != ""
+
+# Render when this is not a live reconcile (nothing to gate on — see above), OR
+# no EPI is required, OR the EPI is Ready, OR the workload is already observed.
+# The last clause is a latch: once the workload exists it is never withdrawn, so
+# a transient EPI blip cannot delete a running app. Takes the raw ocds so tests
+# exercise the exact key construction main.k relies on rather than a
+# re-implementation of it.
+_workloadShouldRender = lambda name: str, ocdsState: any, suffix: str, podIdentityRequired: bool, podIdentityReady: bool, liveReconcile: bool -> bool {
+    not liveReconcile or not podIdentityRequired or podIdentityReady or (name + "-" + suffix) in ocdsState
 }
 
 # Check if Service has ClusterIP assigned
@@ -774,7 +792,7 @@ if _persistenceEnabled:
 # this gate waits on. The Service always renders too — it selects on labels and
 # is valid with zero endpoints, so the HTTPRoute chain stays intact.
 _workloadSuffix = "cronjob" if _isCron else "deployment"
-_renderWorkload = _workloadShouldRender(_name, ocds, _workloadSuffix, _podIdentityRequired, _s3PodIdentityReady)
+_renderWorkload = _workloadShouldRender(_name, ocds, _workloadSuffix, _podIdentityRequired, _s3PodIdentityReady, _isLiveReconcile)
 _gatedCronJob = [_cronjob] if _renderWorkload else []
 _gatedDeployment = [_deployment] if _renderWorkload else []
 if _isCron:

--- a/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
@@ -467,30 +467,30 @@ test_workload_pod_identity_latch = lambda {
 
     # No EPI declared ⇒ render immediately. Unchanged behaviour for every App
     # that does not ask for AWS credentials.
-    assert _workloadShouldRender(_n, _emptyOcds, "deployment", False, False) == True, "an App without an EPI must never be gated"
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", False, False, True) == True, "an App without an EPI must never be gated"
 
     # EPI declared, not yet Ready, workload never created ⇒ withhold. This is the
     # bug: rendering here admits pods into the credential gap.
-    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, False) == False, "workload must be withheld until the EPI is Ready"
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, False, True) == False, "workload must be withheld until the EPI is Ready"
 
     # EPI Ready ⇒ render.
-    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, True) == True, "workload renders once the EPI is Ready"
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, True, True) == True, "workload renders once the EPI is Ready"
 
     # Latch: already observed ⇒ keep rendering even if the EPI reports not-ready.
     # A transient EPI blip must never delete a running workload.
-    assert _workloadShouldRender(_n, _ocdsWithWorkload, "deployment", True, False) == True, "an observed workload latches — never withdrawn on an EPI blip"
+    assert _workloadShouldRender(_n, _ocdsWithWorkload, "deployment", True, False, True) == True, "an observed workload latches — never withdrawn on an EPI blip"
 
     # Guard: an unrelated observed resource must NOT satisfy the latch (proves
     # the suffix is load-bearing, not incidental).
     _wrongKeyOcds = {k: {} for k in [_n + "-service"]}
-    assert _workloadShouldRender(_n, _wrongKeyOcds, "deployment", True, False) == False, "an unrelated observed resource must not latch the workload"
+    assert _workloadShouldRender(_n, _wrongKeyOcds, "deployment", True, False, True) == False, "an unrelated observed resource must not latch the workload"
 
     # The cron fork uses its own suffix and must latch on that, not on Deployment.
     _ocdsWithCron = {k: {
         Resource = {kind = "CronJob"}
     } for k in [_n + "-cronjob"]}
-    assert _workloadShouldRender(_n, _ocdsWithCron, "cronjob", True, False) == True, "an observed CronJob latches under its own suffix"
-    assert _workloadShouldRender(_n, _ocdsWithCron, "deployment", True, False) == False, "a CronJob in ocds must not latch a Deployment"
+    assert _workloadShouldRender(_n, _ocdsWithCron, "cronjob", True, False, True) == True, "an observed CronJob latches under its own suffix"
+    assert _workloadShouldRender(_n, _ocdsWithCron, "deployment", True, False, True) == False, "a CronJob in ocds must not latch a Deployment"
 }
 
 # ---- Test: the EPI gate is driven by s3Bucket.enabled (#1700) ----
@@ -507,5 +507,42 @@ test_pod_identity_required_tracks_s3bucket = lambda {
     else:
         assert _podIdentityRequired == False, "no s3Bucket ⇒ pod identity not required"
         assert len(_epis) == 0, "no s3Bucket must render no EPI"
+    assert True
+}
+
+# ---- Test: the admission gate must NOT fire during `crossplane render` (#1700 follow-up) ----
+# `crossplane render` — which the App Wizard's preview shells out to — has no
+# cluster behind it: ocds is empty and no EPI will EVER report Ready. The #1700
+# gate therefore withheld the Deployment from every preview of an s3Bucket app,
+# so the wizard told developers their claim creates no workload. From inside KCL
+# that state is indistinguishable from "first reconcile on a real cluster" — the
+# case the gate exists for — unless we look at whether the XR came from the API
+# server at all.
+test_workload_renders_in_preview = lambda {
+    _n = option("params").oxr.metadata.name
+    _emptyOcds = {}
+
+    # Live cluster: EPI required, not ready, nothing observed ⇒ withhold. This is
+    # #1700 and must keep working.
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, False, True) == False, "on a live cluster the workload is still withheld until the EPI is Ready"
+
+    # Identical inputs, but not a live reconcile ⇒ render. Withholding here would
+    # make the preview lie about what the claim creates.
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, False, False) == True, "crossplane render must show the workload — there is no cluster to gate on"
+
+    # Render mode must not resurrect a workload that a live cluster is gating,
+    # nor change any of the already-passing branches.
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", False, False, False) == True, "no EPI required renders in preview too"
+    assert _workloadShouldRender(_n, _emptyOcds, "deployment", True, True, True) == True, "EPI ready still renders on a live cluster"
+}
+
+# ---- Test: live-reconcile detection keys off metadata.uid ----
+# The settings fixture mirrors `crossplane render` input: a hand-authored XR the
+# API server has never persisted, so it carries no metadata.uid. Every XR read
+# back from a cluster has one. If this ever inverts, the gate silently stops
+# protecting first reconciles — which is the whole point of #1700.
+test_live_reconcile_detection = lambda {
+    assert _isLiveReconcile == False, "fixture XR has no metadata.uid, so this is render mode"
+    assert not ("uid" in option("params").oxr.metadata), "fixture precondition: no uid in the render fixture"
     assert True
 }


### PR DESCRIPTION
Fixes a regression I introduced in #1703.

## The regression

#1700 withholds the pod-bearing resource until the EKS Pod Identity reports `Ready`. That is correct on a cluster and wrong everywhere else.

`crossplane render` — which the App Wizard's **preview** shells out to — is offline. `ocds` is empty and no EPI will *ever* report Ready. So the gate withheld the Deployment from every preview of an `s3Bucket` app, and the wizard told developers their claim creates no workload. Caught while closing out #1590.

## Why the obvious fix doesn't work

From inside KCL, "offline render" and "first reconcile on a live cluster" are **indistinguishable by state**: both have empty `ocds` and no ready EPI. And the second is precisely the case #1700 exists to catch, so it cannot simply be relaxed.

The discriminator has to be **provenance, not state**. `crossplane render` is handed a hand-authored XR the API server has never persisted, so it carries no `metadata.uid`; every XR read back from a cluster has one:

```
render fixture oxr.metadata:  {name, namespace}
live XR       oxr.metadata:  {name, namespace, uid: e1c5a2b2-…, creationTimestamp: …}
```

## A KCL trap worth flagging

The natural spelling is wrong:

```kcl
oxr.metadata?.uid != None     # ← reports EVERY render as live
```

KCL's optional access yields `Undefined` for a missing key, and `Undefined == None` is **False**. That form silently disables the escape hatch entirely. I verified the semantics in isolation before relying on them:

```
m = {name = "x"}
m?.uid == None       -> False
m?.uid == Undefined  -> True
"uid" in m           -> false
```

So the check is a membership test, matching the `... in ocds` idiom already used throughout this module.

## Verification

**TDD.** Both new tests were written first and watched fail (`name '_isLiveReconcile' is not defined`). `kcl test` → **34/34** (32 pre-existing + 2 new). The existing #1700 assertions were updated to pass `liveReconcile=True` — they are about cluster behaviour and their meaning is unchanged.

`test_live_reconcile_detection` pins the discriminator itself, so if the fixture ever gains a uid (or the semantics invert) the gate does not silently stop protecting first reconciles.

**Proven end to end** through `kcl run` on two fixtures identical except for `oxr.metadata.uid` — `s3Bucket` enabled, no observed Deployment in either:

| Fixture | Deployments rendered |
|---|---|
| preview (no uid) | **1** — regression fixed |
| live (uid set) | **0** — #1700 gate intact |

`./scripts/validate-kcl-compositions.sh` → exit 0, all 5 modules format-clean and syntax-valid.

## Merge sequence

`kcl.mod` bumped `0.6.0` → `0.6.1`. CI on this PR publishes `0.6.1-pr<N>`; `app-composition.yaml` needs repointing to that tag for the PR check to pass, then to `0.6.1` on merge — same dance as #1703/#1706, since the bare tag does not exist until the merge to `main` publishes it.
