### PR TITLE
fix(karpenter): require Nitro so Cilium prefix delegation can work

### DIFF
--- a/infrastructure/base/karpenter-nodepools/default-nodepool.yaml
+++ b/infrastructure/base/karpenter-nodepools/default-nodepool.yaml
@@ -31,6 +31,18 @@ spec:
         - key: karpenter.k8s.aws/instance-memory
           operator: Lt
           values: ["50001"]
+        # Nitro only — REQUIRED for Cilium ENI prefix delegation, which is a
+        # Nitro-only feature. On a Xen instance Cilium falls back to secondary IPs and
+        # the node is hard-capped at (usable ENIs x IPs-per-ENI). Since the scheduler
+        # does not read Cilium IPAM, it keeps placing pods on a node that cannot
+        # network them and they sit in ContainerCreating on "no IPs currently
+        # available on the node".
+        #
+        # Added here as well as on the io pool: nothing in the requirements above
+        # excludes a Xen family, so this pool could select one at any time.
+        - key: karpenter.k8s.aws/instance-hypervisor
+          operator: In
+          values: ["nitro"]
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 15m

--- a/infrastructure/base/karpenter-nodepools/io-nodepool.yaml
+++ b/infrastructure/base/karpenter-nodepools/io-nodepool.yaml
@@ -32,6 +32,25 @@ spec:
         - key: karpenter.k8s.aws/instance-category
           operator: In
           values: ["c", "i", "m", "r"]
+        # Nitro only — REQUIRED for Cilium ENI prefix delegation.
+        #
+        # Prefix delegation is a Nitro-only feature. On a Xen instance Cilium falls
+        # back to secondary IPs and the node is hard-capped at
+        # (usable ENIs x IPs-per-ENI), which the kubelet's advertised max-pods then
+        # dwarfs. The scheduler does not read Cilium IPAM, so it keeps packing pods
+        # onto a node that cannot network them and they sit in ContainerCreating on
+        # "no IPs currently available on the node".
+        #
+        # This pool is the one that hit it: instance-local-nvme > 100 matches the i3
+        # family, the last Xen-based NVMe generation. An i3.large came up with
+        # prefixes=0 on every ENI, 2 usable ENIs x 9 IPs = 18 addresses, against a
+        # kubelet advertising 100 pods.
+        #
+        # The constraint costs nothing: 59 Nitro types still carry >100GB local NVMe,
+        # including i3en, i4i and i7i (the direct i3 successors) plus c5d/c6id/m5d/r5d.
+        - key: karpenter.k8s.aws/instance-hypervisor
+          operator: In
+          values: ["nitro"]
       taints:
         - key: ogenki/io
           value: "true"


### PR DESCRIPTION
## The recurring failure

Pods stick in `ContainerCreating`, repeatedly, on:

```
plugin type="cilium-cni" failed (add): unable to allocate IP via local cilium agent:
[POST /ipam][502] "no IPs currently available on the node"
```

Today it took out `hubble-ui` and three Crossplane providers for 10+ minutes. Earlier it hit the **Kyverno admission controller**, which took its webhook offline and made unrelated `kubectl` operations fail with `no endpoints available for service "kyverno-svc"`.

## Root cause

Two things compound.

**Every node advertises far more pods than Cilium can address:**

| node | instance | kubelet maxPods | Cilium IPs | over-commit |
|---|---|---|---|---|
| `ip-10-0-3-80` | **i3.large** | 100 | **18** | 5.6× |
| `ip-10-0-15-17` | c5.large | 100 | 16 | 6.3× |
| `ip-10-0-22-115` | c5.large | 100 | 16 | 6.3× |
| `ip-10-0-9-248` | m8i-flex.large | 100 | 32 | 3.1× |

The scheduler does not read Cilium IPAM ([cilium#12557](https://github.com/cilium/cilium/issues/12557)), so it keeps placing pods on nodes that cannot network them.

**Prefix delegation is enabled — but it cannot apply to `i3.large`.** From the failing node's `CiliumNode`:

```
attached ENIs: 3
  eni-0ace13…  idx=None  ips=0  prefixes=0     ← reserved for the node
  eni-0bfbc9…  idx=1     ips=9  prefixes=0
  eni-0f3ca9…  idx=2     ips=9  prefixes=0
```

`prefixes=0` everywhere: 2 usable ENIs × 9 secondary IPs = exactly the 18 it capped at. Per `describe-instance-types`, **`i3.large` is the only Xen instance in the fleet** — every other type here is Nitro, and prefix delegation is Nitro-only. On the Nitro nodes it *is* working (c5.large shows a pool of 16 = one `/28` prefix, growing on demand).

Subnets are not the constraint: the pod subnets have **16,186** and **16,329** free addresses.

## How `i3` got selected

The `io` pool asks for `instance-local-nvme > 100` with `instance-category In [c,i,m,r]`. The `i3` family is the classic NVMe match — and the last Xen-based generation.

## The change

A `karpenter.k8s.aws/instance-hypervisor In ["nitro"]` requirement on both pools.

It costs nothing: **59 Nitro types still carry >100GB local NVMe**, including `i3en`, `i4i` and `i7i` (the direct `i3` successors) plus `c5d`, `c6id`, `m5d`, `r5d`.

Applied to `default` as well — nothing in its requirements excluded a Xen family either, so it could select one at any time.

## Verification

`kubectl apply --dry-run=server` accepts both NodePools; `kustomize build` renders clean; pre-commit hooks pass.

Existing nodes are unaffected — this constrains future provisioning only. The one live `i3.large` will drain out through normal consolidation.

## Not in this PR

Two follow-ups worth considering separately:

- **`kubelet.maxPods: 100` on the `default` EC2NodeClass.** Karpenter [defaults to 110 assuming prefix delegation](https://karpenter.sh/v1.0/troubleshooting/); pinning 100 keeps that assumption while the smallest Nitro nodes start at 16 IPs and grow. [maxPodsExpression](https://github.com/aws/karpenter-provider-aws/issues/8739) would let it derive from real capacity.
- **`pre-allocate: 8`** is Cilium's headroom watermark. A burst of more than 8 pods on one node outruns the operator's ENI allocation — which is what happened: the operator *was* creating an ENI at 17:53, just not fast enough, and it had restarted 7 minutes earlier so leadership changed mid-allocation.
