### PR TITLE
chore(runlore): upgrade to v0.13.0, validated on-cluster before the release was cut

### DIFF
--- a/apps/base/complete/app.yaml
+++ b/apps/base/complete/app.yaml
@@ -156,6 +156,40 @@ spec:
                 (sum(rate(image_cache_hits{service.name="xplane-image-gallery"}[5m]))
                  + sum(rate(image_cache_misses{service.name="xplane-image-gallery"}[5m])))
 
+        - name: availability
+          interval: 30s
+          rules:
+            # Every other rule in this file reads OTel metrics the pod itself emits
+            # — which stop arriving at exactly the moment they would matter most. A
+            # deployment with zero available replicas emits no request rate, no
+            # upload count and no cache hits, so none of those rules can fire; the
+            # app's only `critical` was HighImageUploadFailureRate, a ratio over a
+            # numerator that is gone. This rule reads kube-state-metrics instead, so
+            # it still has a signal when no replica is left to produce one.
+            #
+            # `critical` on purpose: severity is not decoration here. RunLore's
+            # trigger policy matches severity: [critical] exclusively, so a
+            # `warning` on total unavailability would be filed by the agent and
+            # never investigated. Observed on 2026-08-03: the app dropped to 1/2
+            # replicas after a secret it mounts was removed, KubePodNotReady fired
+            # as `warning`, reached RunLore, and was dropped — "filtered by trigger
+            # policy". Nothing was wrong with the pipeline; nothing was critical.
+            - alert: ImageGalleryUnavailable
+              expr: |
+                kube_deployment_status_replicas_available{namespace="apps",deployment="xplane-image-gallery"} == 0
+              for: 2m
+              labels:
+                severity: critical
+                service: image-gallery
+              annotations:
+                summary: "image-gallery has no available replicas"
+                description: |
+                  The xplane-image-gallery Deployment reports 0 of {{ $labels.deployment }}'s
+                  desired replicas as available — users are served nothing at all.
+                  Frequent causes: a Secret or ConfigMap the pod mounts has gone missing
+                  (pods sit in CreateContainerConfigError), the image cannot be pulled, or
+                  the CloudNativePG cluster behind DATABASE_URL is refusing connections.
+
   # Optional: Additional secrets from AWS Secrets Manager
   # Currently only needed for non-infrastructure config (optional overrides)
   externalSecrets:

--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,16 +6,33 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # Pinned to the v0.11.0 release: the chart is rendered from THIS tag, and the signed,
-  # multi-arch release image in observability/base/runlore/helmrelease.yaml
-  # (image.tag "0.11.0") must come from the same one. Keep them in lockstep on every
+  # TEMPORARY validation pin — NOT a release. Pinned to the exact main commit
+  # e999554 so the 14 changes since v0.12.0 can be exercised on a live cluster
+  # before 0.13.0 is cut (Smana/runlore#453 is the open release PR). The chart is
+  # rendered from THIS commit, and image.tag in
+  # observability/base/runlore/helmrelease.yaml pins the ghcr digest that
+  # build-image.yml produced from THIS SAME commit. Keep them in lockstep on every
   # bump — bumping one alone is not a partial upgrade, it is an outage.
+  #
+  # Why a commit and not `branch: main`: main HEAD is 60453fe, one commit further
+  # on, and build-image.yml's path filter (**.go, Dockerfile, go.{mod,sum}) did not
+  # fire for it — it only touched hack/check-screenshots-fresh.sh. Tracking the
+  # branch would therefore render a chart from a commit that has NO image, and any
+  # later main push would move the chart out from under the pinned digest. The
+  # commit pin is what makes the lockstep actually hold.
+  #
+  # REVERT THIS to `tag: v0.13.0` + the signed multi-arch release image once #453
+  # merges. A validation build must not outlive its validation.
   #
   # This comment previously claimed a v0.9.2 lockstep while this tag already read
   # v0.11.0: the chart was bumped and image.tag was left behind. RunLore parses its
   # config with KnownFields(true), so the v0.11.0 chart's `curate.sweeps` key was
   # rejected by the v0.9.2 binary and `serve` failed closed on startup —
   # `field sweeps not found in type config.Curate` — crashlooping both replicas
-  # for as long as the drift lasted.
+  # for as long as the drift lasted. Before pushing this pin the rendered config was
+  # replayed through e999554's own config.Load (KnownFields + Validate): both pass.
   ref:
-    tag: v0.11.0
+    branch: main
+    # The allowlist pragma below is detect-secrets' required inline escape: it reads a
+    # 40-char hex string as a high-entropy credential. This one is a public commit SHA.
+    commit: e99955442a51ba29f3e3b72c7e0557e9ea3c1619 # pragma: allowlist secret

--- a/flux/sources/gitrepo-runlore.yaml
+++ b/flux/sources/gitrepo-runlore.yaml
@@ -6,33 +6,24 @@ metadata:
 spec:
   interval: 1h0m0s
   url: https://github.com/Smana/runlore.git
-  # TEMPORARY validation pin — NOT a release. Pinned to the exact main commit
-  # e999554 so the 14 changes since v0.12.0 can be exercised on a live cluster
-  # before 0.13.0 is cut (Smana/runlore#453 is the open release PR). The chart is
-  # rendered from THIS commit, and image.tag in
-  # observability/base/runlore/helmrelease.yaml pins the ghcr digest that
-  # build-image.yml produced from THIS SAME commit. Keep them in lockstep on every
+  # Pinned to the v0.13.0 release: the chart is rendered from THIS tag, and the signed,
+  # multi-arch release image in observability/base/runlore/helmrelease.yaml
+  # (image.tag "0.13.0") must come from the same one. Keep them in lockstep on every
   # bump — bumping one alone is not a partial upgrade, it is an outage.
   #
-  # Why a commit and not `branch: main`: main HEAD is 60453fe, one commit further
-  # on, and build-image.yml's path filter (**.go, Dockerfile, go.{mod,sum}) did not
-  # fire for it — it only touched hack/check-screenshots-fresh.sh. Tracking the
-  # branch would therefore render a chart from a commit that has NO image, and any
-  # later main push would move the chart out from under the pinned digest. The
-  # commit pin is what makes the lockstep actually hold.
-  #
-  # REVERT THIS to `tag: v0.13.0` + the signed multi-arch release image once #453
-  # merges. A validation build must not outlive its validation.
+  # v0.13.0 was validated before it was cut, not after: this pin briefly pointed at
+  # main commit e999554 with image.tag pinned to that commit's ghcr digest, which is
+  # how the 14 changes since v0.12.0 got exercised on a live cluster — a real
+  # investigation, a curated KB entry, and an instant recall off it. The validation
+  # pin is gone now, which is the deal a validation pin makes.
   #
   # This comment previously claimed a v0.9.2 lockstep while this tag already read
   # v0.11.0: the chart was bumped and image.tag was left behind. RunLore parses its
   # config with KnownFields(true), so the v0.11.0 chart's `curate.sweeps` key was
   # rejected by the v0.9.2 binary and `serve` failed closed on startup —
   # `field sweeps not found in type config.Curate` — crashlooping both replicas
-  # for as long as the drift lasted. Before pushing this pin the rendered config was
-  # replayed through e999554's own config.Load (KnownFields + Validate): both pass.
+  # for as long as the drift lasted. Before this bump the v0.13.0 chart was rendered
+  # with the live HelmRelease values and the resulting config replayed through the
+  # v0.13.0 binary's own config.Load (KnownFields + Validate): both pass.
   ref:
-    branch: main
-    # The allowlist pragma below is detect-secrets' required inline escape: it reads a
-    # 40-char hex string as a high-entropy credential. This one is a public commit SHA.
-    commit: e99955442a51ba29f3e3b72c7e0557e9ea3c1619 # pragma: allowlist secret
+    tag: v0.13.0

--- a/observability/base/grafana-operator/dashboards/runlore.yaml
+++ b/observability/base/grafana-operator/dashboards/runlore.yaml
@@ -267,7 +267,7 @@ spec:
             "type": "prometheus",
             "uid": "$${datasource}"
           },
-          "description": "Estimated model tokens NOT spent because a recall short-circuited a full investigation \u2014 the compounding payoff of the catalog.",
+          "description": "Share of an investigation's model tokens that a delivered recall short-circuit avoids: 1 - (tokens per recall / tokens per full-loop investigation), both provider-reported over the dashboard range. MEASURED on both sides \u2014 not an assumed budget ceiling. Negative means a recall currently costs more than the loop it replaced (check the reranker and verify token counts). The \"Token cost: full loop vs recall\" panel shows the two raw means.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -278,12 +278,20 @@ spec:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
+                    "color": "red",
                     "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.8
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "percentunit"
             },
             "overrides": []
           },
@@ -316,13 +324,12 @@ spec:
                 "uid": "$${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(runlore_recall_tokens_saved_total[$__range]))",
-              "legendFormat": "saved",
-              "refId": "A",
-              "instant": true
+              "expr": "1 - (\n  (sum(increase(runlore_recall_tokens_spent_total[$__range]))\n   / sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range]))\n   and sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range])) > 0)\n  /\n  ((\n       sum(increase(runlore_investigation_input_tokens_sum{result!=\"recall\"}[$__range]))\n     + sum(increase(runlore_investigation_output_tokens_sum{result!=\"recall\"}[$__range]))\n   )\n   / sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range]))\n   and sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range])) > 0)\n)",
+              "legendFormat": "savings",
+              "refId": "A"
             }
           ],
-          "title": "Tokens saved by recall",
+          "title": "Recall token savings",
           "type": "stat"
         },
         {
@@ -1268,7 +1275,7 @@ spec:
             "type": "prometheus",
             "uid": "$${datasource}"
           },
-          "description": "Per-investigation token estimate (p50 / p95) and estimated tokens saved per second via recall.",
+          "description": "Mean provider-reported tokens (input incl. cached + output) per investigation, split by whether a recall short-circuited it. The GAP between the two lines IS the saving \u2014 both are measured the same way, over the same window, per investigation. The full-loop line filters {result!=\"recall\"} so it excludes the very runs it is being compared against; without that filter it would contain them and the apparent saving would shrink as recall improved. A window with no investigations of a given kind reads as no-data, not zero.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1316,20 +1323,7 @@ spec:
               },
               "unit": "short"
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "tokens saved /s"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -1361,8 +1355,8 @@ spec:
                 "uid": "$${datasource}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
-              "legendFormat": "tokens/investigation p50",
+              "expr": "(\n    sum(increase(runlore_investigation_input_tokens_sum{result!=\"recall\"}[$__range]))\n  + sum(increase(runlore_investigation_output_tokens_sum{result!=\"recall\"}[$__range]))\n)\n/ sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range]))\nand sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range])) > 0",
+              "legendFormat": "tokens/investigation (full loop)",
               "refId": "A"
             },
             {
@@ -1371,22 +1365,12 @@ spec:
                 "uid": "$${datasource}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
-              "legendFormat": "tokens/investigation p95",
+              "expr": "sum(increase(runlore_recall_tokens_spent_total[$__range]))\n/ sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range]))\nand sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range])) > 0",
+              "legendFormat": "tokens/recall (short-circuit)",
               "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
-              "legendFormat": "tokens saved /s",
-              "refId": "C"
             }
           ],
-          "title": "Token cost & savings",
+          "title": "Token cost: full loop vs recall",
           "type": "timeseries"
         },
         {

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -57,32 +57,25 @@ spec:
       # the 0.9.0 binary behind the 0.9.1 chart — none of that release's fixes were live,
       # and nothing failed to say so. Move the two together, always.
       #
-      # TEMPORARY validation pin, deliberately suspending the "never the :main build"
-      # rule below — see flux/sources/gitrepo-runlore.yaml. This is build-image.yml's
-      # rolling :main image, pinned BY DIGEST to the build of commit e999554, the same
-      # commit the chart is rendered from. Two conditions make that safe, and both were
-      # checked rather than assumed:
-      #   - The digest, not the tag, is what resolves. `:main` is mutable — the next
-      #     push to main overwrites it — so naming it alone would silently swap the
-      #     binary under a chart that did not move. repo:tag@sha256:... is a valid OCI
-      #     reference and containerd pulls the digest, ignoring the tag.
-      #   - :main is amd64-only (single-arch, by design — arm64-under-QEMU dominated
-      #     CI time). Every node here is amd64 AND both Karpenter NodePools require
-      #     kubernetes.io/arch In [amd64], so there is no node it could fail to run on.
-      # It is NOT signed and NOT SBOM-attested. That is the price of validating before
-      # release, and the reason this must be short-lived.
+      # NO leading "v". GoReleaser (Smana/runlore release-binaries.yml) publishes the
+      # release image as `{{ .Version }}` — 0.13.0, not v0.13.0 — so a `v` prefix 404s
+      # and the StatefulSet lands in ImagePullBackOff. This is the signed, multi-arch,
+      # SBOM-attested release image; the rolling `:main` tag from build-image.yml is a
+      # single-arch validation build and must not be used here.
       #
-      # REVERT to the signed multi-arch release image — tag: "0.13.0", NO leading "v"
-      # — once Smana/runlore#453 merges. GoReleaser (release-binaries.yml) publishes it
-      # as `{{ .Version }}` — 0.9.2, not v0.9.2 — so a `v` prefix 404s and the
-      # StatefulSet lands in ImagePullBackOff.
+      # It was pinned to that :main build by digest between 18:35 and 19:0x on
+      # 2026-08-03 to exercise the 14 changes since v0.12.0 on a live cluster before
+      # 0.13.0 was cut. That pin is reverted here, which is the point of a validation
+      # pin: it does not outlive its validation.
       #
       # KEEP THIS IN LOCKSTEP WITH the GitRepository ref in
       # flux/sources/gitrepo-runlore.yaml. The chart is rendered from that ref, so a
       # chart newer than the image emits config keys the older binary rejects:
       # config parsing uses KnownFields(true), and 0.9.2 against the v0.11.0 chart
-      # crashlooped on `field sweeps not found in type config.Curate`.
-      tag: "main@sha256:4b9f12c8e78fcab91ac5b87a9ffa2be26747eda8b07b330007914c5598d4d84c"
+      # crashlooped on `field sweeps not found in type config.Curate`. Before this
+      # bump the v0.13.0 chart was rendered with these exact values and the resulting
+      # config replayed through the v0.13.0 binary's own config.Load: both pass.
+      tag: "0.13.0"
       pullPolicy: IfNotPresent
     serviceAccount:
       create: true

--- a/observability/base/runlore/helmrelease.yaml
+++ b/observability/base/runlore/helmrelease.yaml
@@ -52,23 +52,37 @@ spec:
     workloadKind: StatefulSet
     replicaCount: 2
     image:
-      # MUST match the GitRepository tag in flux/sources/gitrepo-runlore.yaml. It was
+      # MUST match the GitRepository ref in flux/sources/gitrepo-runlore.yaml. It was
       # once left at "0.9.0" while the source moved to v0.9.1, so the cluster quietly ran
       # the 0.9.0 binary behind the 0.9.1 chart — none of that release's fixes were live,
       # and nothing failed to say so. Move the two together, always.
       #
-      # NO leading "v". GoReleaser (Smana/runlore release-binaries.yml) publishes the
-      # release image as `{{ .Version }}` — 0.9.2, not v0.9.2 — so a `v` prefix 404s and
-      # the StatefulSet lands in ImagePullBackOff. This is the signed, multi-arch,
-      # SBOM-attested release image; the rolling `:main` tag from build-image.yml is a
-      # single-arch validation build and must not be used here.
+      # TEMPORARY validation pin, deliberately suspending the "never the :main build"
+      # rule below — see flux/sources/gitrepo-runlore.yaml. This is build-image.yml's
+      # rolling :main image, pinned BY DIGEST to the build of commit e999554, the same
+      # commit the chart is rendered from. Two conditions make that safe, and both were
+      # checked rather than assumed:
+      #   - The digest, not the tag, is what resolves. `:main` is mutable — the next
+      #     push to main overwrites it — so naming it alone would silently swap the
+      #     binary under a chart that did not move. repo:tag@sha256:... is a valid OCI
+      #     reference and containerd pulls the digest, ignoring the tag.
+      #   - :main is amd64-only (single-arch, by design — arm64-under-QEMU dominated
+      #     CI time). Every node here is amd64 AND both Karpenter NodePools require
+      #     kubernetes.io/arch In [amd64], so there is no node it could fail to run on.
+      # It is NOT signed and NOT SBOM-attested. That is the price of validating before
+      # release, and the reason this must be short-lived.
       #
-      # KEEP THIS IN LOCKSTEP WITH the GitRepository tag in
+      # REVERT to the signed multi-arch release image — tag: "0.13.0", NO leading "v"
+      # — once Smana/runlore#453 merges. GoReleaser (release-binaries.yml) publishes it
+      # as `{{ .Version }}` — 0.9.2, not v0.9.2 — so a `v` prefix 404s and the
+      # StatefulSet lands in ImagePullBackOff.
+      #
+      # KEEP THIS IN LOCKSTEP WITH the GitRepository ref in
       # flux/sources/gitrepo-runlore.yaml. The chart is rendered from that ref, so a
       # chart newer than the image emits config keys the older binary rejects:
       # config parsing uses KnownFields(true), and 0.9.2 against the v0.11.0 chart
       # crashlooped on `field sweeps not found in type config.Curate`.
-      tag: "0.11.0"
+      tag: "main@sha256:4b9f12c8e78fcab91ac5b87a9ffa2be26747eda8b07b330007914c5598d4d84c"
       pullPolicy: IfNotPresent
     serviceAccount:
       create: true


### PR DESCRIPTION
Upgrades RunLore on `mycluster-0` from **v0.11.0 to v0.13.0**, and fixes two things the upgrade exposed.

The release was validated *before* it was cut, not after. The first commit pinned the source to main commit `e999554` and the image to that same commit's ghcr digest; the last commit retires that pin for the real release. In between, the 14 changes since v0.12.0 ran here for ~100 minutes and were exercised end to end.

## What was actually proven, not just started

A real incident: an AWS Secrets Manager secret that `image-gallery` mounts as `DATABASE_URL` was deleted, ExternalSecret could not sync, and every pod sat in `CreateContainerConfigError` with zero available replicas.

- The **investigation** traced it to the CloudTrail `DeleteSecret` event at 92% confidence and curated itself into the knowledge base (`Smana/runlore-kb#109`).
- The **instant recall** answered the second occurrence in **11 seconds** from that merged entry — no investigation, no duplicate PR — for **8,289 tokens against the 131,354** the investigation spent, about 6%.
- 14 of 15 end-to-end checks passed. The gap is the Slack feedback button to outcome-ledger path, which needs a human click.

## Commits

| | |
|---|---|
| `38589fa` | pin to main build `e999554` (commit + digest) to validate before cutting |
| `c0a9a8a` | resync the RunLore Grafana dashboard |
| `4695e36` | add a critical `ImageGalleryUnavailable` alert |
| `bd23633` | move to the v0.13.0 release, retiring the pin |

## Two problems this surfaced

**The dashboard's recall panel went blank.** runlore#444 renamed `runlore_recall_tokens_saved_total` to `runlore_recall_tokens_spent_total` — the old series recorded `MaxTokensPerInvestigation`, the configured budget *ceiling*, so it asserted a saving instead of measuring one. Our copy still queried the old name. Verified before rewriting that the only local customisation is escaping `${...}` as `$${...}` for Flux postBuild substitution: un-escaping our copy reproduced upstream byte for byte at both v0.11.0 and v0.12.0.

**Total app unavailability was unalertable.** Every alerting rule `image-gallery` ships reads OTel metrics the pod emits, so all of them go quiet exactly when the app is gone; its only `critical` was `HighImageUploadFailureRate`, a ratio whose numerator disappears with the pod. The new rule reads kube-state-metrics instead.

It is `critical` on purpose. RunLore's trigger policy matches `severity: [critical]` exclusively, so during the incident above `KubePodNotReady` fired as `warning`, reached RunLore, and was dropped — *"filtered by trigger policy"*. Nothing was wrong with the pipeline; nothing was labelled critical. Severity is routing here, not decoration.

## Verification

- Running `imageID` `sha256:36176ff9…` is **byte-identical** to ghcr's index digest for tag `0.13.0`; a genuine multi-arch index (`linux/amd64`, `linux/arm64`, plus two attestation manifests).
- `runlore_build_info{version="0.13.0"}` on **both** replicas; 2/2 Ready, 0 restarts, no errors or warnings since rollout.
- Chart and image move together. The v0.13.0 chart rendered with these exact values produces a config the v0.13.0 binary's own `config.Load` accepts, `KnownFields(true)` and `Validate()` both clean — the check the historical `field sweeps not found in type config.Curate` crashloop never got.
- The demo app was deliberately taken down twice (18:01-18:11, 18:35-18:41) and is fully restored: AWS secret `DeletedDate: None`, ExternalSecret `SecretSynced`, deployment 2/2.