### PR TITLE
fix(eks): recycle bootstrap nodes so they get prefix delegation

### DIFF
--- a/opentofu/eks/init/workflows.tm.hcl
+++ b/opentofu/eks/init/workflows.tm.hcl
@@ -32,6 +32,34 @@ script "deploy" {
       ["bash", "-c", "cd ../configure && ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' $${TF_VAR_flux_git_ref:+-var=\"flux_git_ref=$${TF_VAR_flux_git_ref}\"}"],
     ]
   }
+
+  # Stage 3: the node group exists from Stage 1, i.e. BEFORE Cilium. Cilium
+  # therefore creates its ENIs filled with individual secondary IPs instead of
+  # /28 prefixes, and never converts them — leaving the bootstrap nodes with a
+  # permanent ~42-IP ceiling while every Karpenter node gets ~240. Measured on
+  # mycluster-0: two c7i-flex.xlarge MNG nodes at prefixes=0 next to a Karpenter
+  # c7i-flex.xlarge at prefixes=2. Same instance type; the difference is that the
+  # MNG nodes predate Cilium.
+  #
+  # It surfaces far from the cause: a DaemonSet pod that cannot get an IP keeps
+  # its DaemonSet InProgress, so Helm's --wait times out and an unrelated
+  # HelmRelease reports InstallFailed.
+  #
+  # The script is idempotent — it inspects each node's CiliumNode and only
+  # recycles ones actually missing prefixes — so this is a no-op on every deploy
+  # after the first, and on clusters where prefix delegation is off.
+  #
+  # This lives in a Terramate job rather than a tofu local-exec on purpose: the
+  # configure stack is deliberately local-exec-free (see the comments in
+  # configure/main.tf), and imperative steps belong here, as with
+  # eks-prepare-destroy.sh on the destroy path.
+  job {
+    name        = "stage3-recycle-bootstrap-nodes"
+    description = "Recycle node-group nodes whose ENIs predate Cilium (no-op once they use prefix delegation)"
+    commands = [
+      ["bash", "-c", "../../../scripts/eks-recycle-bootstrap-nodes.sh --cluster-name ${global.eks_cluster_name} --region ${global.region}"],
+    ]
+  }
 }
 
 script "deploy-stage1" {

--- a/scripts/eks-recycle-bootstrap-nodes.sh
+++ b/scripts/eks-recycle-bootstrap-nodes.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Recycle EKS managed-node-group nodes whose ENIs predate Cilium.
+#
+# WHY THIS EXISTS
+# ---------------
+# The platform bootstraps in two stages: Stage 1 creates the EKS cluster with the
+# temporary VPC CNI, Stage 2 replaces it with Cilium. The managed-node-group nodes
+# therefore exist BEFORE Cilium does. When Cilium takes over it creates its own
+# ENIs on them, but it fills those ENIs with individual secondary IPs rather than
+# /28 prefixes — and that allocation is sticky. Cilium never converts an existing
+# secondary-IP ENI to prefix delegation.
+#
+# The result is a permanent, invisible capacity cliff on exactly the bootstrap
+# nodes. Measured on mycluster-0 (2026-08-02):
+#
+#   node             instance          provisioner   prefixes   usable IPs
+#   ip-10-0-8-142    c7i-flex.xlarge   Karpenter     2          ~240
+#   ip-10-0-3-147    c7i-flex.xlarge   EKS MNG       0          42
+#   ip-10-0-9-161    c7i-flex.xlarge   EKS MNG       0          42
+#
+# Same instance type, opposite outcome — the split is *when* the node was created,
+# not what it is. The 42-IP nodes then hit `no IPs currently available on the node`
+# and wedge unrelated things: a DaemonSet pod that cannot get an IP keeps its
+# DaemonSet at InProgress, so Helm's --wait times out and a HelmRelease in a
+# completely different namespace reports InstallFailed. That cost hours to trace.
+#
+# Recycling the node after Cilium is healthy makes the replacement come up with
+# Cilium already running, so its ENIs get prefixes.
+#
+# SAFETY
+# ------
+# Idempotent by construction: it inspects each node's CiliumNode and only recycles
+# ones that actually lack prefixes. On a healthy cluster it is a no-op, so it is
+# safe to run on every deploy. Nodes are recycled ONE AT A TIME, waiting for the
+# replacement to be Ready before continuing.
+#
+# Usage: eks-recycle-bootstrap-nodes.sh --cluster-name <name> --region <region> [--profile <profile>]
+
+set -uo pipefail
+
+CLUSTER_NAME=""
+REGION=""
+PROFILE=""
+# Belt and braces: never touch more than this many nodes in one run.
+MAX_RECYCLE="${EKS_RECYCLE_MAX:-4}"
+
+usage() {
+	echo "Usage: $0 --cluster-name <cluster-name> --region <region> [--profile <profile>]"
+	exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--cluster-name)
+		CLUSTER_NAME="$2"
+		shift 2
+		;;
+	--region)
+		REGION="$2"
+		shift 2
+		;;
+	--profile)
+		PROFILE="$2"
+		shift 2
+		;;
+	*)
+		echo "Unknown option: $1"
+		usage
+		;;
+	esac
+done
+
+[[ -z "$CLUSTER_NAME" || -z "$REGION" ]] && usage
+
+if [[ -n "$PROFILE" ]]; then
+	AWS_CMD="aws --profile ${PROFILE} --region ${REGION}"
+else
+	AWS_CMD="aws --region ${REGION}"
+fi
+
+echo "==> Checking for bootstrap nodes with pre-Cilium ENIs (cluster: ${CLUSTER_NAME})"
+
+# Only meaningful when prefix delegation is actually on. If it is off, individual
+# secondary IPs are the intended behaviour everywhere and there is nothing to fix.
+pd=$(kubectl get cm -n kube-system cilium-config -o jsonpath='{.data.aws-enable-prefix-delegation}' 2>/dev/null)
+if [[ "$pd" != "true" ]]; then
+	echo "    Prefix delegation is not enabled (aws-enable-prefix-delegation=${pd:-<unset>}) — nothing to do."
+	exit 0
+fi
+
+# Wait for Cilium to be fully up. The helm_release that installs it uses wait=false,
+# so reaching this script does NOT imply the DaemonSet is ready — and recycling a
+# node while Cilium is still rolling out would just recreate the problem.
+echo "==> Waiting for the Cilium DaemonSet to be ready (up to 10m)"
+if ! kubectl rollout status daemonset/cilium -n kube-system --timeout=600s >/dev/null 2>&1; then
+	echo "    ERROR: Cilium DaemonSet did not become ready. Refusing to recycle nodes." >&2
+	exit 1
+fi
+echo "    Cilium is ready."
+
+# Returns the number of ENI prefixes Cilium has allocated on a node (0 if none).
+node_prefix_count() {
+	kubectl get ciliumnode "$1" -o json 2>/dev/null |
+		jq '[.status.eni.enis[]? | (.prefixes // []) | length] | add // 0'
+}
+
+mapfile -t MNG_NODES < <(kubectl get nodes -l eks.amazonaws.com/nodegroup -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -v '^[[:space:]]*$')
+
+if [[ ${#MNG_NODES[@]} -eq 0 ]]; then
+	echo "    No managed-node-group nodes found — nothing to do."
+	exit 0
+fi
+
+# Decide up front which nodes need work, so the log states the plan before acting.
+TARGETS=()
+for node in "${MNG_NODES[@]}"; do
+	prefixes=$(node_prefix_count "$node")
+	itype=$(kubectl get node "$node" -o jsonpath='{.metadata.labels.node\.kubernetes\.io/instance-type}' 2>/dev/null)
+
+	if [[ "${prefixes:-0}" -gt 0 ]]; then
+		echo "    ${node} (${itype}): prefixes=${prefixes} — OK"
+		continue
+	fi
+
+	# Prefix delegation requires Nitro. On anything else (e.g. i3.*, which is Xen)
+	# zero prefixes is correct and recycling would loop forever.
+	hypervisor=$(${AWS_CMD} ec2 describe-instance-types --instance-types "$itype" \
+		--query 'InstanceTypes[0].Hypervisor' --output text 2>/dev/null)
+	if [[ "$hypervisor" != "nitro" ]]; then
+		echo "    ${node} (${itype}): prefixes=0 but hypervisor=${hypervisor:-unknown} — prefix delegation unsupported, skipping"
+		continue
+	fi
+
+	echo "    ${node} (${itype}): prefixes=0 on a Nitro instance — NEEDS RECYCLE"
+	TARGETS+=("$node")
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+	echo "==> All managed-node-group nodes already use prefix delegation. Nothing to do."
+	exit 0
+fi
+
+if [[ ${#TARGETS[@]} -gt $MAX_RECYCLE ]]; then
+	echo "    ERROR: ${#TARGETS[@]} nodes flagged, limit is ${MAX_RECYCLE}. Refusing — this looks wrong." >&2
+	echo "    Override with EKS_RECYCLE_MAX if it is genuinely intended." >&2
+	exit 1
+fi
+
+echo "==> Recycling ${#TARGETS[@]} node(s), one at a time"
+
+failures=0
+for node in "${TARGETS[@]}"; do
+	echo ""
+	echo "--> ${node}"
+
+	instance_id=$(kubectl get node "$node" -o jsonpath='{.spec.providerID}' 2>/dev/null | sed 's|.*/||')
+	if [[ -z "$instance_id" ]]; then
+		echo "    ERROR: could not resolve instance ID — skipping." >&2
+		failures=$((failures + 1))
+		continue
+	fi
+
+	kubectl cordon "$node" >/dev/null 2>&1 || true
+
+	# Best-effort drain. At bootstrap the node carries almost nothing, so a failed
+	# or partial drain is not a reason to abort — the instance is about to go away.
+	echo "    draining..."
+	kubectl drain "$node" --ignore-daemonsets --delete-emptydir-data \
+		--timeout=300s --skip-wait-for-delete-timeout=60 >/dev/null 2>&1 ||
+		echo "    (drain incomplete — continuing, the instance is being replaced anyway)"
+
+	echo "    terminating ${instance_id} (the node group restores desiredSize)"
+	if ! ${AWS_CMD} ec2 terminate-instances --instance-ids "$instance_id" >/dev/null 2>&1; then
+		echo "    ERROR: terminate failed for ${instance_id}" >&2
+		kubectl uncordon "$node" >/dev/null 2>&1 || true
+		failures=$((failures + 1))
+		continue
+	fi
+
+	# Wait for the old node object to disappear, then for the group to be whole
+	# again. Waiting on node COUNT rather than a name, since the replacement's
+	# name is not known ahead of time.
+	want=${#MNG_NODES[@]}
+	echo "    waiting for the replacement to join and become Ready (up to 15m)"
+	deadline=$((SECONDS + 900))
+	while ((SECONDS < deadline)); do
+		ready=$(kubectl get nodes -l eks.amazonaws.com/nodegroup \
+			-o jsonpath='{range .items[*]}{.metadata.name}{"="}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' 2>/dev/null |
+			grep -c "=True$")
+		still_there=$(kubectl get node "$node" --no-headers 2>/dev/null | grep -c . || true)
+		if [[ "$ready" -ge "$want" && "$still_there" -eq 0 ]]; then
+			break
+		fi
+		sleep 15
+	done
+
+	if ((SECONDS >= deadline)); then
+		echo "    ERROR: replacement did not become Ready within 15m." >&2
+		failures=$((failures + 1))
+		continue
+	fi
+	echo "    replacement is Ready."
+done
+
+echo ""
+echo "==> Verifying prefix delegation on the node group"
+remaining=0
+for node in $(kubectl get nodes -l eks.amazonaws.com/nodegroup -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+	prefixes=$(node_prefix_count "$node")
+	itype=$(kubectl get node "$node" -o jsonpath='{.metadata.labels.node\.kubernetes\.io/instance-type}' 2>/dev/null)
+	if [[ "${prefixes:-0}" -gt 0 ]]; then
+		echo "    ${node} (${itype}): prefixes=${prefixes} ✅"
+	else
+		echo "    ${node} (${itype}): prefixes=0 ⚠️"
+		remaining=$((remaining + 1))
+	fi
+done
+
+if [[ $failures -gt 0 ]]; then
+	echo "==> Completed with ${failures} failure(s)." >&2
+	exit 1
+fi
+
+# A node can legitimately still report 0 (non-Nitro), so this is a warning rather
+# than an error — the per-node lines above say which and why.
+[[ $remaining -gt 0 ]] && echo "==> ${remaining} node(s) still without prefixes — see the lines above."
+
+echo "==> Done."
+exit 0


### PR DESCRIPTION
Stops rebuilds reproducing the IP-exhaustion class that bit four times on 2026-08-02. Follow-up to the investigation on #1700 / the KB entry on Cilium ENI IPAM capacity.

## Root cause

The node group is created in **Stage 1, before Cilium exists**. When Cilium takes over in Stage 2 it creates ENIs on those nodes filled with **individual secondary IPs rather than /28 prefixes**, and never converts them — the allocation is sticky.

So every bootstrap node ships with a permanent ~42-IP ceiling while every Karpenter node gets ~240:

| Node | Instance | Provisioner | prefixes | usable IPs |
|---|---|---|---|---|
| `ip-10-0-8-142` | **c7i-flex.xlarge** | Karpenter | **2** | ~240 |
| `ip-10-0-3-147` | **c7i-flex.xlarge** | EKS MNG | **0** | 42 |
| `ip-10-0-9-161` | **c7i-flex.xlarge** | EKS MNG | **0** | 42 |

**Same instance type, opposite outcome.** The split is *when* the node was created, not what it is — which also kills the instance-type theory the investigation was carrying until Karpenter happened to provision a `c7i-flex.xlarge` and it came up with prefixes.

Prefix delegation itself was never broken: it is correctly configured at every layer (helm values → `cilium-config` → operator flag `--aws-enable-prefix-delegation='true'` → the custom CNI ConfigMap) and works on 5 of 8 nodes.

## Why it is expensive to diagnose

It surfaces nowhere near the cause. A DaemonSet pod that cannot get an IP keeps its DaemonSet at `InProgress`, so Helm's `--wait` times out and a **HelmRelease in an unrelated namespace** reports `InstallFailed`. Nothing points at the node.

## The change

A stage-3 job on the EKS deploy script, recycling node-group nodes whose ENIs predate Cilium.

**Idempotent by construction** — it reads each node's `CiliumNode` and only recycles ones actually missing prefixes. A no-op on every deploy after the first, and on clusters where prefix delegation is off. Nodes go one at a time, waiting for the replacement to be `Ready`.

**A Terramate job, not a tofu `local-exec`** — deliberately. The configure stack is intentionally local-exec-free (three separate comments in `configure/main.tf` say so), and imperative steps belong in the workflow, exactly as `eks-prepare-destroy.sh` already does on the destroy path.

### Safety properties

- **Waits for the Cilium DaemonSet** before touching anything. The `helm_release` uses `wait = false`, so reaching this script does *not* imply Cilium is up — recycling early would just recreate the problem.
- **Skips non-Nitro instances.** On `i3.*` (Xen) zero prefixes is correct, and recycling would loop forever.
- **Refuses to act on more than `EKS_RECYCLE_MAX`** (default 4) nodes.
- Bails out entirely if `aws-enable-prefix-delegation` is not `true`.

## Verification

Run against the **live cluster** with `EKS_RECYCLE_MAX=0`, which exercises every step except the terminate:

```
==> Checking for bootstrap nodes with pre-Cilium ENIs (cluster: mycluster-0)
==> Waiting for the Cilium DaemonSet to be ready (up to 10m)
    Cilium is ready.
    ip-10-0-3-147 (c7i-flex.xlarge): prefixes=0 on a Nitro instance — NEEDS RECYCLE
    ip-10-0-9-161 (c7i-flex.xlarge): prefixes=0 on a Nitro instance — NEEDS RECYCLE
    ERROR: 2 nodes flagged, limit is 0. Refusing — this looks wrong.
EXIT=1
```

Correct detection on both nodes, correct refusal at the cap.

Also: `shellcheck -x -S warning` across `./scripts` passes (the exact CI invocation), and the job resolves under `terramate script info deploy` with the same rendering as the existing stage-2 job.

## What is NOT verified

**The recycle path has not run end to end** — that needs a cluster rebuild or an actual node termination. The detection, gating, ordering and refusal logic are proven against real state; the drain → terminate → wait-for-replacement sequence is not. Flagging that rather than implying otherwise.

The two existing nodes on this cluster stay at 42 IPs until they are recycled; this change prevents the *next* rebuild from reproducing it.
