### PR TITLE
fix(runlore): scope NetworkPolicy ingress to its real callers

### DIFF
--- a/observability/base/runlore/ciliumnetworkpolicy-ingress.yaml
+++ b/observability/base/runlore/ciliumnetworkpolicy-ingress.yaml
@@ -1,0 +1,34 @@
+---
+# Companion to the chart-rendered NetworkPolicy (values.networkPolicy.ingressFrom).
+#
+# runlore's HTTPRoute parents onto `platform-public` (GatewayClass cilium), and this
+# cluster runs the shared cilium-envoy DaemonSet with hostNetwork=true
+# (external-envoy-proxy=true). Traffic leaving that proxy toward a pod is classified
+# by Cilium as the reserved `ingress` entity — it is not a pod in a namespace, so a
+# Kubernetes NetworkPolicy `from: namespaceSelector` can never match it.
+#
+# Because Cilium unions Kubernetes NetworkPolicies with CiliumNetworkPolicies, the
+# effective ingress allow-list for :8080 is:
+#   observability namespace  (chart NetworkPolicy — vmagent scrape + Alertmanager webhook)
+# + runlore peer pods        (chart NetworkPolicy — leader forwarding, runlore#264)
+# + ingress entity           (this policy — Gateway data plane / Slack interactions)
+# and nothing else.
+#
+# Dropping this file without also clearing `ingressFrom` black-holes every externally
+# routed request, including Slack's POST /slack/interactions. See issue #1589.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: runlore-gateway-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: runlore
+      app.kubernetes.io/instance: runlore
+  ingress:
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -105,6 +105,24 @@ spec:
       # Renders a CiliumNetworkPolicy allowing egress to the EKS Pod Identity
       # credential endpoint (169.254.170.23:80, host entity) — required on Cilium.
       awsPodIdentity: true
+      # Scope who may reach :8080. Left empty the chart emits no `from:` at all,
+      # i.e. every pod in the cluster can post to the webhook endpoint (#1589).
+      # In-cluster callers all live in `observability`: vmagent scrapes /metrics
+      # (vmServiceScrape below) and Alertmanager/VMAlert POST the incident
+      # webhook. The chart always prepends a peer podSelector, so replica-to-
+      # replica leader forwarding (runlore#264) survives this narrowing.
+      #
+      # NOT expressible here: the Gateway data plane. runlore's HTTPRoute hangs
+      # off `platform-public` (GatewayClass cilium), and this cluster runs the
+      # shared cilium-envoy DaemonSet with hostNetwork=true — so from runlore's
+      # side that traffic is Cilium's `ingress` entity, not a pod in a namespace.
+      # A namespaceSelector cannot match it, and adding one here alone would
+      # black-hole Slack's POST /slack/interactions. It is allowed instead by
+      # ciliumnetworkpolicy-ingress.yaml (Cilium unions the two policies).
+      ingressFrom:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
       # The chart's non-strict egress only opens 443/6443 — but VictoriaMetrics
       # (vmsingle :8428) and VictoriaLogs (:9428) listen on other ports, so without
       # this the agent's metrics/logs tool calls hang until they time out, starving

--- a/observability/base/runlore/kustomization.yaml
+++ b/observability/base/runlore/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: runlore
 
 resources:
+  - ciliumnetworkpolicy-ingress.yaml
   - externalsecret-credentials.yaml
   - externalsecret-slack.yaml
   - externalsecret-webhook.yaml


### PR DESCRIPTION
Ports #1589 to `main`. It was opened against `chore/runlore-v0.12.0`, so **on `main` runlore's `:8080` is still reachable by every pod in the cluster.**

> ⏸️ **Hold** — merge alongside the runlore v0.12.0 release cut, per the plan on #1725/#1726.

## What is wrong on `main`

The chart's NetworkPolicy leaves `ingressFrom` empty, so it emits no `from:` at all — every pod in the cluster can POST to runlore's webhook port.

Worth correcting a misconception #1589 itself started with: runlore is **not** unprotected. `kubectl get cnp` lists only CiliumNetworkPolicies and misses the chart's `networking.k8s.io/v1` one, which Cilium enforces identically. Egress was already default-deny. Ingress was the real gap.

## The change

Two policies, because one alone cannot express it:

- `values.networkPolicy.ingressFrom` → the `observability` namespace (vmagent scrapes `/metrics`, Alertmanager/VMAlert POST the webhook). The chart always prepends a peer `podSelector`, so leader forwarding survives.
- New `ciliumnetworkpolicy-ingress.yaml` → `fromEntities: [ingress]` on 8080.

**The second one is load-bearing.** Setting `ingressFrom` alone black-holes every externally routed request: runlore's HTTPRoute parents onto `platform-public` (GatewayClass `cilium`), and this cluster runs the shared `cilium-envoy` DaemonSet with `hostNetwork=true` — so that traffic arrives as Cilium's reserved `ingress` entity, which no `namespaceSelector` can match. Cilium unions the two, giving `observability` + peers + `ingress` and nothing else.

## Compatibility with `main`

Checked rather than assumed — `main` pins runlore `v0.11.0`, and that chart both documents and renders the value:

```
deploy/helm/runlore/templates/networkpolicy.yaml:22
  {{- with .Values.networkPolicy.ingressFrom }}
```

## Verification (from the original, on a live cluster)

| Path | Evidence |
|---|---|
| Gateway → pod | `POST /slack/interactions` → `401 unauthorized` in 50ms — runlore's own signature rejection, so it reached the pod |
| observability → pod | `up{namespace="runlore"}` = `1` for both pods |
| peer → peer | both pods `1/1`, leader election intact |
| Drops | `hubble observe --verdict DROPPED` → no rows |

Here: `./scripts/validate-manifests.sh` → `Valid: 1195, Invalid: 0, Skipped: 0`, all gates passed.

Egress `443`/`6443`-to-anywhere is deliberately unchanged — tracked on #1589.