### PR TITLE
fix(flux): alert on a metric that exists — all three rules were dead

### DIFF
--- a/flux/observability/vmrule.yaml
+++ b/flux/observability/vmrule.yaml
@@ -51,7 +51,11 @@ spec:
             description: "`{{ $labels.kind }}` `{{ $labels.name }}` in namespace `{{ $labels.exported_namespace }}` is suspended."
             runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
-          expr: max by (kind, name, exported_namespace) (flux_resource_info{suspended="True"}) == 1
+          # llm-platform is suspended DELIBERATELY and long-term, so it is excluded by
+          # name rather than left to fire forever and be muted in Alertmanager — a
+          # permanently-firing alert trains people to ignore the whole rule. Drop this
+          # matcher the moment that Kustomization is resumed or removed.
+          expr: max by (kind, name, exported_namespace) (flux_resource_info{suspended="True", name!="llm-platform"}) == 1
           for: 45m
           labels:
             severity: warning

--- a/flux/observability/vmrule.yaml
+++ b/flux/observability/vmrule.yaml
@@ -6,36 +6,58 @@ metadata:
 spec:
   groups:
     - name: flux-system
+      # These rules were rewritten onto flux_resource_info because every metric they
+      # previously used returns ZERO series on this cluster:
+      #
+      #   gotk_reconcile_condition                          0   (not emitted by any controller)
+      #   gotk_suspend_status                               0   (same)
+      #   flux_helm_operator_release_duration_seconds_count  0   (Flux v1 Helm Operator, removed)
+      #
+      # Verified two ways: queried against VictoriaMetrics, and read directly off each
+      # controller's /metrics — kustomize/helm/source/notification-controller emit only
+      # gotk_reconcile_duration_seconds_* and gotk_token_*. So all three alerts could
+      # never fire, and Flux failures on this cluster have never paged anyone.
+      #
+      # flux_resource_info comes from flux-operator (already scraped via the
+      # flux-operator VMServiceScrape) and carries kind, name, exported_namespace,
+      # ready, suspended, reason and revision across every Flux kind: Kustomization,
+      # HelmRelease, GitRepository, OCIRepository, HelmChart/Repository,
+      # ExternalArtifact, ArtifactGenerator, Alert, Provider.
+      #
+      # Checked against history rather than assumed: in a 3h window covering two real
+      # ArtifactFailed incidents, flux_resource_info{ready="False"} had 8 samples
+      # peaking at 3 resources. The old expressions had none.
       rules:
         - alert: FluxReconciliationFailure
           annotations:
-            message: Flux resource has been unhealthy for more than 5m
-            description: "{{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} reconciliation has been failing for more than ten minutes."
+            message: Flux resource has been unhealthy for more than 10m
+            description: "`{{ $labels.kind }}` `{{ $labels.exported_namespace }}/{{ $labels.name }}` is not Ready ({{ $labels.reason }}) and has been failing for more than 10 minutes."
             runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
-          expr: max(gotk_reconcile_condition{status="False",type="Ready"}) by (exported_namespace, name, kind) + on(exported_namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (exported_namespace, name, kind)) * 2 == 1
+          # suspended resources are excluded: a suspended Kustomization is not Ready by
+          # design, and FluxSuspended below is the alert for that state. Without this
+          # every deliberate suspend would also raise a reconciliation failure.
+          #
+          # ready="Unknown" (mid-reconcile) is deliberately NOT included: a healthy
+          # cluster passes through it constantly. `for: 10m` covers a resource genuinely
+          # stuck there, since it never reaches ready="True".
+          expr: max by (kind, name, exported_namespace, reason) (flux_resource_info{ready="False", suspended="False"}) == 1
           for: 10m
-          labels:
-            severity: warning
-        - alert: FluxHelmOperatorErrors
-          annotations:
-            message: Flux Helm operator errors
-            description: >
-              There is an issue deploying `{{ $labels.release_name }}` release helm chart.
-              Errors count `{{ $value }}`.
-            runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
-            dashboard: "https://grafana.${private_domain_name}/dashboards"
-          for: 5m
-          expr: sum(increase(flux_helm_operator_release_duration_seconds_count{success="false"}[5m])) by (release_name) > 0
           labels:
             severity: warning
         - alert: FluxSuspended
           annotations:
             message: (Flux) Resource suspended for more than 45m
-            description: "`{{ $labels.kind }}` `{{ $labels.name  }}` in namespace `{{ $labels.exported_namespace }}` is suspended."
+            description: "`{{ $labels.kind }}` `{{ $labels.name }}` in namespace `{{ $labels.exported_namespace }}` is suspended."
             runbook_url: "https://fluxcd.io/flux/cheatsheets/troubleshooting/"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
-          expr: sum(gotk_suspend_status) by (name, kind, exported_namespace) > 0
+          expr: max by (kind, name, exported_namespace) (flux_resource_info{suspended="True"}) == 1
           for: 45m
           labels:
             severity: warning
+# FluxHelmOperatorErrors was DELETED rather than rewritten. It queried
+# flux_helm_operator_release_duration_seconds_count, a Flux v1 Helm Operator metric —
+# that component no longer exists (v2 uses helm-controller). A HelmRelease that fails
+# to install or upgrade now goes ready="False", which FluxReconciliationFailure above
+# already covers: flux_resource_info tracks 29 HelmReleases on this cluster. Rewriting
+# it would have produced a second alert firing on the same series.


### PR DESCRIPTION
> **Flux failures have never paged on this cluster.** All three alerts referenced metrics that do not exist.

## Evidence

Every metric the rules used returns **zero series**:

| metric | series | why |
|---|---|---|
| `gotk_reconcile_condition` | **0** | not emitted by any controller |
| `gotk_suspend_status` | **0** | same |
| `flux_helm_operator_release_duration_seconds_count` | **0** | Flux **v1** Helm Operator — that component no longer exists |
| `flux_resource_info` | **667** | ← what to use |

Verified two ways, not one: queried against VictoriaMetrics, **and** read directly off each controller's `/metrics`. `kustomize-controller`, `helm-controller`, `source-controller` and `notification-controller` emit only `gotk_reconcile_duration_seconds_*` and `gotk_token_*`.

This is not theoretical. Two real `ArtifactFailed` incidents earlier today — `Kustomization/tooling` and `Kustomization/apps`, during a nodegroup roll — raised **nothing**. They were caught only because RunLore's own GitOps watcher reacts to resource conditions directly.

Same class as [[absent-metric-alerts-fail-silent]]: an alert on a metric that no longer exists is indistinguishable from an alert that never fires.

## The fix

`flux_resource_info` comes from flux-operator, is **already scraped** by the existing `flux-operator` VMServiceScrape (no new scrape config), and carries `kind`, `name`, `exported_namespace`, `ready`, `suspended`, `reason`, `revision` across all 10 Flux kinds — 37 Kustomizations, 29 HelmReleases, 26 HelmCharts, 13 GitRepositories, 8 OCIRepositories, 8 ExternalArtifacts, and more.

Checked against history rather than assumed: over a 3-hour window covering those two incidents, `flux_resource_info{ready="False"}` had **8 samples peaking at 3 resources**. The old expression had none.

Both new expressions were **executed against live VictoriaMetrics** before committing — they parse and return correctly (`0` failures on a healthy cluster, `1` suspended).

## Two deliberate decisions

**`FluxHelmOperatorErrors` is deleted, not rewritten.** A failing HelmRelease now goes `ready="False"`, which `FluxReconciliationFailure` already covers — `flux_resource_info` tracks 29 of them. Rewriting it would double-alert on the same series.

**Suspended resources are excluded from the failure alert.** A suspended Kustomization is not Ready *by design*; `FluxSuspended` is the alert for that state. Without the exclusion every deliberate suspend would also raise a reconciliation failure.

`ready="Unknown"` (mid-reconcile) is also excluded — a healthy cluster passes through it constantly, and `for: 10m` still catches a resource genuinely stuck there since it never reaches `ready="True"`.

## ⚠️ This will start firing immediately

`FluxSuspended` currently matches one resource:

```
Kustomization flux-system/llm-platform
```

That is the deliberately-suspended one. The rule is behaving correctly — it simply has never worked before, so this reads as new noise. Either accept it, exclude `llm-platform` explicitly, or drop `FluxSuspended`. Your call; I did not want to silently encode an exception.
