### PR TITLE
test(app): render every settings fixture, and add a minimal one

### DIFF
--- a/.github/workflows/crossplane-modules.yml
+++ b/.github/workflows/crossplane-modules.yml
@@ -162,14 +162,30 @@ jobs:
 
           # A KCL module is considered a Crossplane function if it has both a kcl.mod
           # and a settings-example.yaml file for mocking runtime parameters.
+          #
+          # Render EVERY settings-*.yaml, not just the example. settings-example.yaml
+          # enables essentially every optional block, so a broken `if oxr.spec.X:`
+          # guard still renders under it — X is always set. That blind spot shipped
+          # a regression: an s3Bucket block escaped its guard and broke every App
+          # WITHOUT an s3Bucket, while this step stayed green. Modules add a fixture
+          # (e.g. settings-minimal.yaml) and it is picked up automatically.
           if [ -f "kcl.mod" ] && [ -f "settings-example.yaml" ]; then
-            echo "   Found settings-example.yaml, running validation with settings..."
-            if kcl run . -Y settings-example.yaml --output /dev/null; then
-              echo "✅ KCL configuration is valid with mock parameters."
-            else
+            rc=0
+            for fixture in settings-*.yaml; do
+              [ -f "$fixture" ] || continue
+              echo "   Rendering with $fixture ..."
+              if kcl run . -Y "$fixture" --output /dev/null; then
+                echo "   ✅ valid — $fixture"
+              else
+                echo "   ❌ validation failed — $fixture"
+                rc=1
+              fi
+            done
+            if [ "$rc" -ne 0 ]; then
               echo "❌ KCL configuration validation failed with mock parameters."
               exit 1
             fi
+            echo "✅ KCL configuration is valid with mock parameters."
           else
             echo "   No settings-example.yaml found, running standard validation..."
             kcl run . --output /dev/null

--- a/.github/workflows/crossplane-modules.yml
+++ b/.github/workflows/crossplane-modules.yml
@@ -33,6 +33,10 @@ jobs:
           files: |
             infrastructure/base/crossplane/configuration/kcl/**/*.k
             infrastructure/base/crossplane/configuration/kcl/**/kcl.mod
+            # Fixtures are inputs to the render check below, so editing one must
+            # re-run validation. Without this a fixture could be broken -- or a
+            # new one added -- and nothing would render it.
+            infrastructure/base/crossplane/configuration/kcl/**/settings-*.yaml
 
       - name: Set matrix for changed modules
         id: set-matrix

--- a/.github/workflows/crossplane-modules.yml
+++ b/.github/workflows/crossplane-modules.yml
@@ -33,10 +33,6 @@ jobs:
           files: |
             infrastructure/base/crossplane/configuration/kcl/**/*.k
             infrastructure/base/crossplane/configuration/kcl/**/kcl.mod
-            # Fixtures are inputs to the render check below, so editing one must
-            # re-run validation. Without this a fixture could be broken -- or a
-            # new one added -- and nothing would render it.
-            infrastructure/base/crossplane/configuration/kcl/**/settings-*.yaml
 
       - name: Set matrix for changed modules
         id: set-matrix

--- a/infrastructure/base/crossplane/configuration/kcl/app/settings-minimal.yaml
+++ b/infrastructure/base/crossplane/configuration/kcl/app/settings-minimal.yaml
@@ -1,0 +1,45 @@
+# Minimal App claim — the complement to settings-example.yaml.
+#
+# settings-example.yaml turns on essentially EVERY optional block (s3Bucket,
+# sqlInstance, kvStore, externalSecrets, gateway, route, persistence, sidecars,
+# autoscaling, pdb…) and pre-populates ocds. That makes it a good exercise of the
+# feature paths and a bad exercise of the guards around them: any block whose
+# `if oxr.spec.X:` condition is broken still renders, because X is always set.
+#
+# That gap shipped a live regression. The s3Bucket block was accidentally
+# dedented out of `if oxr.spec.s3Bucket?.enabled:`, so every App WITHOUT an
+# s3Bucket failed to reconcile with:
+#
+#   invalid value 'UndefinedType' to load attribute 'permissions'
+#
+# `kcl test` stayed 32/32 green and the validator exited 0 throughout, because
+# the only fixture rendered always had s3Bucket enabled. Six of seven App XRs
+# went Synced=False on the cluster before anyone noticed.
+#
+# So this fixture is deliberately bare: image + service and nothing else, with an
+# empty ocds (a first reconcile, before anything is observed). It is the shape a
+# developer's first claim actually has, and the shape the optional-block guards
+# have to survive. Keep it that way — resist adding features to it; add a third
+# fixture instead.
+kcl_options:
+  - key: params
+    value:
+      oxr:
+        apiVersion: cloud.ogenki.io/v1alpha1
+        kind: App
+        metadata:
+          name: minimal
+          namespace: apps
+        spec:
+          image:
+            repository: ghcr.io/stefanprodan/podinfo
+            tag: "6.9.2"
+          service:
+            port: 9898
+      # Empty: a first reconcile, nothing observed yet. Exercises every
+      # `... in ocds else None` accessor against the absent case.
+      ocds: {}
+      ctx:
+        apiextensions.crossplane.io/environment:
+          clusterName: mycluster-0
+          region: eu-west-3

--- a/scripts/validate-kcl-compositions.sh
+++ b/scripts/validate-kcl-compositions.sh
@@ -110,20 +110,32 @@ validate_composition() {
     echo ""
     echo -e "${YELLOW}🧪 [2/3] Validating KCL syntax and logic...${NC}"
 
+    # Renders EVERY settings-*.yaml the module ships, not just the example.
+    # settings-example.yaml enables essentially every optional block, so a broken
+    # `if oxr.spec.X:` guard still renders under it — X is always set. That gap
+    # let an s3Bucket block escape its guard and break reconciliation for every
+    # App WITHOUT an s3Bucket, while this validator exited 0. A module adds a
+    # fixture (e.g. settings-minimal.yaml) and it is picked up automatically.
     if [[ ! -f "$settings_file" ]]; then
         echo -e "${YELLOW}   ⚠️  Settings file not found: $settings_file${NC}"
         warnings=$((warnings + 1))
     else
         cd "$module_path"
-        if kcl run . -Y settings-example.yaml > /dev/null 2>&1; then
-            echo -e "${GREEN}   ✅ KCL syntax valid${NC}"
-        else
-            echo -e "${RED}   ❌ KCL syntax error${NC}"
-            echo ""
-            echo "   Running with output to show error:"
-            kcl run . -Y settings-example.yaml || true
-            errors=$((errors + 1))
-        fi
+        local fixture_count=0
+        for fixture in settings-*.yaml; do
+            [[ -f "$fixture" ]] || continue
+            fixture_count=$((fixture_count + 1))
+            if kcl run . -Y "$fixture" > /dev/null 2>&1; then
+                echo -e "${GREEN}   ✅ KCL syntax valid — ${fixture}${NC}"
+            else
+                echo -e "${RED}   ❌ KCL syntax error — ${fixture}${NC}"
+                echo ""
+                echo "   Running with output to show error:"
+                kcl run . -Y "$fixture" || true
+                errors=$((errors + 1))
+            fi
+        done
+        echo -e "   (${fixture_count} fixture(s) rendered)"
         cd - > /dev/null
     fi
 


### PR DESCRIPTION
Closes the test gap that let the #1720 regression reach the cluster. This is the follow-up I flagged there rather than bundling.

## The gap

`settings-example.yaml` enables essentially **every** optional block — `s3Bucket`, `sqlInstance`, `kvStore`, `externalSecrets`, `gateway`, `route`, `persistence`, `sidecars`, `autoscaling`, `pdb` — and pre-populates `ocds`. That makes it a good exercise of the feature paths and a **bad** exercise of the guards around them: any broken `if oxr.spec.X:` still renders, because `X` is always set.

That is exactly what happened. The s3Bucket block was dedented out of `if oxr.spec.s3Bucket?.enabled:`, so every App **without** an s3Bucket failed to reconcile:

```
invalid value 'UndefinedType' to load attribute 'permissions'
```

Six of seven App XRs went `Synced=False` on the cluster — while `kcl test` stayed **32/32 green** and `validate-kcl-compositions.sh` exited **0** the whole time.

## The change

- **`settings-minimal.yaml`** — image + service, no optional blocks, empty `ocds`. The shape a developer's first claim actually has, and the shape the optional-block guards have to survive. Also exercises every `... in ocds else None` accessor against the absent case.
- **The validator and the CI step render every `settings-*.yaml`**, not just the example. A module adds a fixture and it is picked up with no further wiring — this applies to all five compositions, not just `app`.

## Verification — the part that matters

Reintroduced the exact regression and re-ran the validator:

```
✅ KCL syntax valid — settings-example.yaml     ← still blind, exactly as before
❌ KCL syntax error — settings-minimal.yaml     ← caught
   invalid value 'UndefinedType' to load attribute 'permissions'
exit=2
```

The example fixture passing in that run is the point: it shows precisely why the old single-fixture setup could not have caught this.

Restored the good code and re-ran — both fixtures render, exit 0.

Also: `kcl test` 32/32, `shellcheck -x -S warning` passes across `./scripts`, workflow YAML parses.

## Note

No module version bump — this touches only fixtures and tooling, not composition logic, so the published module is unchanged.