### PR TITLE
fix(app): restore the s3Bucket guard indentation broken by the revert

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.7.0
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.7.1-pr1720
 
         - step: ready
           functionRef:

--- a/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
+++ b/infrastructure/base/crossplane/configuration/kcl/app/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "app"
 edition = "v0.11."
-version = "0.7.0"
+version = "0.7.1"
 description = "Crossplane composition function for deploying applications with infrastructure"
 
 [dependencies]

--- a/infrastructure/base/crossplane/configuration/kcl/app/main.k
+++ b/infrastructure/base/crossplane/configuration/kcl/app/main.k
@@ -1127,70 +1127,70 @@ if oxr.spec.s3Bucket?.enabled:
         }
     }]
 
-# EKS Pod Identity for S3 access
-_s3Epi = [
-    {
-        apiVersion = "cloud.ogenki.io/v1alpha1"
-        kind = "EPI"
-        metadata = _managedMetadata("s3-pod-identity")
-        spec = {
-            serviceAccount = {
-                name = _name
-                namespace = _namespace
+    # EKS Pod Identity for S3 access
+    _s3Epi = [
+        {
+            apiVersion = "cloud.ogenki.io/v1alpha1"
+            kind = "EPI"
+            metadata = _managedMetadata("s3-pod-identity")
+            spec = {
+                serviceAccount = {
+                    name = _name
+                    namespace = _namespace
+                }
+                clusters = [{
+                    name = envConfig.clusterName
+                    region = envConfig.region
+                }]
+                if oxr.spec.s3Bucket.permissions == "custom" and oxr.spec.s3Bucket.customPolicy:
+                    policyDocument = oxr.spec.s3Bucket.customPolicy
+                elif oxr.spec.s3Bucket.permissions == "readwrite":
+                    policyDocument = """{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": \"""" + _bucketArn + """\"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject"
+                ],
+                "Resource": \"""" + _bucketArn + """/*\"
             }
-            clusters = [{
-                name = envConfig.clusterName
-                region = envConfig.region
-            }]
-            if oxr.spec.s3Bucket.permissions == "custom" and oxr.spec.s3Bucket.customPolicy:
-                policyDocument = oxr.spec.s3Bucket.customPolicy
-            elif oxr.spec.s3Bucket.permissions == "readwrite":
-                policyDocument = """{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": \"""" + _bucketArn + """\"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": \"""" + _bucketArn + """/*\"
+        ]
+    }"""
+                elif oxr.spec.s3Bucket.permissions == "readonly":
+                    policyDocument = """{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": \"""" + _bucketArn + """\"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject"
+                ],
+                "Resource": \"""" + _bucketArn + """/*\"
+            }
+        ]
+    }"""
+            }
         }
     ]
-}"""
-            elif oxr.spec.s3Bucket.permissions == "readonly":
-                policyDocument = """{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": \"""" + _bucketArn + """\"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": \"""" + _bucketArn + """/*\"
-        }
-    ]
-}"""
-        }
-    }
-]
-_s3BucketResources = _s3ResourceList(_s3Bucket, _s3BucketVersioning, _s3Epi, oxr.spec.s3Bucket.versioning or False)
-_items += _s3BucketResources
+    _s3BucketResources = _s3ResourceList(_s3Bucket, _s3BucketVersioning, _s3Epi, oxr.spec.s3Bucket.versioning or False)
+    _items += _s3BucketResources
 
 # External Secrets
 # Create ExternalSecrets from AWS Secrets Manager using dataFrom pattern


### PR DESCRIPTION
Hotfix for a regression I introduced in #1718. **Currently breaking reconciliation on the cluster.**

## Impact

The revert left `_s3Epi` and `_s3BucketResources` at column 0 — outside `if oxr.spec.s3Bucket?.enabled:`. Every App **without** an s3Bucket then evaluated the EPI policy branch and failed:

```
cannot compose resources: pipeline step "app" returned a fatal result:
failed to run kcl function pipelines: EvaluationError
  main.k:1195  if oxr.spec.s3Bucket.permissions == "custom" ...
  invalid value 'UndefinedType' to load attribute 'permissions'
```

**6 of 7 App XRs went `Synced=False`.** Existing resources kept running (`Ready` stayed `True`), so no outage — but nothing reconciled. Only `image-gallery`, the one app that *has* an s3Bucket, was unaffected.

Re-indents the block back inside its guard. No logic change.

## Why the tests missed it — worth fixing separately

`settings-example.yaml` is the **single fixture** CI renders, and it always sets `s3Bucket.enabled: true`. The unguarded path is therefore never exercised: `kcl test` stayed 32/32 green and `validate-kcl-compositions.sh` exited 0 through the whole regression.

Reproduced locally with the same fixture minus `s3Bucket` — fails before this change, passes after. **A second no-s3 fixture in the validator would have caught this**; I have deliberately not bundled that here so the hotfix stays minimal, but it is the real lesson and I would suggest it as a follow-up.

## Verification

`kcl test` → 32/32. Rendered with and without `s3Bucket`, across every versioning state:

```
no s3Bucket           Deployment=1                       (was: EvaluationError)
versioning=true       Bucket=1 Deployment=1 EPI=1
versioning=false      Bucket=1 Deployment=1 EPI=1
wizard payload        Bucket=1 Deployment=1 EPI=1
```

`kcl.mod` → `0.7.1`.