### PR TITLE
chore(headlamp): upgrade v0.44.0

### DIFF
--- a/tooling/base/headlamp/helmrelease.yaml
+++ b/tooling/base/headlamp/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: headlamp
-      version: "0.41.0"
+      version: "0.44.0"
       sourceRef:
         kind: HelmRepository
         name: headlamp


### PR DESCRIPTION
Ports the Headlamp bump to `main`. It was committed onto `chore/runlore-v0.12.0`, so `main` is still on `0.41.0` and would stay there through a rebuild.

> ⏸️ **Hold** — merge alongside the runlore v0.12.0 release cut, per the plan on the other ports.

Chart `0.41.0` → `0.44.0`. Nothing else changes; the HelmRelease values are untouched.

Unrelated to the Cilium/IPAM work in the sibling PRs — it is only here because it happened to be committed on the same branch, and would otherwise be silently lost when that branch is eventually retired.

## Verification

`./scripts/validate-manifests.sh` → `Valid: 1193, Invalid: 0, Skipped: 0`, all gates passed, exit 0. That gate renders the chart through `helm template` with the repo's own values, so a values-schema break in the new chart version would fail here rather than at reconcile time.

Live: Headlamp is already running `0.44.0` on `mycluster-0` from the branch, `1/1 Ready`.