### PR TITLE
chore(app): pin the composition to the released 0.7.0 module

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.7.0-pr1718
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.7.0
 
         - step: ready
           functionRef:


### PR DESCRIPTION
Follow-up to #1718, same sequencing as #1706/#1714/#1716.

`validate-composition-versions` requires the `-prN` tag while a PR is open and the bare version on `main`, and `0.7.0` does not exist until the merge publishes it.

**Verified anonymously pullable** (`function-kcl` pulls without credentials):

```
GET ghcr.io/v2/smana/cloud-native-ref/crossplane-app/manifests/0.7.0  ->  HTTP 200
```

No behaviour change — same module content as `0.7.0-pr1718`.