### PR TITLE
fix(app): stop the s3Bucket set emitting duplicate composed resources

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.1
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.6.2-pr1715
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 edition = "v0.11."
-version = "0.6.1"
+version = "0.6.2"
 description = "Crossplane composition function for deploying applications with infrastructure"
 
 [dependencies]

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -583,6 +583,25 @@ _workloadShouldRender = lambda name: str, ocdsState: any, suffix: str, podIdenti
     not liveReconcile or not podIdentityRequired or podIdentityReady or (name + "-" + suffix) in ocdsState
 }
 
+# The s3Bucket set, assembled in ONE expression.
+#
+# This used to be `_s3BucketResources = [Bucket]`, then `+= [BucketVersioning]`
+# under a conditional, then `+= [EPI]`. Under function-kcl that mutation shape
+# re-evaluates and emits the Bucket and the EPI TWICE whenever the middle `+=`
+# is skipped — i.e. whenever versioning is off — and crossplane rejects the
+# render outright:
+#
+#   multiple composed resources with name "<app>-s3-bucket" returned:
+#   Bucket/<app>-s3-bucket and Bucket/<app>-s3-bucket
+#
+# Same class as function-kcl#285, which the externalSecrets block already guards
+# against by building its list in a single comprehension. It stayed latent
+# because every s3Bucket claim in the repo sets versioning: true — but the App
+# Wizard's default is off, so the first S3 app created through the form hit it.
+_s3ResourceList = lambda bucket: [any], versioningResource: [any], epi: [any], versioningEnabled: bool -> [any] {
+    bucket + (versioningResource if versioningEnabled else []) + epi
+}
+
 # Check if Service has ClusterIP assigned
 # Services are ready when they have a ClusterIP (can route traffic)
 _serviceReady = _observedService?.spec?.clusterIP != None
@@ -1111,7 +1130,7 @@ if oxr.spec.s3Bucket?.enabled:
     _bucketName = (oxr.spec.s3Bucket.region or envConfig.region) + "-ogenki-" + _name
     _bucketArn = "arn:aws:s3:::" + _bucketName
 
-    _s3BucketResources = [
+    _s3Bucket = [
         {
             apiVersion = "s3.aws.m.upbound.io/v1beta1"
             kind = "Bucket"
@@ -1135,49 +1154,48 @@ if oxr.spec.s3Bucket?.enabled:
         }
     ]
 
-    # Add BucketVersioning as separate resource if versioning is enabled
-    if oxr.spec.s3Bucket.versioning:
-        _s3BucketResources += [{
-            apiVersion = "s3.aws.m.upbound.io/v1beta1"
-            kind = "BucketVersioning"
-            metadata = _metadata("s3-bucket-versioning")
-            spec = {
-                providerConfigRef = {
-                    name = oxr.spec.s3Bucket.providerConfigRef?.name or "default"
-                    kind = "ClusterProviderConfig"
+    # BucketVersioning, rendered only when versioning is enabled. Kept as its own
+    # list so the final set is ONE concatenation — see _s3ResourceList.
+    _s3BucketVersioning = [{
+        apiVersion = "s3.aws.m.upbound.io/v1beta1"
+        kind = "BucketVersioning"
+        metadata = _metadata("s3-bucket-versioning")
+        spec = {
+            providerConfigRef = {
+                name = oxr.spec.s3Bucket.providerConfigRef?.name or "default"
+                kind = "ClusterProviderConfig"
+            }
+            forProvider = {
+                region = oxr.spec.s3Bucket.region or envConfig.region
+                bucketRef = {
+                    name = _name + "-s3-bucket"
                 }
-                forProvider = {
-                    region = oxr.spec.s3Bucket.region or envConfig.region
-                    bucketRef = {
-                        name = _name + "-s3-bucket"
-                    }
-                    versioningConfiguration = {
-                        status = "Enabled"
-                    }
+                versioningConfiguration = {
+                    status = "Enabled"
                 }
             }
-        }]
+        }
+    }]
 
-    # Add EKS Pod Identity for S3 access
-    _s3BucketResources += [
-        # EKS Pod Identity for S3 access
-        {
-            apiVersion = "cloud.ogenki.io/v1alpha1"
-            kind = "EPI"
-            metadata = _managedMetadata("s3-pod-identity")
-            spec = {
-                serviceAccount = {
-                    name = _name
-                    namespace = _namespace
-                }
-                clusters = [{
-                    name = envConfig.clusterName
-                    region = envConfig.region
-                }]
-                if oxr.spec.s3Bucket.permissions == "custom" and oxr.spec.s3Bucket.customPolicy:
-                    policyDocument = oxr.spec.s3Bucket.customPolicy
-                elif oxr.spec.s3Bucket.permissions == "readwrite":
-                    policyDocument = """{
+# EKS Pod Identity for S3 access
+_s3Epi = [
+    {
+        apiVersion = "cloud.ogenki.io/v1alpha1"
+        kind = "EPI"
+        metadata = _managedMetadata("s3-pod-identity")
+        spec = {
+            serviceAccount = {
+                name = _name
+                namespace = _namespace
+            }
+            clusters = [{
+                name = envConfig.clusterName
+                region = envConfig.region
+            }]
+            if oxr.spec.s3Bucket.permissions == "custom" and oxr.spec.s3Bucket.customPolicy:
+                policyDocument = oxr.spec.s3Bucket.customPolicy
+            elif oxr.spec.s3Bucket.permissions == "readwrite":
+                policyDocument = """{
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -1198,8 +1216,8 @@ if oxr.spec.s3Bucket?.enabled:
         }
     ]
 }"""
-                elif oxr.spec.s3Bucket.permissions == "readonly":
-                    policyDocument = """{
+            elif oxr.spec.s3Bucket.permissions == "readonly":
+                policyDocument = """{
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -1218,10 +1236,11 @@ if oxr.spec.s3Bucket?.enabled:
         }
     ]
 }"""
-            }
         }
-    ]
-    _items += _s3BucketResources
+    }
+]
+_s3BucketResources = _s3ResourceList(_s3Bucket, _s3BucketVersioning, _s3Epi, oxr.spec.s3Bucket.versioning or False)
+_items += _s3BucketResources
 
 # External Secrets
 # Create ExternalSecrets from AWS Secrets Manager using dataFrom pattern

--- a/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main_test.k
@@ -546,3 +546,45 @@ test_live_reconcile_detection = lambda {
     assert not ("uid" in option("params").oxr.metadata), "fixture precondition: no uid in the render fixture"
     assert True
 }
+
+# ---- Test: the s3Bucket set never emits a duplicate composed resource ----
+# The block used to build `_s3BucketResources` by mutation — `= [Bucket]`, then
+# `+= [BucketVersioning]` under a conditional, then `+= [EPI]`. Under function-kcl
+# that shape re-evaluates and emits the Bucket and the EPI TWICE when the middle
+# `+=` is skipped (i.e. versioning off), which crossplane rejects outright:
+#
+#   multiple composed resources with name "<app>-s3-bucket" returned:
+#   Bucket/<app>-s3-bucket and Bucket/<app>-s3-bucket
+#
+# Latent since nothing in the repo sets versioning off — but it is the wizard's
+# default, so the first S3 app created through the form hit it. Same class as
+# function-kcl#285, which the externalSecrets block below already guards against.
+#
+# Driven through the real constructor rather than `items`, because KCL's single
+# global fixture pins versioning=true and cannot encode the failing case.
+test_s3_resources_never_duplicate = lambda {
+    _b = {kind = "Bucket", metadata = {name = "x-s3-bucket"}}
+    _v = {kind = "BucketVersioning", metadata = {name = "x-s3-bucket-versioning"}}
+    _e = {kind = "EPI", metadata = {name = "x-s3-pod-identity"}}
+    _off = _s3ResourceList([_b], [_v], [_e], False)
+    _on = _s3ResourceList([_b], [_v], [_e], True)
+    assert len(_off) == 2, "versioning off ⇒ Bucket + EPI only, got {}".format(len(_off))
+    assert len(_on) == 3, "versioning on ⇒ Bucket + BucketVersioning + EPI, got {}".format(len(_on))
+    assert len([r for r in _off if r.kind == "Bucket"]) == 1, "exactly one Bucket with versioning off"
+    assert len([r for r in _on if r.kind == "Bucket"]) == 1, "exactly one Bucket with versioning on"
+    assert len([r for r in _off if r.kind == "EPI"]) == 1, "exactly one EPI with versioning off"
+    assert len([r for r in _on if r.kind == "BucketVersioning"]) == 1, "versioning on adds exactly one BucketVersioning"
+    assert len([r for r in _off if r.kind == "BucketVersioning"]) == 0, "versioning off adds no BucketVersioning"
+}
+
+# ---- Test: rendered s3 resources carry unique composition-resource-names ----
+# End-to-end guard on the fixture (versioning=true). Crossplane keys composed
+# resources by that annotation, so a repeat is a hard render failure, not a warning.
+test_s3_items_unique_names = lambda {
+    if option("params").oxr.spec.s3Bucket?.enabled:
+        _names = [r.metadata.annotations["krm.kcl.dev/composition-resource-name"] for r in items if r.kind in ["Bucket", "BucketVersioning", "EPI"]]
+        _uniq = {n: 1 for n in _names}
+        assert len(_names) == len(_uniq), "duplicate composition-resource-name among s3 resources: {}".format(_names)
+
+    assert True
+}


### PR DESCRIPTION
Found while verifying #1713. **Not a regression from it** — see below.

## The bug

`_s3BucketResources` was built by mutation:

```kcl
_s3BucketResources = [ Bucket ]
if versioning:
    _s3BucketResources += [ BucketVersioning ]
_s3BucketResources += [ EPI ]
```

Under function-kcl that shape re-evaluates and emits the Bucket and the EPI **twice** whenever the middle `+=` is skipped — i.e. whenever versioning is off. Crossplane rejects the render outright:

```
multiple composed resources with name "preview-probe-s3-bucket" returned:
Bucket/preview-probe-s3-bucket and Bucket/preview-probe-s3-bucket
```

The two are byte-identical. This is the same class as [function-kcl#285](https://github.com/crossplane-contrib/function-kcl/issues/285), which the `externalSecrets` block *immediately below* already guards against by building its list in a single comprehension — the s3Bucket block simply never got the same treatment, despite the `NOTE:` comment sitting right above it.

## Why it stayed hidden

Bisected to one field:

| `versioning` | Buckets emitted |
|---|---|
| `true` | 1 |
| `false` | **2** |
| absent | **2** |

Every `s3Bucket` claim in this repo sets `versioning: true`, and the one live S3 app (`image-gallery`) has exactly one bucket — confirmed against the cluster. But the App Wizard's default is versioning **off**, so the first S3 app created through the form hits it, in preview *and* on a real reconcile.

## Not caused by #1700 / #1713

Checked rather than assumed. Rendering the identical fixture against the pre-#1700 composition — `d17fbdb6^`, which contains no `_workloadShouldRender` at all — produces the same **2 Buckets and 2 EPIs**.

## The fix

Assemble the set in one expression via `_s3ResourceList`, so duplication is *structurally impossible* rather than merely absent:

```kcl
_s3ResourceList = lambda bucket: [any], versioningResource: [any], epi: [any], versioningEnabled: bool -> [any] {
    bucket + (versioningResource if versioningEnabled else []) + epi
}
```

## Verification

**TDD** — both tests written first and watched fail (`name '_s3ResourceList' is not defined`). `kcl test` → **36/36** (34 pre-existing + 2 new).

`test_s3_resources_never_duplicate` drives the real constructor across both versioning states (the global fixture pins `versioning: true` and cannot encode the failing case). `test_s3_items_unique_names` adds an end-to-end guard that no two rendered s3 resources share a `composition-resource-name`, since crossplane keys on it and a repeat is a hard failure.

Rendered across every versioning state:

```
versioning=true (stock)  Bucket=1 EPI=1 BucketVersioning=1   (unchanged)
versioning=false         Bucket=1 EPI=1 BucketVersioning=0   (was 2/2)
versioning absent        Bucket=1 EPI=1 BucketVersioning=0   (was 2/2)
wizard-style payload     Bucket=1 EPI=1 BucketVersioning=0   (was 2/2)
```

`./scripts/validate-kcl-compositions.sh` → exit 0, all 5 modules format-clean and syntax-valid.

## Merge sequence

`kcl.mod` bumped `0.6.1` → `0.6.2`; the composition pin needs the `-pr<N>` tag while this is open, then `0.6.2` on merge — same dance as #1703/#1706 and #1713/#1714.