### PR TITLE
fix(karpenter): require Nitro so Cilium prefix delegation can work

### DIFF
--- a/infrastructure/base/karpenter-nodepools/default-nodepool.yaml
+++ b/infrastructure/base/karpenter-nodepools/default-nodepool.yaml
@@ -31,6 +31,18 @@ spec:
         - key: karpenter.k8s.aws/instance-memory
           operator: Lt
           values: ["50001"]
+        # Nitro only — REQUIRED for Cilium ENI prefix delegation, which is a
+        # Nitro-only feature. On a Xen instance Cilium falls back to secondary IPs and
+        # the node is hard-capped at (usable ENIs x IPs-per-ENI). Since the scheduler
+        # does not read Cilium IPAM, it keeps placing pods on a node that cannot
+        # network them and they sit in ContainerCreating on "no IPs currently
+        # available on the node".
+        #
+        # Added here as well as on the io pool: nothing in the requirements above
+        # excludes a Xen family, so this pool could select one at any time.
+        - key: karpenter.k8s.aws/instance-hypervisor
+          operator: In
+          values: ["nitro"]
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 15m

--- a/infrastructure/base/karpenter-nodepools/io-nodepool.yaml
+++ b/infrastructure/base/karpenter-nodepools/io-nodepool.yaml
@@ -32,6 +32,25 @@ spec:
         - key: karpenter.k8s.aws/instance-category
           operator: In
           values: ["c", "i", "m", "r"]
+        # Nitro only — REQUIRED for Cilium ENI prefix delegation.
+        #
+        # Prefix delegation is a Nitro-only feature. On a Xen instance Cilium falls
+        # back to secondary IPs and the node is hard-capped at
+        # (usable ENIs x IPs-per-ENI), which the kubelet's advertised max-pods then
+        # dwarfs. The scheduler does not read Cilium IPAM, so it keeps packing pods
+        # onto a node that cannot network them and they sit in ContainerCreating on
+        # "no IPs currently available on the node".
+        #
+        # This pool is the one that hit it: instance-local-nvme > 100 matches the i3
+        # family, the last Xen-based NVMe generation. An i3.large came up with
+        # prefixes=0 on every ENI, 2 usable ENIs x 9 IPs = 18 addresses, against a
+        # kubelet advertising 100 pods.
+        #
+        # The constraint costs nothing: 59 Nitro types still carry >100GB local NVMe,
+        # including i3en, i4i and i7i (the direct i3 successors) plus c5d/c6id/m5d/r5d.
+        - key: karpenter.k8s.aws/instance-hypervisor
+          operator: In
+          values: ["nitro"]
       taints:
         - key: ogenki/io
           value: "true"


### PR DESCRIPTION
Ports #1725 to `main`. It was opened against `chore/runlore-v0.12.0`, so **a rebuild from `main` today would still provision non-Nitro nodes.** Cherry-picked, authorship preserved.

## Why

Cilium ENI prefix delegation is a **Nitro-only** feature. On a Xen instance Cilium silently falls back to individual secondary IPs — no error, no warning, just a much lower per-node IP ceiling.

Observed on `mycluster-0`: an `i3.large` (Xen) sat at `prefixes=0`, `18/18 addresses allocated`, and stranded five pods in `ContainerCreating` — including Crossplane's `function-auto-ready`, which blocked **all** XR reconciliation cluster-wide until the pods were evicted. Every Nitro node in the same cluster had prefixes.

The failure surfaces nowhere near its cause: a pod that cannot get an IP wedges whatever depends on it, so the visible symptom was Crossplane compositions failing.

## The change

Adds a `karpenter.k8s.aws/instance-hypervisor: nitro` requirement to both NodePools (`default` and `io`), so Karpenter cannot provision an instance type where prefix delegation is impossible.

## Verification

`./scripts/validate-manifests.sh` → `Valid: 1193, Invalid: 0, Skipped: 0`, all gates passed, exit 0.

Live confirmation the constraint is right: after removing the `i3.large` NodeClaim, every remaining node in the cluster reports prefixes ≥ 1 and there are zero stuck pods.

## Related

- #1727 (already on `main`) recycles bootstrap node-group nodes so they get prefixes too
- The companion `max-pods` change (#1726 + #1728) is being ported separately