### PR TITLE
chore(app): pin the composition to the released 0.6.1 module

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.1-pr1713
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.1
 
         - step: ready
           functionRef:


### PR DESCRIPTION
Follow-up to #1713, same sequencing as #1706 followed #1703.

That PR had to merge with `0.6.1-pr1713` in place: `validate-composition-versions` requires the `-prN` tag while a PR is open, and the bare `0.6.1` does not exist until the workflow runs on `main` — which the merge itself triggers. On `main` the check flips to expecting the bare version, so it went red on the merge commit. This turns it green.

**Verified the tag is real and anonymously pullable** — `function-kcl` pulls without credentials, so this is the check that matters:

```
GET ghcr.io/v2/smana/cloud-native-ref/crossplane-app/manifests/0.6.1  ->  HTTP 200
```

Also drops the stale preview comment. Preview tags are overwritten by subsequent pushes, so `main` must never keep one.

No behaviour change — `0.6.1` and `0.6.1-pr1713` are the same module content.