### PR TITLE
chore(app): pin the composition to the released 0.7.1 module

### DIFF
--- a/infrastructure/base/crossplane/configuration/app-composition.yaml
+++ b/infrastructure/base/crossplane/configuration/app-composition.yaml
@@ -30,7 +30,7 @@ spec:
               kind: KCLRun
               spec:
                   target: Resources
-                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.7.1-pr1720
+                  source: oci://ghcr.io/smana/cloud-native-ref/crossplane-app:0.7.1
 
         - step: ready
           functionRef:


### PR DESCRIPTION
Follow-up to the #1720 hotfix — same sequencing as the previous pin PRs.

Verified anonymously pullable (`function-kcl` pulls without credentials):

```
GET ghcr.io/v2/smana/cloud-native-ref/crossplane-app/manifests/0.7.1  ->  HTTP 200
```

No behaviour change — same content as `0.7.1-pr1720`.