### PR TITLE
fix(eks): cap managed nodegroup max-pods at Cilium's real ceiling

### DIFF
--- a/opentofu/eks/init/main.tf
+++ b/opentofu/eks/init/main.tf
@@ -147,11 +147,35 @@ module "eks" {
       capacity_type        = "SPOT"
       force_update_version = true
       instance_types       = ["c7i.xlarge", "c7i-flex.xlarge", "c6i.xlarge", "t3a.xlarge", "c7i.2xlarge", "c7i-flex.2xlarge"]
-      # Exemple of how to configure Bottlerocket. https://bottlerocket.dev/en/os/1.41.x/api/settings/
-      # bootstrap_extra_args = <<-EOT
-      #   [settings.host-containers.admin]
-      #   enabled = true
-      # EOT
+
+      # max-pods must match what CILIUM can address, not what AWS can attach.
+      #
+      # The AMI default comes from the AWS formula, which counts the primary ENI's
+      # secondary IPs:        ENIs x (IPs-1) + 2  =  4 x 14 + 2  =  58
+      # Cilium runs ENI IPAM with first-interface-index: 1, so eth0 is skipped
+      # entirely -- it sits in the NODE subnet (10.0.0.0/20) while pods must come
+      # from the pod subnet (100.64.0.0/18). Its real ceiling is:
+      #                       (ENIs-1) x (IPs-1)  =  3 x 14      =  42
+      #
+      # The 16-pod gap is not theoretical. The scheduler fills to 58, Cilium runs
+      # out at 42, and the overflow sits in ContainerCreating on "no IPs currently
+      # available on the node" -- observed on both nodes of this group.
+      #
+      # Prefix delegation would lift the ceiling to 3 x 14 x 16, but cannot be
+      # relied on HERE: these nodes are created during cluster bootstrap, before a
+      # cilium-operator exists to apply it, and their ENIs are never converted
+      # afterwards. Both showed prefixes=0 while every later Karpenter node had
+      # prefixes. Upstream also reports isPrefixDelegated flipping across an
+      # instance's lifetime (cilium/cilium#29634), so 42 is the guaranteed floor
+      # rather than a pessimistic guess.
+      #
+      # 42 holds for every instance_type above -- all six are 4 ENIs x 15 IPs.
+      # Re-check with `aws ec2 describe-instance-types` before adding a type.
+      # Bottlerocket settings reference: https://bottlerocket.dev/en/os/1.41.x/api/settings/
+      bootstrap_extra_args = <<-EOT
+        [settings.kubernetes]
+        max-pods = 42
+      EOT
     }
   }
 


### PR DESCRIPTION
Follow-up to #1725. That PR removed the *hard* cap (Xen instances can't do prefix delegation); this one closes the remaining over-commit.

## Which nodes are actually over-committed

Measured on `mycluster-0`, and it is **not** the Karpenter nodes:

| population | nodes | maxPods | prefix delegation | real ceiling | verdict |
|---|---|---|---|---|---|
| Karpenter `default` | 7 | 100 | **working** (1–2 prefixes, growing on demand) | c5.large → **288** | fine, no change |
| managed nodegroup `main` | 2 | **58** | **not used** — `prefixes=0` on every ENI | **42** | over by 16 |

One of the two was sitting at **42/42 exhausted** while six other nodes had free capacity.

## The arithmetic

```
AWS formula    ENIs × (IPs−1) + 2  =  4 × 14 + 2  =  58   ← counts eth0's secondary IPs
Cilium actual  (ENIs−1) × (IPs−1)  =  3 × 14      =  42   ← first-interface-index: 1 skips eth0
```

`first-interface-index: 1` is correct and deliberate — eth0 lives in the **node** subnet (`10.0.0.0/20`), while pods must get addresses from the **pod** subnet (`100.64.0.0/18`). So the primary ENI's 14 secondary IPs are unusable for pods, and the AMI's default counts them anyway.

The formula was validated against reality before being trusted: it predicts **18** for the `i3.large` that failed earlier today, and that node's pool was exactly 18.

## Why not rely on prefix delegation here

It would lift the ceiling to `3 × 14 × 16`. It is not dependable for *this* group:

- These nodes are created during **cluster bootstrap**, before a `cilium-operator` exists to apply prefix delegation. Their ENIs are allocated in secondary-IP mode and never converted.
- Both showed `prefixes=0`; every Karpenter node created later showed `prefixes≥1`. The split is by node **age**, not AMI — all nine nodes are Bottlerocket.
- Upstream reports `isPrefixDelegated` flipping across an instance's lifetime, leaving "some ENIs with secondary IPs only, some with prefixes only, and some with both" ([cilium/cilium#29634](https://github.com/cilium/cilium/issues/29634), open).

**42 is the guaranteed floor**, not a pessimistic guess. If prefix delegation does engage the node simply has headroom it won't use.

## Scope check

42 holds for **every** `instance_type` in the group — all six (`c7i.xlarge`, `c7i-flex.xlarge`, `c6i.xlarge`, `t3a.xlarge`, `c7i.2xlarge`, `c7i-flex.2xlarge`) are 4 ENIs × 15 IPs. Re-check with `describe-instance-types` before adding a type with fewer ENIs; the comment in the code says so.

## Verification

`tofu fmt -check` clean, `tofu validate` Success, pre-commit (incl. tflint) passed.

**Requires `tofu apply` and node replacement** — this is a launch-template change, so it is not picked up by Flux and does not take effect until the nodegroup rolls. `force_update_version = true` is already set.

## Not changed

Karpenter's `kubelet.maxPods: 100`. I checked before assuming it needed fixing: with prefix delegation working, a c5.large reaches 288 addresses, so 100 is comfortable. The remaining risk there is allocation *latency* — `pre-allocate: 8` is the watermark, and a burst larger than that can outrun the operator's ENI allocation. That is a tuning question with no obviously correct value, so it stays a separate decision.
