### PR TITLE
fix(eks): set node-group max-pods to Cilium's real ceiling

### DIFF
--- a/opentofu/eks/init/main.tf
+++ b/opentofu/eks/init/main.tf
@@ -161,20 +161,36 @@ module "eks" {
       # out at 42, and the overflow sits in ContainerCreating on "no IPs currently
       # available on the node" -- observed on both nodes of this group.
       #
-      # Prefix delegation would lift the ceiling to 3 x 14 x 16, but cannot be
-      # relied on HERE: these nodes are created during cluster bootstrap, before a
-      # cilium-operator exists to apply it, and their ENIs are never converted
-      # afterwards. Both showed prefixes=0 while every later Karpenter node had
-      # prefixes. Upstream also reports isPrefixDelegated flipping across an
-      # instance's lifetime (cilium/cilium#29634), so 42 is the guaranteed floor
-      # rather than a pessimistic guess.
+      # That 42 floor assumed prefix delegation could not be relied on here --
+      # these nodes are created during bootstrap, before a cilium-operator exists
+      # to apply it, and Cilium never converts an existing secondary-IP ENI. Both
+      # showed prefixes=0 while every later Karpenter node had prefixes.
       #
-      # 42 holds for every instance_type above -- all six are 4 ENIs x 15 IPs.
+      # That assumption no longer holds. The deploy script now recycles node-group
+      # nodes after Cilium is healthy (scripts/eks-recycle-bootstrap-nodes.sh,
+      # stage 3), so their replacements come up with Cilium already running and DO
+      # get prefixes. Verified on mycluster-0: both node-group nodes now report
+      # prefixes=3 after being replaced, alongside every Karpenter node.
+      #
+      # With prefix delegation applied the ceiling becomes
+      #                       (ENIs-1) x (IPs-1) x 16  =  3 x 14 x 16  =  672
+      # so IP addressability stops being the binding constraint and the limit
+      # becomes Kubernetes' own recommended maximum of 110 pods per node.
+      #
+      # 110 accepts one residual risk deliberately: upstream reports
+      # isPrefixDelegated flipping across an instance's lifetime
+      # (cilium/cilium#29634). If that happened, capacity would fall back to 42
+      # and pods above it would sit in ContainerCreating on "no IPs currently
+      # available on the node". The 42 floor was immune to that; 110 is not. The
+      # trade is deliberate -- pinning every node to 42 wastes ~85% of a
+      # prefix-delegated node to guard against a bug we have not observed here.
+      # If it ever bites, that symptom is the signature to look for.
+      #
       # Re-check with `aws ec2 describe-instance-types` before adding a type.
       # Bottlerocket settings reference: https://bottlerocket.dev/en/os/1.41.x/api/settings/
       bootstrap_extra_args = <<-EOT
         [settings.kubernetes]
-        max-pods = 42
+        max-pods = 110
       EOT
     }
   }

--- a/opentofu/eks/init/main.tf
+++ b/opentofu/eks/init/main.tf
@@ -147,11 +147,35 @@ module "eks" {
       capacity_type        = "SPOT"
       force_update_version = true
       instance_types       = ["c7i.xlarge", "c7i-flex.xlarge", "c6i.xlarge", "t3a.xlarge", "c7i.2xlarge", "c7i-flex.2xlarge"]
-      # Exemple of how to configure Bottlerocket. https://bottlerocket.dev/en/os/1.41.x/api/settings/
-      # bootstrap_extra_args = <<-EOT
-      #   [settings.host-containers.admin]
-      #   enabled = true
-      # EOT
+
+      # max-pods must match what CILIUM can address, not what AWS can attach.
+      #
+      # The AMI default comes from the AWS formula, which counts the primary ENI's
+      # secondary IPs:        ENIs x (IPs-1) + 2  =  4 x 14 + 2  =  58
+      # Cilium runs ENI IPAM with first-interface-index: 1, so eth0 is skipped
+      # entirely -- it sits in the NODE subnet (10.0.0.0/20) while pods must come
+      # from the pod subnet (100.64.0.0/18). Its real ceiling is:
+      #                       (ENIs-1) x (IPs-1)  =  3 x 14      =  42
+      #
+      # The 16-pod gap is not theoretical. The scheduler fills to 58, Cilium runs
+      # out at 42, and the overflow sits in ContainerCreating on "no IPs currently
+      # available on the node" -- observed on both nodes of this group.
+      #
+      # Prefix delegation would lift the ceiling to 3 x 14 x 16, but cannot be
+      # relied on HERE: these nodes are created during cluster bootstrap, before a
+      # cilium-operator exists to apply it, and their ENIs are never converted
+      # afterwards. Both showed prefixes=0 while every later Karpenter node had
+      # prefixes. Upstream also reports isPrefixDelegated flipping across an
+      # instance's lifetime (cilium/cilium#29634), so 42 is the guaranteed floor
+      # rather than a pessimistic guess.
+      #
+      # 42 holds for every instance_type above -- all six are 4 ENIs x 15 IPs.
+      # Re-check with `aws ec2 describe-instance-types` before adding a type.
+      # Bottlerocket settings reference: https://bottlerocket.dev/en/os/1.41.x/api/settings/
+      bootstrap_extra_args = <<-EOT
+        [settings.kubernetes]
+        max-pods = 42
+      EOT
     }
   }
 


### PR DESCRIPTION
Ports #1726 + #1728 to `main`. Both were opened against `chore/runlore-v0.12.0`, so **a rebuild from `main` today would still use the AMI default and over-schedule.** Cherry-picked as two commits so the reasoning trail and authorship survive; the net result is `max-pods = 110`.

## The bug (#1726)

`max-pods` must match what **Cilium** can address, not what AWS can attach.

The AMI default comes from the AWS formula, which counts the primary ENI's secondary IPs: `4 x 14 + 2 = 58`. But Cilium runs ENI IPAM with `first-interface-index: 1`, so eth0 is skipped entirely — it sits in the node subnet (`10.0.0.0/20`) while pods must come from the pod subnet (`100.64.0.0/18`).

That 16-pod gap is not theoretical: the scheduler fills to 58, Cilium runs out, and the overflow sits in `ContainerCreating` on `no IPs currently available on the node` — observed on both nodes of this group.

## Why the follow-up raised it to 110 (#1728)

#1726 pinned `42` because prefix delegation could not be relied on for these nodes: they are created during bootstrap, before a `cilium-operator` exists to apply it, and Cilium never converts an existing secondary-IP ENI.

**#1727 (already on `main`) fixed that premise** — it recycles node-group nodes after Cilium is healthy, so replacements come up with Cilium running and do get prefixes. Verified live:

```
ip-10-0-12-225  c7i-flex.xlarge  MNG  prefixes=3
ip-10-0-9-143   c7i-flex.xlarge  MNG  prefixes=3
```

With prefixes applied the ceiling is `(ENIs-1) x (IPs-1) x 16 = 672`, so IP addressability stops being the constraint and Kubernetes' recommended 110 takes over.

**48 was considered and rejected** — that was Cilium's on-demand allocation on a single ENI (`pre-allocate: 8`, no `max-allocate`, 1 of 3 usable ENIs attached), not a ceiling. It would have moved the artificial cap rather than removed it.

## Risk accepted, deliberately

Upstream reports `isPrefixDelegated` flipping across an instance's lifetime ([cilium/cilium#29634](https://github.com/cilium/cilium/issues/29634)). If that happened, capacity falls back to 42 and pods above it wedge in `ContainerCreating`. **42 was immune; 110 is not.** Pinning to 42 wastes ~85% of a prefix-delegated node to guard against a bug not observed here, so the in-code comment records the symptom to watch for rather than pretending the risk is gone.

## Verification

`tofu fmt -check` clean · `tofu validate` Success · `trivy config` no findings.

## Note

`bootstrap_extra_args` is baked at launch, so this applies to **newly created** nodes — existing ones keep their current value until replaced.