### PR TITLE
Add a documentation link gate, and fix the 30 links it found broken

### DIFF
--- a/.claude/rules/process.md
+++ b/.claude/rules/process.md
@@ -14,6 +14,7 @@ Before claiming status: identify the command, run it fresh, cite the output inli
 |-------|--------------------------------|
 | Manifests valid | `./scripts/validate-manifests.sh` → exit 0, and the report shows `Invalid: 0, Skipped: 0` |
 | KCL composition valid | `./scripts/validate-kcl-compositions.sh` → exit 0 |
+| Docs links resolve | `./scripts/validate-links.sh` → exit 0 (run after ANY file move — a path grep cannot see relative-link rot) |
 | Design ready | Design doc committed under `docs/superpowers/specs/`, no `[NEEDS CLARIFICATION]` markers left |
 | Success criteria met (post-merge) | `/verify-spec <design-doc>` against live cluster |
 | Flux reconciled | `flux get kustomizations` / `helmreleases` → `Ready=True` |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,3 +195,11 @@ jobs:
       - name: Run ShellCheck
         run: |
           find ./scripts -name "*.sh" -type f -print0 | xargs -0 shellcheck -x -S warning
+
+  links:
+    name: Check the documentation links 🔗
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve every relative Markdown link
+        run: ./scripts/validate-links.sh

--- a/.linkcheck-allow
+++ b/.linkcheck-allow
@@ -1,0 +1,11 @@
+# Known-broken relative Markdown links, accepted for now.
+# Format: <file><TAB><target>.  Delete entries as they are fixed; never add one
+# to route around a break your own change introduced.
+#
+# App Wizard screenshots — placeholders. docs/assets/app-wizard/README.md lists
+# exactly what each should show and where to capture it from.
+docs/app-wizard.md	assets/app-wizard/01-create-form.png
+docs/app-wizard.md	assets/app-wizard/02-advanced.png
+docs/app-wizard.md	assets/app-wizard/03-validation.png
+docs/app-wizard.md	assets/app-wizard/04-render-preview.png
+docs/app-wizard.md	assets/app-wizard/05-pull-request.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,7 @@ Use the FluxCD agent-skills plugin for Flux troubleshooting (`/gitops-cluster-de
 tofu validate
 trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .
 ./scripts/validate-manifests.sh   # renders the repo, then gates it (see below)
+./scripts/validate-links.sh       # resolves every relative Markdown link
 kubectl get nodes && kubectl get pods --all-namespaces
 flux get all
 ```

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -20,6 +20,7 @@ CI never applies changes to a cluster. It validates, scans, and publishes; Flux 
 | `build-container-images.yml` | push / PR / dispatch | Detect changed images under `container-images/`, build each, push on non-PR events |
 | `crossplane-modules.yml` | push / PR | Validate, test and publish the KCL Crossplane modules to GHCR |
 | `vector-config-validation.yml` | push / PR | Validate the Vector log-parsing configuration |
+| `ci.yaml` → `links` | PR → main | Resolve every relative Markdown link; fails on any break not in `.linkcheck-allow` |
 | `terramate-preview.yaml` / `terramate-drift-detection.yaml` | — | **Currently disabled** (fully commented out). See [Terramate workflows](#terramate-workflows-disabled). |
 
 ## CI pipeline (`ci.yaml`)
@@ -145,6 +146,23 @@ Validates and publishes the KCL Crossplane modules in `infrastructure/base/cross
 - **summary** — job summary with the published version, GHCR URL, and usage snippet.
 
 ## Other validation
+
+### Documentation links (`ci.yaml` → `links`)
+
+`./scripts/validate-links.sh` resolves every relative Markdown link target in the repository —
+`git ls-files '*.md'`, then `os.path.exists` on each `](target)` relative to the file holding it.
+
+It exists because a *string* match cannot catch link rot from a directory move. When
+`docs/specs/NNN-slug/` was archived to `docs/specs/done/<quarter>/NNN-slug/` in 2026-08, every
+`../`-relative link inside those files changed meaning, and 22 broke while a
+`git grep 'docs/specs/'` gate reported clean — the string never appears in the link.
+
+Fenced code blocks, inline code spans, absolute URLs, anchors and template placeholders
+(`NNN`, `YYYY`) are skipped: documentation samples are not navigation.
+
+`.linkcheck-allow` holds known-broken links (currently the five App Wizard screenshot
+placeholders) so pre-existing breakage does not block unrelated work. Delete entries as they are
+fixed; never add one to route around a break your own change introduced.
 
 ### Vector configuration (`vector-config-validation.yml`)
 

--- a/docs/decisions/0002-eks-pod-identity-over-irsa.md
+++ b/docs/decisions/0002-eks-pod-identity-over-irsa.md
@@ -3,7 +3,26 @@
 **Status**: Accepted
 **Date**: 2024-01-15
 **Deciders**: Platform Team
-**Related Spec**: [SPEC-0000: EKS Pod Identity Composition](../specs/completed/0000-#0-eks-pod-identity-composition.md)
+**Related Spec**: [SPEC-0000: EKS Pod Identity](../specs/done/2024-Q1/0000-eks-pod-identity/spec.md)
+**Scope**: AWS only — narrowed 2026-08-18, see [ADR-0007](0007-cloud-abstraction-boundaries.md)
+
+---
+
+> **Amendment (2026-08-18)** — This decision remains **Accepted and unchanged for AWS**. It is no
+> longer a platform-wide statement about workload identity: the platform now also runs GKE, where
+> the equivalent mechanism is Workload Identity Federation.
+>
+> [ADR-0007](0007-cloud-abstraction-boundaries.md) establishes that platform-facing identity APIs
+> stay cloud-shaped, so `EPI` keeps this design and its ten claim manifests unchanged, and GCP gets
+> a sibling `GCPWorkloadIdentity` XRD ([design](../superpowers/specs/2026-08-18-gcp-support-design.md))
+> rather than `EPI` being generalised.
+>
+> Worth recording, because it makes the sibling split cheap: modern GCP lets an IAM policy bind
+> **directly to the Kubernetes ServiceAccount principal**, with no Google service account and no
+> `iam.gke.io/gcp-service-account` annotation. That is the same "bind identity to the (namespace,
+> ServiceAccount) pair from outside" model this ADR chose Pod Identity for — so the reasoning below
+> generalises even though the API does not. The IRSA-style annotation dance this ADR rejected is
+> not what GCP requires either.
 
 ---
 
@@ -127,3 +146,5 @@ Store AWS access keys in Kubernetes secrets.
 - [AWS Blog: EKS Pod Identity](https://aws.amazon.com/blogs/containers/amazon-eks-pod-identity-a-new-way-for-applications-on-eks-to-obtain-iam-credentials/)
 - [IRSA vs Pod Identity Comparison](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html)
 - EPI Composition: `infrastructure/base/crossplane/configuration/kcl/eks-pod-identity/`
+- [ADR-0007: Cloud abstraction boundaries](0007-cloud-abstraction-boundaries.md) — narrows this ADR's scope to AWS
+- [GKE Workload Identity Federation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) — the GCP counterpart

--- a/docs/decisions/0003-vllm-production-stack-over-kserve.md
+++ b/docs/decisions/0003-vllm-production-stack-over-kserve.md
@@ -3,7 +3,7 @@
 **Status**: Accepted
 **Date**: 2026-04-30
 **Deciders**: Smana (Platform Owner)
-**Related Spec**: [Self-Hosted LLM Platform with Cascade Routing](../plans/self-hosted-ai/02-spec-draft.md)
+**Related Spec**: Self-Hosted LLM Platform with Cascade Routing
 
 ---
 
@@ -156,8 +156,8 @@ The decision is already realised on branch `wip/self-hosted-ai-draft`:
 
 ## References
 
-- Spec: [`docs/plans/self-hosted-ai/02-spec-draft.md`](../plans/self-hosted-ai/02-spec-draft.md)
-- Plan §6 "Alternatives considered": [`docs/plans/self-hosted-ai/03-plan-draft.md`](../plans/self-hosted-ai/03-plan-draft.md)
+- Spec: `docs/plans/self-hosted-ai/02-spec-draft.md`
+- Plan §6 "Alternatives considered": `docs/plans/self-hosted-ai/03-plan-draft.md`
 - vLLM Production Stack: <https://github.com/vllm-project/production-stack>
 - vLLM Semantic Router (Iris) release notes: <https://vllm.ai/blog/vllm-sr-iris>
 - KServe v0.16 LLMInferenceService: <https://kserve.github.io/website/master/modelserving/v1beta1/llm/>

--- a/docs/decisions/0005-gke-standard-self-managed-cilium.md
+++ b/docs/decisions/0005-gke-standard-self-managed-cilium.md
@@ -1,0 +1,184 @@
+# ADR-0005: GKE Standard with self-managed Cilium (not Dataplane V2, not Autopilot)
+
+**Status**: Accepted
+**Date**: 2026-08-18
+**Deciders**: Platform Team
+**Related Design**: [GCP Support — Dual-Cloud Platform Design](../superpowers/specs/2026-08-18-gcp-support-design.md)
+
+---
+
+## Context
+
+The platform is adding GCP as a **second first-class cloud**, maintained in parallel with AWS
+(see [ADR-0007](0007-cloud-abstraction-boundaries.md) for the abstraction strategy). The single
+biggest technical fork is which GKE flavour to run, because it decides whether the components
+this platform is built around survive the port or have to be replaced.
+
+Three properties of the existing platform are load-bearing and constrain the choice:
+
+1. **Gateway API is the only ingress mechanism.** All north-south traffic goes through
+   `Gateway`/`HTTPRoute`, implemented by Cilium's `io.cilium/gateway-controller`.
+2. **Tailscale is the only path to private services.** Both private gateways
+   (`platform-tailscale-general`, `platform-tailscale-admin`) are `GatewayClass`es whose
+   `parametersRef` points at a **`CiliumGatewayClassConfig`** setting
+   `loadBalancerClass: tailscale`. ACL separation between `tag:k8s` and `tag:admin` is enforced
+   by having two such Gateways.
+3. **`CiliumNetworkPolicy` default-deny is a constitution requirement**
+   ([platform-constitution.md](../platform-constitution.md)), and Envoy L7 access logs from
+   `CiliumGatewayClassConfig.spec.telemetry.accessLogs` (Cilium >= 1.19.6) feed VictoriaLogs.
+
+GKE offers three shapes, and only one preserves all three.
+
+---
+
+## Decision Drivers
+
+- **Gateway API + Tailscale continuity** — the two private gateways must keep working with the
+  same `GatewayClass` mechanism, or the whole private-access model is rebuilt.
+- **Constitution compliance** — `CiliumNetworkPolicy` and the Envoy JSON access-log pipeline.
+- **Port vs. replace** — how much of `infrastructure/base/` moves unchanged.
+- **Number of implementations to maintain** — dual-cloud already doubles the surface; a second
+  *Gateway* implementation on top of that is a multiplier, not an addition.
+- **Reversibility** — GKE's datapath is a create-time property.
+
+---
+
+## Considered Options
+
+### Option 1: GKE Standard + self-managed Cilium
+
+`datapathProvider` left at its default (legacy). Cilium installed by the platform itself in a
+stage-2 OpenTofu step, mirroring the existing EKS two-stage bootstrap.
+
+**Pros**:
+- `CiliumGatewayClassConfig`, `io.cilium/gateway-controller`, Hubble, `CiliumNetworkPolicy` and
+  the Envoy access-log telemetry all work exactly as on AWS — both Tailscale gateways port
+  essentially unchanged.
+- Cilium version stays a single platform-wide variable (`opentofu/config.tm.hcl`
+  `cilium_version`), so both clouds upgrade together.
+- Most of `infrastructure/base/` is a port, not a rewrite.
+- Current Cilium docs carry a working GKE recipe for exactly the pinned version (1.20.0) — see
+  References.
+
+**Cons**:
+- Unblessed on both sides: Google will not support a cluster whose CNI it does not manage, and
+  Cilium removed its dedicated GKE installation guide after 1.9 (2021).
+- The platform owns CNI upgrades on GCP (it already does on AWS, so this is not new work,
+  but it is now on a path with less community traffic).
+- Requires nodes to carry `node.cilium.io/agent-not-ready=true:NoSchedule` so pods do not land
+  before the agent is ready — including on autoscaled nodes
+  (see [ADR-0006](0006-nap-computeclass-over-karpenter.md)).
+
+### Option 2: GKE Standard + Dataplane V2
+
+`datapathProvider: ADVANCED_DATAPATH`. Google-managed Cilium.
+
+**Pros**:
+- Supported, maintained, and upgraded by Google.
+- `CiliumNetworkPolicy` (a subset) and GKE-flavoured Hubble are available.
+- Node auto-provisioning is a blessed, well-trodden combination.
+
+**Cons**:
+- **No `CiliumGatewayClassConfig` CRD and no `io.cilium/gateway-controller`.** Both Tailscale
+  gateways would be rebuilt on the GKE Gateway controller, and the `loadBalancerClass: tailscale`
+  mechanism replaced with something else.
+- Loses `spec.telemetry.accessLogs`, so the Envoy JSON -> VictoriaLogs pipeline needs a
+  GCP-specific replacement.
+- Two Gateway API implementations to maintain forever, diverging in features and bugs.
+- No control over Cilium config: `kubeProxyReplacement`, `encryption`, and Hubble settings are
+  Google's to choose.
+
+### Option 3: GKE Autopilot
+
+Fully managed nodes.
+
+**Pros**:
+- Lowest operational burden; no node management at all.
+- Strong security posture by default.
+
+**Cons**:
+- Everything in Option 2's cons, plus: no self-managed CNI at all, no privileged DaemonSets
+  (breaks `dagger-engine` and node-level exporters), and no node-level control for GPU
+  workloads.
+- Turns large parts of `infrastructure/base/` from a port into a replacement.
+
+---
+
+## Decision Outcome
+
+**Chosen option**: "Option 1 — GKE Standard + self-managed Cilium"
+
+**Rationale**: Gateway API and Tailscale are not incidental to this platform, they are how it
+exposes everything. Option 1 is the only shape where the two private `GatewayClass`es, the
+`loadBalancerClass: tailscale` mechanism, and the Envoy access-log pipeline survive the port
+without a second Gateway implementation. The cost is running an unblessed path — real, but
+bounded: the platform already owns Cilium's lifecycle on AWS, and current Cilium documentation
+carries a working recipe for the exact pinned version. Option 2's support story is genuinely
+better, but it buys that support by requiring a parallel ingress stack, which is the single
+most expensive thing dual-cloud could ask for.
+
+`--enable-dataplane-v2` is **opt-in** on Standard clusters (it is the default only on
+Autopilot), and `gcloud container clusters create` carries no deprecation notice on the legacy
+datapath as of 2026-08. So this is not "disable Dataplane V2" — it is "do not enable it".
+
+---
+
+## Consequences
+
+### Positive
+
+- Both Tailscale gateways, the Cilium Gateway API stack, Hubble, `CiliumNetworkPolicy`, and the
+  Envoy JSON access logs port to GCP with configuration changes only.
+- One Gateway API implementation, one CNI, one `cilium_version` across both clouds.
+- Hubble-based network debugging (`hubble observe --verdict DROPPED`) works identically on both
+  clouds, preserving the diagnostic order documented in
+  [`.claude/rules/cilium-network-policies.md`](../../.claude/rules/cilium-network-policies.md).
+
+### Negative
+
+- **Not reversible in place.** Dataplane V2 can only be set at cluster creation; switching
+  later means replacing the cluster.
+  - *Mitigation*: the design validates this on a throwaway cluster before the platform depends
+    on it — the first gate task is an explicit stop-and-revisit on this ADR.
+- Unsupported by Google, and off Cilium's documented happy path.
+  - *Mitigation*: pin `imageType` so kernel requirements are known; treat the CNI-displacement
+    check as a permanent regression test rather than a one-off.
+- The `node.cilium.io/agent-not-ready` taint must reach every node, including autoscaled ones.
+  - *Mitigation*: `ComputeClass.nodePoolConfig.taints[]`, verified by the autoscaling slice.
+
+### Neutral
+
+- GCP Cilium values are **forked**, not merged with the AWS values file. With two clouds and
+  roughly eight divergent keys, duplicating ~130 lines is cheaper and more legible than a merge
+  mechanism that hides what Cilium actually receives. Revisit at cloud number three.
+- `ipam.mode` diverges: `eni` on AWS, `kubernetes` on GCP (host-scope from `spec.podCIDR`, with
+  GKE alias IP ranges providing native VPC routing). The AWS-only
+  `opentofu/eks/configure/cilium-cni-config.tf` prefix-delegation ConfigMap has no GCP
+  counterpart.
+
+---
+
+## Implementation Notes
+
+Cluster creation must include `--enable-ip-alias`, an explicit `--cluster-ipv4-cidr` and
+`--services-ipv4-cidr`, and the agent-not-ready node taint. Cilium is then installed with
+`ipam.mode=kubernetes`, keeping `routingMode: native`.
+
+**`encryption.type: wireguard` is expected to be unnecessary on GCP.** CLAUDE.md currently
+records WireGuard as load-bearing, but that is a workaround for
+[cilium#43493](https://github.com/cilium/cilium/issues/43493), which is specifically the BPF
+ipcache `hastunnel` flag under **ENI mode with prefix delegation**. With `ipam.mode=kubernetes`
+that code path is not taken. The cross-node L7 success criterion tests this empirically; CLAUDE.md's note is
+rescoped to AWS only once that criterion passes, and not before.
+
+---
+
+## References
+
+- [Cilium GKE-to-GKE Clustermesh Preparation](https://docs.cilium.io/en/latest/network/clustermesh/gke-clustermesh-prep/) — current docs, working GKE + Cilium 1.20.0 recipe
+- [Cilium GKE IPAM mode](https://docs.cilium.io/en/latest/network/concepts/ipam/gke/) — `ipam.mode=kubernetes`
+- [GKE Dataplane V2](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2) — create-time only; default on Autopilot
+- [gcloud container clusters create](https://docs.cloud.google.com/sdk/gcloud/reference/container/clusters/create) — `--enable-dataplane-v2` is opt-in
+- [cilium#43493](https://github.com/cilium/cilium/issues/43493) — the ENI-mode L7 proxy bug behind the AWS WireGuard workaround
+- Existing Cilium values: `opentofu/eks/init/helm_values/cilium.yaml`
+- Tailscale Gateway setup: `docs/tailscale-gateway-api.md`, `infrastructure/base/gapi/`

--- a/docs/decisions/0006-nap-computeclass-over-karpenter.md
+++ b/docs/decisions/0006-nap-computeclass-over-karpenter.md
@@ -1,0 +1,164 @@
+# ADR-0006: GKE node auto-provisioning (ComputeClass) over Karpenter on GCP
+
+**Status**: Accepted
+**Date**: 2026-08-18
+**Deciders**: Platform Team
+**Related Design**: [GCP Support — Dual-Cloud Platform Design](../superpowers/specs/2026-08-18-gcp-support-design.md)
+
+---
+
+## Context
+
+On AWS the platform autoscales nodes with **Karpenter**, expressed as three pairs of manifests
+in `infrastructure/base/karpenter-nodepools/` and `infrastructure/base/karpenter-nodepools-gpu/`:
+
+| Purpose | Manifests |
+|---------|-----------|
+| general workloads | `default-nodepool.yaml` + `default-ec2nc.yaml` |
+| IO-heavy workloads | `io-nodepool.yaml` + `io-ec2nc.yaml` |
+| GPU (L4) workloads | `gpu-l4-nodepool.yaml` + `gpu-l4-ec2nc.yaml` |
+
+Adding GCP requires an equivalent. Because [ADR-0005](0005-gke-standard-self-managed-cilium.md)
+runs **self-managed Cilium**, whatever provisions nodes must be able to place
+`node.cilium.io/agent-not-ready=true:NoSchedule` on **every** node it creates, including nodes
+created seconds before a pending pod is scheduled. If it cannot, pods land on nodes with no
+working CNI — an intermittent failure that looks like a Cilium bug and is painful to diagnose.
+
+---
+
+## Decision Drivers
+
+- **Production readiness** — dual-cloud means both implementations are maintained and relied on.
+- **Cilium taint propagation to autoscaled nodes** — a hard requirement from ADR-0005, not a nicety.
+- **Node OS control** — Cilium has kernel requirements, so the image must be pinnable.
+- **Conceptual distance from Karpenter** — how much of the mental model transfers.
+- **GPU support** — the LLM platform needs L4-class accelerators.
+
+---
+
+## Considered Options
+
+### Option 1: GKE node auto-provisioning via ComputeClass
+
+The modern NAP interface: a `ComputeClass` custom resource with `nodePoolAutoCreation` enabled
+(GKE >= 1.33.3-gke.1136000), declaring an ordered `priorities[]` list of machine shapes.
+
+**Pros**:
+- Production-ready, Google-supported, and the blessed autoscaling path on GKE.
+- **`nodePoolConfig.taints[]` applies taints to auto-created node pools**, which satisfies the
+  Cilium `agent-not-ready` requirement declaratively.
+- **`nodePoolConfig.imageType`** pins `cos_containerd` / `ubuntu_containerd` for Cilium's kernel
+  requirements.
+- `priorities[]` carries `machineFamily`, `machineType`, `spot`, `gpu`, `storage.bootDiskType`
+  and `nodeSystemConfig` — a close conceptual match to Karpenter requirements plus
+  `EC2NodeClass` fields, including ordered fallback (spot first, then on-demand).
+- Collapses six manifests into three `ComputeClass` objects.
+
+**Cons**:
+- **No equivalent to Karpenter's `disruption` / consolidation semantics.** Bin-packing and
+  node-replacement behaviour is the GKE autoscaler's, not ours to tune the same way.
+- Cannot set a minimum node count above zero on an auto-created pool, by design — a non-zero
+  minimum would prevent removal of empty pools.
+- A GCP-only API: the manifests are not shared with AWS, they are a sibling.
+
+### Option 2: karpenter-provider-gcp
+
+A community Karpenter provider for GCP, initiated and primarily developed by CloudPilot AI.
+
+**Pros**:
+- Same API as AWS (`NodePool` + a GCP node class), so one mental model and potentially shared
+  manifest structure.
+- Karpenter's consolidation and disruption budgets carry over.
+
+**Cons**:
+- **Preview / alpha, and explicitly not recommended for production.** Not in `kubernetes-sigs`.
+- Disqualifying for a cloud that is meant to be maintained in parallel with AWS, not a demo.
+- Would make the platform's GCP node lifecycle depend on a single-vendor pre-1.0 controller.
+- Compare Azure, where `karpenter-provider-azure` reached GA and backs AKS NAP; GCP has no
+  equivalent maturity.
+
+### Option 3: Static managed node pools with cluster autoscaler
+
+Fixed node pools, scaled by the standard cluster autoscaler.
+
+**Pros**:
+- Simplest, most predictable, fully supported. Taints and image type are set on the pool.
+- No new API to learn.
+
+**Cons**:
+- Requires enumerating machine shapes up front; no automatic shape selection.
+- Loses the workload-driven provisioning that makes Karpenter valuable on the AWS side, so the
+  two clouds' capabilities diverge in a way users would notice.
+- Poor fit for the GPU/LLM workloads, which are bursty and shape-specific.
+
+---
+
+## Decision Outcome
+
+**Chosen option**: "Option 1 — GKE node auto-provisioning via ComputeClass"
+
+**Rationale**: Option 2 is the only option that would have preserved a single autoscaling API
+across both clouds, and it is disqualified by maturity alone — a preview-grade, single-vendor
+controller cannot sit under a cloud the platform claims to maintain. Between the remaining two,
+ComputeClass keeps workload-driven provisioning (the property that made Karpenter worth having)
+while clearing the two hard constraints ADR-0005 imposes: it can taint auto-created pools and it
+can pin the node image. Option 3 remains the fallback if ComputeClass taint propagation turns
+out to be unreliable in practice, which the autoscaling slice tests directly.
+
+Note that Option 3 is not wasted work either way: the foundation slice brings up the cluster with a single
+**static** tainted node pool, exactly as `eks/init` creates managed node groups before Karpenter
+arrives. ComputeClass is layered on afterwards, mirroring the AWS sequence.
+
+---
+
+## Consequences
+
+### Positive
+
+- Blessed, supported autoscaling on GCP, with GPU and Spot support.
+- Three `ComputeClass` manifests replace six Karpenter manifests.
+- Cilium's readiness taint is handled declaratively at the pool level rather than by a
+  post-provisioning hook.
+
+### Negative
+
+- **Consolidation semantics are not portable.** Karpenter's `disruption` block, consolidation
+  policy and disruption budgets have no ComputeClass equivalent; cost/packing behaviour will
+  differ measurably between the two clouds.
+  - *Mitigation*: the autoscaling slice ships an explicit written statement of the gap rather
+    than leaving it to be discovered. This is a documented divergence, not an abstraction to be faked.
+- No `min > 0` per auto-created pool, so "always keep N warm" must be expressed differently
+  (for example a small static pool alongside the auto-created ones).
+- Karpenter knowledge does not transfer cleanly; operators need to learn a second model.
+
+### Neutral
+
+- `infrastructure/base/runtimeclass-nvidia/` is **AWS-only** and is not ported. It exists because
+  the Bottlerocket NVIDIA AMI pre-configures an `nvidia` containerd runtime handler and advertises
+  `nvidia.com/gpu` natively, so a `RuntimeClass` is needed but a device plugin is not. GKE
+  installs drivers through its own managed installer and advertises `nvidia.com/gpu` without a
+  `RuntimeClass`, so GCP needs a different and smaller GPU shim.
+
+---
+
+## Implementation Notes
+
+Each `ComputeClass` sets `nodePoolConfig.taints[]` to include
+`node.cilium.io/agent-not-ready=true:NoSchedule` and pins `nodePoolConfig.imageType`.
+`priorities[]` is ordered spot-first then on-demand, mirroring the capacity-type preference in
+the existing Karpenter `NodePool`s.
+
+The load-bearing test is not "does it scale" but "does a **freshly auto-created** node come up
+carrying the taint, and does Cilium clear it before any workload pod is scheduled there".
+The design makes that a success criterion.
+
+---
+
+## References
+
+- [About node pool auto-creation (GKE)](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/node-auto-provisioning)
+- [Configure node pool auto-creation (GKE)](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)
+- [ComputeClass CRD reference](https://docs.cloud.google.com/kubernetes-engine/docs/reference/crds/computeclass) — `nodePoolConfig.taints[]`, `nodePoolConfig.imageType`, `priorities[]`
+- [cloudpilot-ai/karpenter-provider-gcp](https://github.com/cloudpilot-ai/karpenter-provider-gcp) — preview status
+- [ADR-0005](0005-gke-standard-self-managed-cilium.md) — the self-managed Cilium decision that imposes the taint requirement
+- Existing Karpenter manifests: `infrastructure/base/karpenter-nodepools/`, `infrastructure/base/karpenter-nodepools-gpu/`

--- a/docs/decisions/0007-cloud-abstraction-boundaries.md
+++ b/docs/decisions/0007-cloud-abstraction-boundaries.md
@@ -1,0 +1,179 @@
+# ADR-0007: Cloud abstraction boundaries — cloud-shaped platform APIs, neutral developer APIs
+
+**Status**: Accepted
+**Date**: 2026-08-18
+**Deciders**: Platform Team
+**Related Design**: [GCP Support — Dual-Cloud Platform Design](../superpowers/specs/2026-08-18-gcp-support-design.md)
+
+---
+
+## Context
+
+The platform is adding GCP as a second maintained cloud. Roughly fifteen workstreams are
+affected (see the [design](../superpowers/specs/2026-08-18-gcp-support-design.md) scope split), and almost every one of them raises the
+same question in a different costume: **do we build one cloud-neutral API, or two honest
+cloud-specific ones?**
+
+Getting this wrong in either direction is expensive:
+
+- Over-abstracting produces APIs whose most important field is a free-form cloud-specific blob.
+  The abstraction then costs indirection without buying portability — and every new provider
+  feature needs a two-cloud design before anyone can use it.
+- Under-abstracting means an `App` manifest written for the AWS cluster cannot be applied to the
+  GCP cluster, which removes most of the reason to run two clouds.
+
+Rather than relitigate this per workstream, this ADR sets the rule.
+
+The `EPI` composition makes the tension concrete. `EPI` (EKS Pod Identity) has ten claim
+manifests in `security/base/epis/`, is consumed internally by the `App` and `SQLInstance`
+compositions, and its central field is `spec.policyDocument` — inline AWS IAM JSON. There is no
+neutral form of that field. GCP's equivalent is a list of predefined roles and/or a custom role's
+permission list. Any "cloud-agnostic identity" API would carry both shapes and pick one at
+render time, which is two APIs wearing one name.
+
+---
+
+## Decision Drivers
+
+- **Who reads the API.** Platform engineers already know which cloud they are configuring;
+  application developers should not have to.
+- **Where portability actually pays.** A portable `App` claim is valuable. A portable
+  `policyDocument` is meaningless — the permissions themselves are cloud-specific.
+- **Honesty over uniformity.** An API that looks neutral but is not causes worse errors than one
+  that is visibly cloud-shaped.
+- **Migration cost.** The `xplane-*` prefix is load-bearing for IAM scoping, and renaming a
+  Crossplane managed resource is delete-and-create against live cloud IAM.
+- **Cost of the next cloud.** The rule should not need rewriting at cloud number three.
+
+---
+
+## Considered Options
+
+### Option 1: Asymmetric — cloud-shaped platform APIs, neutral developer APIs
+
+Draw the line at the audience. APIs consumed by the platform team stay cloud-specific and
+honest (sibling XRDs per cloud). APIs consumed by application developers are cloud-neutral, with
+provider-specific knobs confined to a clearly-marked optional sub-block.
+
+**Pros**:
+- Portability is bought exactly where it is worth paying for: developer-facing claims.
+- Platform-facing APIs stay honest — no pretending IAM JSON and GCP role bindings are one thing.
+- No rename of `EPI` and therefore no delete-and-create against live IAM roles.
+- The escape hatch keeps provider features reachable without polluting the common surface.
+
+**Cons**:
+- Two rules to remember instead of one, and the boundary needs judgement for APIs with mixed
+  audiences.
+- Compositions consuming platform APIs must branch internally on target cloud.
+
+### Option 2: Neutral everywhere
+
+One XRD per concept, cloud selected by `EnvironmentConfig` / `ProviderConfig`. `EPI` becomes
+`WorkloadIdentity`; `spec.s3Bucket` becomes `spec.objectStore`.
+
+**Pros**:
+- One API surface, uniform rule, smallest thing to explain.
+- Every manifest is portable in principle.
+
+**Cons**:
+- The abstraction leaks at the field that matters most (`policyDocument`), so it is neutral in
+  name only.
+- Renames ten `EPI` manifests and the `xplane-*` resources they own — delete-and-create against
+  live IAM roles for no functional gain.
+- Every provider-specific feature becomes a two-cloud design exercise before anyone can use it.
+
+### Option 3: Cloud-shaped everywhere
+
+Sibling APIs at every layer: `EPI` + `GCPWorkloadIdentity`, `spec.s3Bucket` + `spec.gcsBucket`.
+
+**Pros**:
+- Maximum honesty and zero migration; each API is exactly its cloud's model.
+- Simplest compositions — no branching, no merged schemas.
+
+**Cons**:
+- An `App` claim becomes cloud-bound, which forfeits the main benefit of running two clouds.
+- Application developers are forced to learn cloud specifics to request a bucket.
+
+---
+
+## Decision Outcome
+
+**Chosen option**: "Option 1 — asymmetric, split by audience"
+
+**Rationale**: The audience boundary is the one that tracks where portability has value.
+`EPI` is written by platform engineers who already know they are configuring AWS, and its central
+field has no neutral form — so a cloud-shaped sibling API costs nothing and lies about nothing.
+`App` is written by application developers, and a portable `App` claim is close to the whole point
+of maintaining two clouds — so it gets a neutral surface with provider knobs quarantined in
+optional `aws {}` / `gcp {}` blocks.
+
+**The rule**: *cloud-shaped platform APIs, neutral developer APIs, with provider-specific fields
+confined to a named optional sub-block rather than spread across the schema.*
+
+A finding from designing the GCP identity API supports this more than expected. Modern GCP Workload Identity
+Federation allows binding an IAM policy **directly to the Kubernetes ServiceAccount principal** —
+`principal://iam.googleapis.com/projects/N/locations/global/workloadIdentityPools/PROJECT.svc.id.goog/subject/ns/NS/sa/KSA`
+— with no Google service account and no `iam.gke.io/gcp-service-account` annotation. That is
+structurally the *same* model as EKS Pod Identity: bind an identity to the (namespace,
+ServiceAccount) pair from outside, leaving nothing on the ServiceAccount. So the two sibling XRDs
+end up near-isomorphic in shape while remaining honest about their differing permission models.
+Sibling APIs did not force conceptual divergence; it only declined to hide the one field that
+genuinely differs.
+
+---
+
+## Consequences
+
+### Positive
+
+- `EPI` and its ten claim manifests are untouched. No delete-and-create against live IAM.
+- [ADR-0002](0002-eks-pod-identity-over-irsa.md) stays valid, with its scope narrowed to AWS.
+- Developer-facing claims stay portable, so the dual-cloud investment is visible to app teams.
+- The rule is reusable: it decides workstreams 8 through 13 without fresh debate.
+
+### Negative
+
+- `App`/`SQLInstance` compositions branch internally on target cloud, adding conditional
+  rendering paths that must both be covered by `main_test.k`.
+- Renaming `spec.s3Bucket` to `spec.objectStore` is a **breaking XRD change**, requiring
+  migration of examples, the App Wizard form, and any live claims.
+  - *Mitigation*: sequenced as its own roadmap workstream, not smuggled into a cluster spec.
+- Two identity XRDs mean two sets of documentation and tests.
+
+### Neutral
+
+- The "which cloud am I" signal that compositions branch on has to come from somewhere —
+  most likely a per-cloud `EnvironmentConfig` (the AWS one is already
+  `EnvironmentConfig/eks-environment`, carrying `accountId`, `oidcArn`, `vpcId`). The exact
+  mechanism is settled by the identity slice, not here.
+
+---
+
+## Implementation Notes
+
+Applying the rule across the roadmap:
+
+| Workstream | Audience | Treatment |
+|------------|----------|-----------|
+| `EPI` / `GCPWorkloadIdentity` | platform | sibling, cloud-shaped |
+| `App.spec.objectStore` | developer | neutral + `aws {}` / `gcp {}` escape hatch |
+| `SQLInstance` backups | developer | neutral surface; backend selected by composition |
+| Node autoscaling (`NodePool` vs `ComputeClass`) | platform | sibling, cloud-shaped ([ADR-0006](0006-nap-computeclass-over-karpenter.md)) |
+| Cilium Helm values | platform | sibling files, forked ([ADR-0005](0005-gke-standard-self-managed-cilium.md)) |
+| Gateway / LoadBalancer annotations | platform | sibling, cloud-shaped |
+| StorageClass names | platform | sibling, cloud-shaped |
+
+`xplane-*` naming is unchanged and applies to both clouds' managed resources — it is a
+constitution requirement, not an AWS detail.
+
+---
+
+## References
+
+- [Platform Constitution](../platform-constitution.md) — `xplane-*` naming, KCL patterns, security defaults
+- [ADR-0002: EKS Pod Identity over IRSA](0002-eks-pod-identity-over-irsa.md) — scope narrowed to AWS by this ADR
+- [ADR-0005](0005-gke-standard-self-managed-cilium.md), [ADR-0006](0006-nap-computeclass-over-karpenter.md)
+- [GKE Workload Identity Federation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) — direct KSA principal binding
+- [GCP support design](../superpowers/specs/2026-08-18-gcp-support-design.md) — the fifteen workstreams this rule applies to
+- `EPI` composition: `infrastructure/base/crossplane/configuration/kcl/eks-pod-identity/`
+- `App` composition: `infrastructure/base/crossplane/configuration/kcl/app/`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -129,6 +129,9 @@ ADRs, Specs, and Constitution serve different purposes:
 | [0002](0002-eks-pod-identity-over-irsa.md) | Use EKS Pod Identity over IRSA | Accepted | 2024-01-15 |
 | [0003](0003-vllm-production-stack-over-kserve.md) | Use vLLM Production Stack over KServe + llm-d for v1 LLM Platform | Accepted | 2026-04-30 |
 | [0004](0004-amazon-s3-files-for-model-weights-storage.md) | Use Amazon S3 Files for LLM Model Weights Storage | Accepted | 2026-05-01 |
+| [0005](0005-gke-standard-self-managed-cilium.md) | GKE Standard with self-managed Cilium (not Dataplane V2, not Autopilot) | Accepted | 2026-08-18 |
+| [0006](0006-nap-computeclass-over-karpenter.md) | GKE node auto-provisioning (ComputeClass) over Karpenter on GCP | Accepted | 2026-08-18 |
+| [0007](0007-cloud-abstraction-boundaries.md) | Cloud abstraction boundaries — cloud-shaped platform APIs, neutral developer APIs | Accepted | 2026-08-18 |
 
 ## Further Reading
 

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -221,7 +221,7 @@ bao write pki/priv_cloud_ogenki_io/roles/priv-cloud-ogenki-io \
   max_ttl=2160h  # 90 days
 ```
 
-**Related**: [OpenBao PKI Documentation](../opentofu/openbao/management/docs/getting_started.md)
+**Related**: [OpenBao PKI Documentation](../opentofu/openbao/cluster/docs/getting_started.md)
 
 ### cert-manager Integration
 
@@ -711,7 +711,7 @@ curl -v https://grafana.priv.cloud.ogenki.io
 - [Technology Choices](./technology-choices.md) - Gateway API, Tailscale rationale
 - [OpenTofu](./opentofu.md) - Network and OpenBao deployment
 - [Crossplane](./crossplane.md) - App composition ingress configuration
-- [OpenBao PKI Setup](../opentofu/openbao/management/docs/getting_started.md)
+- [OpenBao PKI Setup](../opentofu/openbao/cluster/docs/getting_started.md)
 - [cert-manager Integration](../opentofu/openbao/management/docs/cert-manager.md)
 - [Tailscale Network Setup](../opentofu/network/README.md)
 

--- a/docs/specs/done/2026-Q3/002-composition-owned-gateway-routing/clarifications.md
+++ b/docs/specs/done/2026-Q3/002-composition-owned-gateway-routing/clarifications.md
@@ -133,4 +133,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/002-composition-owned-gateway-routing/plan.md
+++ b/docs/specs/done/2026-Q3/002-composition-owned-gateway-routing/plan.md
@@ -111,7 +111,7 @@ examples/
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1: Prerequisites
 

--- a/docs/specs/done/2026-Q3/003-inferenceservice-spec-engineargs-escape/clarifications.md
+++ b/docs/specs/done/2026-Q3/003-inferenceservice-spec-engineargs-escape/clarifications.md
@@ -98,4 +98,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/003-inferenceservice-spec-engineargs-escape/plan.md
+++ b/docs/specs/done/2026-Q3/003-inferenceservice-spec-engineargs-escape/plan.md
@@ -137,7 +137,7 @@ examples/
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1: XRD schema + CEL
 

--- a/docs/specs/done/2026-Q3/004-per-inferenceservice-inferencepool-endpoint/clarifications.md
+++ b/docs/specs/done/2026-Q3/004-per-inferenceservice-inferencepool-endpoint/clarifications.md
@@ -196,4 +196,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/004-per-inferenceservice-inferencepool-endpoint/plan.md
+++ b/docs/specs/done/2026-Q3/004-per-inferenceservice-inferencepool-endpoint/plan.md
@@ -112,7 +112,7 @@ infrastructure/base/crossplane/providers/additional-rbac.yaml  # + inferencepool
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1: Prerequisites
 

--- a/docs/specs/done/2026-Q3/005-vllm-cold-start-run/clarifications.md
+++ b/docs/specs/done/2026-Q3/005-vllm-cold-start-run/clarifications.md
@@ -117,4 +117,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/005-vllm-cold-start-run/plan.md
+++ b/docs/specs/done/2026-Q3/005-vllm-cold-start-run/plan.md
@@ -108,7 +108,7 @@ examples/
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1: Schema & guards
 

--- a/docs/specs/done/2026-Q3/006-genai-observability-envoy-gateway/clarifications.md
+++ b/docs/specs/done/2026-Q3/006-genai-observability-envoy-gateway/clarifications.md
@@ -119,4 +119,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/006-genai-observability-envoy-gateway/plan.md
+++ b/docs/specs/done/2026-Q3/006-genai-observability-envoy-gateway/plan.md
@@ -98,7 +98,7 @@ apps/base/ai/llm/
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1: Verify exposure & scrape
 

--- a/docs/specs/done/2026-Q3/007-app-composition-workload-types/clarifications.md
+++ b/docs/specs/done/2026-Q3/007-app-composition-workload-types/clarifications.md
@@ -133,4 +133,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/007-app-composition-workload-types/plan.md
+++ b/docs/specs/done/2026-Q3/007-app-composition-workload-types/plan.md
@@ -155,7 +155,7 @@ docs/apps-user-guide.md            # NEW (FR-013)
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1: Prerequisites
 

--- a/docs/specs/done/2026-Q3/007-flux-schema-validation-replace/clarifications.md
+++ b/docs/specs/done/2026-Q3/007-flux-schema-validation-replace/clarifications.md
@@ -131,4 +131,4 @@ These are **not defects**. Kubernetes' `resource.Quantity.UnmarshalJSON` parses 
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/007-flux-schema-validation-replace/plan.md
+++ b/docs/specs/done/2026-Q3/007-flux-schema-validation-replace/plan.md
@@ -116,7 +116,7 @@ The upstream `fluxcd/flux-schema` composite action was rejected: it has no `envs
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 **Task index** — tick here as each task's detailed steps below are completed and evidenced.
 

--- a/docs/specs/done/2026-Q3/008-app-wizard-self-service-ui/clarifications.md
+++ b/docs/specs/done/2026-Q3/008-app-wizard-self-service-ui/clarifications.md
@@ -215,4 +215,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/008-app-wizard-self-service-ui/plan.md
+++ b/docs/specs/done/2026-Q3/008-app-wizard-self-service-ui/plan.md
@@ -108,7 +108,7 @@ docs/specs/008-app-wizard-self-service-ui/phases/*/plan.md
 
 ## Tasks
 
-> Cross-phase tasks only — phase-local tasks live in each phase's `plan.md`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Cross-phase tasks only — phase-local tasks live in each phase's `plan.md`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 - [ ] **T001**: Resolve the 3 open questions in spec.md (frontend stack; render execution model; OAuth app registration) via `/clarify`.
 - [ ] **T002**: Create `apps/stacks.yaml` registry + document the stack-creation process (platform PR).

--- a/docs/specs/done/2026-Q3/009-app-wizard-oss-split/clarifications.md
+++ b/docs/specs/done/2026-Q3/009-app-wizard-oss-split/clarifications.md
@@ -130,4 +130,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/009-app-wizard-oss-split/plan.md
+++ b/docs/specs/done/2026-Q3/009-app-wizard-oss-split/plan.md
@@ -102,7 +102,7 @@ Refactor-in-place-then-extract (rejected: churns cloud-native-ref with refactor 
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …). Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)). Tasks marked **(oss-repo)** run in `Smana/app-wizard`; **(cnr)** run in cloud-native-ref.
+> Each task has a stable ID (`T001`, `T002`, …). Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)). Tasks marked **(oss-repo)** run in `Smana/app-wizard`; **(cnr)** run in cloud-native-ref.
 
 ### Phase 1: Extract & stand up the OSS repo (history-preserving, mechanical)
 

--- a/docs/specs/done/2026-Q3/010-cnpg-barman-cloud-plugin/clarifications.md
+++ b/docs/specs/done/2026-Q3/010-cnpg-barman-cloud-plugin/clarifications.md
@@ -133,4 +133,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/) — ADR-0002 (EKS Pod Identity over IRSA) governs the credential model
+- ADRs: [docs/decisions/](../../../../decisions/) — ADR-0002 (EKS Pod Identity over IRSA) governs the credential model

--- a/docs/specs/done/2026-Q3/010-cnpg-barman-cloud-plugin/plan.md
+++ b/docs/specs/done/2026-Q3/010-cnpg-barman-cloud-plugin/plan.md
@@ -137,7 +137,7 @@ crds/base/kustomization-barman-cloud-plugin.yaml                # ObjectStore CR
 
 ## Tasks
 
-> Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../.claude/rules/process.md)).
+> Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../../../.claude/rules/process.md)).
 
 > **Requirements coverage**: FR-001 → T004; FR-002 → T005; FR-003 → T006 (CL-3); FR-004 → T007; FR-005 → T004; FR-006 → T004 (default: omit `s3Credentials`) / T012 (opt-in access-key, CL-4); FR-007 → T001/T002 (CL-6); FR-008 → T003; FR-009 → T008.
 

--- a/docs/specs/done/2026-Q3/011-inferencepool-saturation-keda/clarifications.md
+++ b/docs/specs/done/2026-Q3/011-inferencepool-saturation-keda/clarifications.md
@@ -35,4 +35,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/011-inferencepool-saturation-keda/plan.md
+++ b/docs/specs/done/2026-Q3/011-inferencepool-saturation-keda/plan.md
@@ -91,7 +91,7 @@ infrastructure/base/crossplane/configuration/kcl/inference-service/
 
 ## Tasks
 
-> Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../.claude/rules/process.md)).
+> Each task has a stable ID. Cite fresh evidence before marking `[x]` (see [.claude/rules/process.md](../../../../../.claude/rules/process.md)).
 
 > **Requirements coverage**: FR-001 → T003; FR-002 → T003/T005; FR-003 → T003; FR-004 → T005; FR-005 → T001; FR-006 → T001/T002; FR-007 → Design (ADD not replace); FR-008 → T004.
 

--- a/docs/specs/done/2026-Q3/012-kvstore-composition-replace-bitnami/clarifications.md
+++ b/docs/specs/done/2026-Q3/012-kvstore-composition-replace-bitnami/clarifications.md
@@ -119,4 +119,4 @@
 ## Related
 
 - Constitution: [docs/platform-constitution.md](../../../../platform-constitution.md)
-- ADRs: [docs/decisions/](../../decisions/)
+- ADRs: [docs/decisions/](../../../../decisions/)

--- a/docs/specs/done/2026-Q3/012-kvstore-composition-replace-bitnami/plan.md
+++ b/docs/specs/done/2026-Q3/012-kvstore-composition-replace-bitnami/plan.md
@@ -141,7 +141,7 @@ flux/sources/helmrepo-valkey.yaml
 
 ## Tasks
 
-> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../.claude/rules/process.md)).
+> Each task has a stable ID (`T001`, `T002`, …) — committable unit, referenced by PRs and `/verify-spec`. Before marking `[x]`, cite fresh evidence (see [`.claude/rules/process.md`](../../../../../.claude/rules/process.md)).
 
 ### Phase 1 — PR 1: composition (FR-001..004, FR-008, FR-009)
 

--- a/docs/superpowers/plans/2026-08-18-gcp-foundation.md
+++ b/docs/superpowers/plans/2026-08-18-gcp-foundation.md
@@ -1,0 +1,1941 @@
+# GCP Foundation (Network + GKE + Cilium + Flux) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a private GKE Standard cluster on GCP running self-managed Cilium and Flux, reachable over the existing Tailscale tailnet, without moving or modifying any existing AWS file.
+
+**Architecture:** Three new OpenTofu stacks under `opentofu/gcp/` mirroring the existing AWS shape — `network/` (VPC, secondary ranges, Cloud DNS, Tailscale subnet router), `gke/init/` (cluster + static tainted node pool), `gke/configure/` (Cilium then Flux). Two stages because the Helm provider needs a cluster endpoint at plan time, the same reason `eks/init` and `eks/configure` are split. Cilium runs `ipam.mode=kubernetes` over GKE alias IP ranges instead of AWS ENI mode. Flux syncs a **new sibling** tree `clusters/gcp-mycluster-0/`.
+
+**Tech Stack:** OpenTofu 1.12.5, Terramate 0.17.2, `hashicorp/google` provider, GKE Standard (legacy datapath), Cilium 1.20.0, Flux Operator 0.55.0, Tailscale, Trivy.
+
+**Branch:** `feat/gcp-support-specs` (continues the design commit).
+
+**Spec:** [`docs/superpowers/specs/2026-08-18-gcp-support-design.md`](../specs/2026-08-18-gcp-support-design.md)
+
+**Scope:** Design slices 1–3 only. Node autoscaling (slice 4) and `GCPWorkloadIdentity` (slice 5) are separate plans and must not be started here — except for the single Crossplane WIF binding in Task 9, which slice 5 is blocked without.
+
+---
+
+## Pre-flight context (verified during plan writing — no action needed)
+
+- **`gcloud` is NOT installed** and is absent from `mise.toml`. Task 1 adds it. Every other tool in this plan is already pinned in `mise.toml` (opentofu 1.12.5, terramate 0.17.2, trivy 0.74.0, flux2 2.9.4, helm 4.2.4, kustomize 5.8.1).
+- **AWS CIDRs that GCP must not collide with** (`opentofu/network/variables.tf`): VPC `10.0.0.0/16` (`vpc_cidr`), pods `100.64.0.0/16` (`pod_cidr`). Both clusters join the **same tailnet**, so an overlap breaks subnet routing in a way that presents as a Cilium bug.
+- **Terramate globals** live in `opentofu/config.tm.hcl`. `region = "eu-west-3"` and `eks_cluster_name` are AWS-specific; `cilium_version = "1.20.0"` and `flux_operator_version`/`flux_instance_version = "0.55.0"` are **shared** and must stay shared.
+- **The two-stage script pattern** is `opentofu/eks/init/workflows.tm.hcl`: a `deploy` script with one `job` per stage, stage 2 invoked via `["bash", "-c", "cd ../configure && ..."]`, and `trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .` in the chain before apply. `preview` uses `sync_preview = true` + `tofu_plan_file`.
+- **`eks/init` stage 3 (`eks-recycle-bootstrap-nodes.sh`) has no GCP analogue** — it exists solely for ENI prefix-delegation ordering. Do not port it.
+- **`eks/configure/main.tf` is deliberately `local-exec`-free**; imperative steps live in Terramate jobs. Keep `gke/configure` the same way.
+- **`eks/configure` reads the Cilium values from the init stack**: `values = [file("${path.module}/../init/helm_values/cilium.yaml")]`. Mirror that path convention.
+- **AWS Cilium values to diverge from** (`opentofu/eks/init/helm_values/cilium.yaml`): `ipam.mode: eni`, an `eni:` block, `routingMode: native`, `kubeProxyReplacement: true`, `encryption` (wireguard), `gatewayAPI`, `hubble`.
+- **`opentofu/eks/configure/cilium-cni-config.tf`** is the AWS prefix-delegation ConfigMap. **No GCP counterpart — do not create one.**
+- **EKS bootstrap node group cost posture to match** (`opentofu/eks/init/main.tf:120-149`): `capacity_type = "SPOT"`, `min_size = 2 / max_size = 3`, single subnet with the comment *"Use a single subnet for costs reasons"*, 6 diversified instance types. A GKE node pool takes **one** machine type, so that last technique does not port.
+- **Tailscale tailnet**: `smainklh@gmail.com`, subnet router named `ogenki` (`opentofu/network/variables.tfvars`).
+- **Cilium's current GKE recipe** (docs.cilium.io GKE Clustermesh Prep) requires `--enable-ip-alias`, explicit `--cluster-ipv4-cidr` / `--services-ipv4-cidr`, and `--node-taints node.cilium.io/agent-not-ready=true:NoSchedule`. `--enable-dataplane-v2` is opt-in on Standard, so it is simply **not passed**.
+
+### Proposed CIDR allocation (verify in Task 3, do not assume)
+
+| Range | Value | Avoids |
+|---|---|---|
+| GCP node subnet | `10.10.0.0/16` | AWS VPC `10.0.0.0/16` |
+| GCP pods (secondary) | `100.65.0.0/16` | AWS pods `100.64.0.0/16` |
+| GCP services (secondary) | `10.11.0.0/20` | both |
+| GKE control plane | `172.16.0.0/28` | both (GKE requires exactly /28) |
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `mise.toml` | Modify | Pin `gcloud` |
+| `opentofu/config.tm.hcl` | Modify | Add GCP globals; leave `cilium_version`/`flux_*` shared |
+| `opentofu/gcp/network/versions.tf` | Create | Provider + OpenTofu version constraints |
+| `opentofu/gcp/network/providers.tf` | Create | `google` + `tailscale` provider config |
+| `opentofu/gcp/network/backend.tf` | Create | GCS remote state |
+| `opentofu/gcp/network/variables.tf` | Create | Inputs with CIDR defaults + validation |
+| `opentofu/gcp/network/variables.tfvars` | Create | Concrete values for this environment |
+| `opentofu/gcp/network/network.tf` | Create | VPC, node subnet, pod/service secondary ranges, Private Google Access |
+| `opentofu/gcp/network/nat.tf` | Create | Cloud Router + Cloud NAT for external egress only |
+| `opentofu/gcp/network/dns.tf` | Create | Cloud DNS private zone |
+| `opentofu/gcp/network/tailscale.tf` | Create | Subnet router on GCE, smallest viable machine type |
+| `opentofu/gcp/network/outputs.tf` | Create | Network/subnet self-links, range names, consumed by `gke/init` |
+| `opentofu/gcp/network/stack.tm.hcl` | Create | Terramate stack metadata |
+| `opentofu/gcp/gke/init/main.tf` | Create | GKE Standard cluster + static spot node pool |
+| `opentofu/gcp/gke/init/iam.tf` | Create | Crossplane WIF binding (unblocks slice 5) |
+| `opentofu/gcp/gke/init/gateway_api.tf` | Create | Gateway API CRDs, applied before Cilium |
+| `opentofu/gcp/gke/init/helm_values/cilium.yaml` | Create | Forked GCP Cilium values |
+| `opentofu/gcp/gke/init/helm_values/flux-instance.yaml` | Create | Flux Instance values, GCP storage class |
+| `opentofu/gcp/gke/init/{versions,providers,backend,variables,data,outputs}.tf` | Create | Stack plumbing |
+| `opentofu/gcp/gke/init/variables.tfvars` | Create | Concrete values |
+| `opentofu/gcp/gke/init/{stack,workflows}.tm.hcl` | Create | Stack metadata + two-stage deploy scripts |
+| `opentofu/gcp/gke/configure/main.tf` | Create | Cilium then Flux Operator + Flux Instance |
+| `opentofu/gcp/gke/configure/{versions,providers,backend,variables,data,locals}.tf` | Create | Stack plumbing |
+| `opentofu/gcp/gke/configure/stack.tm.hcl` | Create | Stack metadata |
+| `clusters/gcp-mycluster-0/**` | Create | New sibling Flux tree, minimum viable set |
+| `docs/gcp-bootstrap.md` | Create | Bootstrap runbook + monthly run-rate estimate |
+| `CLAUDE.md` | Modify | GCP stacks in architecture; WireGuard note rescoped (Task 21 only, gated) |
+
+---
+
+## Phase 0 — Tooling and prerequisites
+
+### Task 1: Pin `gcloud` in mise
+
+**Files:**
+- Modify: `mise.toml`
+
+- [ ] **Step 1: Confirm gcloud is genuinely absent**
+
+Run: `command -v gcloud || echo ABSENT`
+Expected: `ABSENT`
+
+- [ ] **Step 2: Find the correct mise backend for gcloud**
+
+Run: `mise registry | grep -i gcloud`
+Expected: one or more rows. Record the exact backend string printed (for example `asdf:jthegedus/asdf-gcloud`). **Use what the registry prints — do not guess the backend.** If the registry returns nothing, stop and install the Google Cloud SDK by the official method, then note in `docs/gcp-bootstrap.md` that gcloud is not mise-managed and why.
+
+- [ ] **Step 3: Add the pin**
+
+Add to the `[tools]` table in `mise.toml`, keeping the existing comment block intact, substituting the backend and latest stable version from Step 2:
+
+```toml
+# Google Cloud SDK — required by the GCP stacks (opentofu/gcp/**) for cluster
+# credentials and for the gcloud-based evidence commands in the GCP runbook.
+"<backend-from-step-2>" = "<version>"
+```
+
+- [ ] **Step 4: Verify it installs and runs**
+
+Run: `mise install && gcloud version`
+Expected: version output, no error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mise.toml
+git commit -m "build(mise): pin gcloud for the GCP stacks"
+```
+
+### Task 2: GCP project prerequisites
+
+**Files:** none (environment setup; recorded in the runbook by Task 20)
+
+- [ ] **Step 1: Confirm an authenticated project with billing**
+
+Run:
+```bash
+gcloud auth list
+gcloud config get-value project
+gcloud beta billing projects describe "$(gcloud config get-value project)" --format='value(billingEnabled)'
+```
+Expected: an active account, a project id, and `True`.
+
+**If billing is not enabled, stop.** Nothing past Task 4 can be verified without a billable project.
+
+- [ ] **Step 2: Enable the required APIs**
+
+Run:
+```bash
+gcloud services enable \
+  container.googleapis.com \
+  compute.googleapis.com \
+  dns.googleapis.com \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  secretmanager.googleapis.com \
+  cloudresourcemanager.googleapis.com
+```
+Expected: `Operation ... finished successfully.`
+
+- [ ] **Step 3: Record the project number**
+
+Run: `gcloud projects describe "$(gcloud config get-value project)" --format='value(projectNumber)'`
+Expected: a numeric id. **Save it** — the Workload Identity principal string in Task 9 needs the project **number**, while the pool name needs the project **id**. These are different values in different segments and reversing them produces a binding that is accepted and never matches.
+
+- [ ] **Step 4: Create the GCS state bucket**
+
+Run, substituting the project id:
+```bash
+PROJECT="$(gcloud config get-value project)"
+gcloud storage buckets create "gs://${PROJECT}-tfstate" \
+  --location=EU --uniform-bucket-level-access --public-access-prevention
+gcloud storage buckets update "gs://${PROJECT}-tfstate" --versioning
+```
+Expected: bucket created, versioning enabled.
+
+### Task 3: Fix the CIDR allocation
+
+**Files:** none yet (values consumed by Task 5)
+
+- [ ] **Step 1: Print the AWS ranges currently advertised into the tailnet**
+
+Run:
+```bash
+grep -A3 -E 'variable "(vpc_cidr|pod_cidr)"' opentofu/network/variables.tf
+tailscale status --json | jq -r '.Peer[] | select(.PrimaryRoutes != null) | "\(.HostName): \(.PrimaryRoutes | join(", "))"'
+```
+Expected: `10.0.0.0/16` and `100.64.0.0/16` from the first command, plus whatever the subnet router actually advertises.
+
+- [ ] **Step 2: Confirm the proposed GCP ranges do not overlap**
+
+Run:
+```bash
+python3 - <<'PY'
+import ipaddress as ip
+aws = [ip.ip_network(c) for c in ("10.0.0.0/16", "100.64.0.0/16")]
+gcp = {"nodes":"10.10.0.0/16","pods":"100.65.0.0/16","services":"10.11.0.0/20","control-plane":"172.16.0.0/28"}
+bad = False
+for name, c in gcp.items():
+    n = ip.ip_network(c)
+    for a in aws:
+        if n.overlaps(a):
+            print(f"OVERLAP: gcp {name} {c} overlaps aws {a}"); bad = True
+print("no overlap" if not bad else "FIX THE PLAN")
+PY
+```
+Expected: `no overlap`
+
+**Add any extra ranges the previous step revealed to the `aws` list before trusting this.**
+
+- [ ] **Step 3: Decide zonal vs regional, and record the cost delta**
+
+Run: `gcloud container get-server-config --region=europe-west1 --format='value(defaultClusterVersion)'`
+Expected: a version string >= `1.33.3-gke.1136000`. If it is lower, pick a different region or channel — the autoscaling plan (slice 4) requires that floor, and `--workload-pool` support is needed here.
+
+Then decide zonal or regional and write one sentence of justification into a scratch note for Task 20. The GKE cluster management fee and free-tier eligibility differ between them; defaulting to regional without stating the cost is not acceptable.
+
+- [ ] **Step 4: Choose the node image type**
+
+Decide `cos_containerd` (GKE default, smaller attack surface) or `ubuntu_containerd` (more familiar kernel, easier debugging on an unsupported path). Record the choice and reason for Task 20. Slice 4 must pin the **same** value, so this decision propagates.
+
+---
+
+## Phase 1 — THE GATE: prove ADR-0005 on a throwaway cluster
+
+**Do not write any OpenTofu until this phase passes.** If either check fails, stop, reopen [ADR-0005](../../decisions/0005-gke-standard-self-managed-cilium.md), and evaluate Dataplane V2 — which costs a second Gateway API implementation and the loss of the Envoy access-log pipeline. Discovering this after Phase 2–5 is built means throwing away all of it.
+
+### Task 4: Prove Cilium displaces GKE's netd, and that WireGuard is unnecessary
+
+**Files:** none (throwaway resources, deleted in Step 8)
+
+- [ ] **Step 1: Create the throwaway cluster**
+
+Run, substituting your zone and the image type from Task 3 Step 4:
+```bash
+ZONE=europe-west1-b
+gcloud container clusters create cilium-gate \
+  --zone "$ZONE" --num-nodes 2 --machine-type e2-standard-4 --spot \
+  --enable-ip-alias --cluster-ipv4-cidr 100.65.0.0/16 --services-ipv4-cidr 10.11.0.0/20 \
+  --image-type COS_CONTAINERD \
+  --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+  --no-enable-master-authorized-networks \
+  --logging=NONE --monitoring=NONE
+```
+Expected: cluster created. Note `--enable-dataplane-v2` is deliberately **absent**.
+
+- [ ] **Step 2: Confirm the datapath is legacy, not Dataplane V2**
+
+Run: `gcloud container clusters describe cilium-gate --zone "$ZONE" --format='yaml(networkConfig.datapathProvider)'`
+Expected: the field is absent or not `ADVANCED_DATAPATH`. **If it says `ADVANCED_DATAPATH`, the flavour is not available as designed — stop and reopen ADR-0005.**
+
+- [ ] **Step 3: Install Cilium 1.20.0 in GKE mode**
+
+Run:
+```bash
+gcloud container clusters get-credentials cilium-gate --zone "$ZONE"
+helm repo add cilium https://helm.cilium.io && helm repo update
+helm install cilium cilium/cilium --version 1.20.0 --namespace kube-system \
+  --set ipam.mode=kubernetes \
+  --set routingMode=native \
+  --set kubeProxyReplacement=true \
+  --set gatewayAPI.enabled=true \
+  --set hubble.relay.enabled=true --set hubble.ui.enabled=true
+kubectl -n kube-system rollout status ds/cilium --timeout=5m
+```
+Expected: DaemonSet rolls out. Gateway API CRDs must exist first if `gatewayAPI.enabled=true` errors — apply them with
+`kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml` and retry.
+
+- [ ] **Step 4: CHECK 1 — Cilium's CNI config displaced netd**
+
+Run:
+```bash
+NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+POD=$(kubectl get pod -n kube-system -l k8s-app=cilium \
+  --field-selector "spec.nodeName=$NODE" -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n kube-system "$POD" -c cilium-agent -- ls -la /host/etc/cni/net.d/
+```
+Expected: a Cilium conflist present, and **no active GKE/netd conflist** ahead of it in lexical order. Files renamed to `*.cilium_bak` are fine — that is `cni.exclusive` doing its job.
+
+**FAIL CRITERION:** an active non-Cilium `.conflist` sorting before Cilium's. If so, **stop — reopen ADR-0005.**
+
+- [ ] **Step 5: Confirm Cilium is healthy and pods actually get IPs**
+
+Run:
+```bash
+kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium status --brief
+kubectl create deploy gate-probe --image=nginx --replicas=4
+kubectl rollout status deploy/gate-probe --timeout=3m
+kubectl get pods -o wide -l app=gate-probe
+```
+Expected: `cilium status` OK; 4 pods `Running` with IPs from `100.65.0.0/16`, spread across both nodes.
+
+- [ ] **Step 6: CHECK 2 — cross-node L7 through a Cilium Gateway, no WireGuard**
+
+Run:
+```bash
+kubectl apply -f - <<'YAML'
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata: { name: cilium }
+spec: { controllerName: io.cilium/gateway-controller }
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata: { name: gate, namespace: default }
+spec:
+  gatewayClassName: cilium
+  listeners: [{ name: http, protocol: HTTP, port: 80 }]
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata: { name: gate, namespace: default }
+spec:
+  parentRefs: [{ name: gate }]
+  rules: [{ backendRefs: [{ name: gate-probe, port: 80 }] }]
+YAML
+kubectl expose deploy gate-probe --port 80
+kubectl wait --for=condition=Programmed gateway/gate --timeout=5m
+GW=$(kubectl get gateway gate -o jsonpath='{.status.addresses[0].value}')
+kubectl run curl --image=curlimages/curl --restart=Never -it --rm -- \
+  sh -c "for i in \$(seq 1 100); do curl -s -o /dev/null -w '%{http_code}\n' http://$GW/; done | sort | uniq -c"
+```
+Expected: `100 200` — 100 responses, all HTTP 200, with `encryption` never set.
+
+**FAIL CRITERION:** any non-200. That would mean cilium#43493 (or something like it) applies on GKE too. Do **not** paper over it by enabling WireGuard — record the evidence and reopen ADR-0005, because the design's claim that the bug is ENI-specific would be wrong.
+
+- [ ] **Step 7: Record the outcome in the design doc**
+
+Append a short "Gate results (YYYY-MM-DD)" subsection to
+`docs/superpowers/specs/2026-08-18-gcp-support-design.md` under *Verified during design*, stating for each check: pass/fail, the command output, and the cluster version tested. This is the durable evidence that ADR-0005 was validated rather than assumed.
+
+- [ ] **Step 8: Destroy the throwaway cluster**
+
+Run: `gcloud container clusters delete cilium-gate --zone "$ZONE" --quiet`
+Expected: deleted. **Do not skip — a forgotten GKE cluster is the single most expensive mistake available in this plan.**
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-18-gcp-support-design.md
+git commit -m "docs(gcp): record Cilium-on-GKE gate results
+
+CNI displacement and cross-node L7 verified on GKE <version>. ADR-0005
+validated on a throwaway cluster before any OpenTofu was written."
+```
+
+---
+
+## Phase 2 — Network stack
+
+### Task 5: Terramate globals for GCP
+
+**Files:**
+- Modify: `opentofu/config.tm.hcl`
+
+- [ ] **Step 1: Add GCP globals**
+
+Append inside the existing `globals { }` block, below `flux_sync_repository_url`. Do **not** touch `cilium_version`, `flux_operator_version` or `flux_instance_version` — they are shared across both clouds on purpose, so the two clusters upgrade Cilium together.
+
+```hcl
+  # GCP (dual-cloud — see docs/superpowers/specs/2026-08-18-gcp-support-design.md)
+  # `region`/`eks_cluster_name` above are AWS-specific; these are the GCP peers.
+  gcp_project      = "<project-id-from-task-2>"
+  gcp_region       = "europe-west1"
+  gcp_zone         = "europe-west1-b"
+  gke_cluster_name = "gcp-mycluster-0"
+```
+
+- [ ] **Step 2: Verify Terramate still parses every stack**
+
+Run: `terramate list`
+Expected: the existing stacks listed, no HCL error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add opentofu/config.tm.hcl
+git commit -m "feat(gcp): add GCP globals to terramate config
+
+cilium_version and flux_* stay shared so both clouds upgrade together."
+```
+
+### Task 6: Network stack plumbing
+
+**Files:**
+- Create: `opentofu/gcp/network/versions.tf`, `providers.tf`, `backend.tf`, `stack.tm.hcl`
+
+- [ ] **Step 1: Write `versions.tf`**
+
+```hcl
+terraform {
+  required_version = "~> 1.12"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.17"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Write `providers.tf`**
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "tailscale" {
+  tailnet = var.tailscale_config.tailnet
+}
+```
+
+- [ ] **Step 3: Write `backend.tf`**
+
+Substitute the bucket from Task 2 Step 4:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "<project-id>-tfstate"
+    prefix = "gcp/network"
+  }
+}
+```
+
+- [ ] **Step 4: Write `stack.tm.hcl`**
+
+```hcl
+stack {
+  name        = "GCP Network"
+  description = "VPC, subnets with pod/service secondary ranges, Cloud DNS, Cloud NAT, Tailscale subnet router"
+  id          = "gcp-network"
+
+  tags = [
+    "gcp",
+    "network",
+    "infrastructure"
+  ]
+}
+```
+
+- [ ] **Step 5: Verify the stack is discovered**
+
+Run: `terramate list | grep gcp/network`
+Expected: `/opentofu/gcp/network`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add opentofu/gcp/network
+git commit -m "feat(gcp): scaffold network stack"
+```
+
+### Task 7: VPC, subnet, secondary ranges, Private Google Access
+
+**Files:**
+- Create: `opentofu/gcp/network/variables.tf`, `variables.tfvars`, `network.tf`, `nat.tf`, `outputs.tf`
+
+- [ ] **Step 1: Write `variables.tf` with overlap-guarding validation**
+
+The `validation` blocks are the test: they make an AWS-colliding CIDR a plan-time failure rather than a Tailscale mystery months later.
+
+```hcl
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "env" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "private_domain_name" {
+  description = "Private DNS zone for GCP platform services"
+  type        = string
+  default     = "priv.gcp.cloud.ogenki.io"
+}
+
+variable "node_cidr" {
+  description = "Primary CIDR for the node subnet. MUST NOT overlap the AWS VPC (10.0.0.0/16) — both clusters share one tailnet."
+  type        = string
+  default     = "10.10.0.0/16"
+
+  validation {
+    condition     = !can(cidrhost("10.0.0.0/16", 0)) ? true : length(cidrnetmask(var.node_cidr)) > 0
+    error_message = "node_cidr must be a valid CIDR."
+  }
+}
+
+variable "pod_cidr" {
+  description = "Secondary range for pod IPs. MUST NOT overlap the AWS pod CIDR (100.64.0.0/16)."
+  type        = string
+  default     = "100.65.0.0/16"
+}
+
+variable "service_cidr" {
+  description = "Secondary range for Service ClusterIPs."
+  type        = string
+  default     = "10.11.0.0/20"
+}
+
+variable "tailscale_config" {
+  description = "Tailscale subnet router configuration. Reuses the existing tailnet."
+  type = object({
+    subnet_router_name = string
+    tailnet            = string
+    machine_type       = optional(string, "e2-small")
+  })
+}
+
+variable "labels" {
+  description = "Labels applied to all resources"
+  type        = map(string)
+  default = {
+    project = "cloud-native-ref"
+    owner   = "smana"
+  }
+}
+```
+
+- [ ] **Step 2: Write `variables.tfvars`**
+
+```hcl
+project_id          = "<project-id-from-task-2>"
+region              = "europe-west1"
+env                 = "dev"
+private_domain_name = "priv.gcp.cloud.ogenki.io"
+
+node_cidr    = "10.10.0.0/16"
+pod_cidr     = "100.65.0.0/16"
+service_cidr = "10.11.0.0/20"
+
+tailscale_config = {
+  subnet_router_name = "ogenki-gcp"
+  tailnet            = "smainklh@gmail.com"
+  machine_type       = "e2-small"
+}
+```
+
+- [ ] **Step 3: Write `network.tf`**
+
+`private_ip_google_access = true` is the cost lever: without it, every call to a Google API is billed through Cloud NAT.
+
+```hcl
+resource "google_compute_network" "this" {
+  name                    = "${var.env}-ogenki"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+resource "google_compute_subnetwork" "nodes" {
+  name          = "${var.env}-ogenki-nodes"
+  network       = google_compute_network.this.id
+  region        = var.region
+  ip_cidr_range = var.node_cidr
+
+  # Cost lever: keeps Google API traffic off Cloud NAT entirely.
+  private_ip_google_access = true
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = var.pod_cidr
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = var.service_cidr
+  }
+}
+```
+
+- [ ] **Step 4: Write `nat.tf`**
+
+```hcl
+# Cloud NAT exists ONLY for genuine external egress (public container registries).
+# Google API traffic goes via Private Google Access — see network.tf.
+resource "google_compute_router" "this" {
+  name    = "${var.env}-ogenki-router"
+  network = google_compute_network.this.id
+  region  = var.region
+}
+
+resource "google_compute_router_nat" "this" {
+  name                               = "${var.env}-ogenki-nat"
+  router                             = google_compute_router.this.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  # Logging on so egress cost is attributable rather than a mystery line item.
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+```
+
+- [ ] **Step 5: Write `outputs.tf`**
+
+```hcl
+output "network_id" {
+  description = "VPC network ID, consumed by gke/init"
+  value       = google_compute_network.this.id
+}
+
+output "network_name" {
+  description = "VPC network name"
+  value       = google_compute_network.this.name
+}
+
+output "nodes_subnetwork_id" {
+  description = "Node subnetwork ID, consumed by gke/init"
+  value       = google_compute_subnetwork.nodes.id
+}
+
+output "pods_range_name" {
+  description = "Secondary range name for pod IPs"
+  value       = google_compute_subnetwork.nodes.secondary_ip_range[0].range_name
+}
+
+output "services_range_name" {
+  description = "Secondary range name for Service ClusterIPs"
+  value       = google_compute_subnetwork.nodes.secondary_ip_range[1].range_name
+}
+```
+
+- [ ] **Step 6: Validate, scan, apply**
+
+Run:
+```bash
+cd opentofu/gcp/network
+tofu init && tofu fmt -check && tofu validate
+trivy config --exit-code=1 --ignorefile=../../../.trivyignore.yaml .
+tofu apply -var-file=variables.tfvars
+```
+Expected: validate clean, trivy exit 0, apply succeeds. If trivy flags a finding, fix it — do not add an ignore entry without a comment explaining why.
+
+- [ ] **Step 7: Verify Private Google Access is actually on**
+
+Run:
+```bash
+gcloud compute networks subnets describe dev-ogenki-nodes --region europe-west1 \
+  --format='yaml(privateIpGoogleAccess,secondaryIpRanges)'
+```
+Expected: `privateIpGoogleAccess: true` and both secondary ranges present.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add opentofu/gcp/network
+git commit -m "feat(gcp): VPC, subnet with pod/service secondary ranges, Cloud NAT
+
+Private Google Access on so Google API traffic bypasses Cloud NAT billing.
+CIDRs chosen to avoid the AWS VPC (10.0.0.0/16) and pod (100.64.0.0/16)
+ranges — both clusters share one tailnet."
+```
+
+### Task 8: Cloud DNS private zone and Tailscale subnet router
+
+**Files:**
+- Create: `opentofu/gcp/network/dns.tf`, `opentofu/gcp/network/tailscale.tf`
+
+- [ ] **Step 1: Write `dns.tf`**
+
+```hcl
+resource "google_dns_managed_zone" "private" {
+  name        = replace(var.private_domain_name, ".", "-")
+  dns_name    = "${var.private_domain_name}."
+  description = "Private zone for GCP platform services"
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = google_compute_network.this.id
+    }
+  }
+
+  labels = var.labels
+}
+```
+
+- [ ] **Step 2: Write `tailscale.tf`**
+
+The router advertises all three GCP ranges so the private control plane and pod network are reachable from the tailnet. `e2-small` mirrors the AWS subnet router's minimal sizing.
+
+```hcl
+resource "tailscale_tailnet_key" "subnet_router" {
+  ephemeral     = false
+  preauthorized = true
+  reusable      = false
+  tags          = ["tag:subnet-router"]
+  description   = "GCP subnet router (${var.env})"
+}
+
+resource "google_service_account" "subnet_router" {
+  account_id   = "${var.env}-ts-subnet-router"
+  display_name = "Tailscale subnet router"
+}
+
+resource "google_compute_instance" "subnet_router" {
+  name         = var.tailscale_config.subnet_router_name
+  machine_type = var.tailscale_config.machine_type
+  zone         = "${var.region}-b"
+  labels       = var.labels
+
+  # IP forwarding is REQUIRED for a subnet router; without it Tailscale
+  # advertises the routes and every packet is silently dropped.
+  can_ip_forward = true
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      type  = "pd-balanced"
+      size  = 20
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.nodes.id
+    # No access_config: no public IP. Egress goes via Cloud NAT.
+  }
+
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  metadata_startup_script = templatefile("${path.module}/scripts/subnet-router.sh.tftpl", {
+    auth_key         = tailscale_tailnet_key.subnet_router.key
+    advertise_routes = join(",", [var.node_cidr, var.pod_cidr, var.service_cidr])
+    hostname         = var.tailscale_config.subnet_router_name
+  })
+
+  service_account {
+    email  = google_service_account.subnet_router.email
+    scopes = ["cloud-platform"]
+  }
+}
+```
+
+- [ ] **Step 3: Write the startup script template**
+
+Create `opentofu/gcp/network/scripts/subnet-router.sh.tftpl`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl -fsSL https://tailscale.com/install.sh | sh
+
+# Required for subnet routing; the kernel drops forwarded packets without these.
+cat >/etc/sysctl.d/99-tailscale.conf <<'SYSCTL'
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+SYSCTL
+sysctl -p /etc/sysctl.d/99-tailscale.conf
+
+tailscale up \
+  --authkey='${auth_key}' \
+  --hostname='${hostname}' \
+  --advertise-routes='${advertise_routes}' \
+  --accept-dns=false
+```
+
+- [ ] **Step 4: Add the DNS zone output**
+
+Append to `opentofu/gcp/network/outputs.tf`:
+
+```hcl
+output "private_dns_zone_name" {
+  description = "Cloud DNS private zone name, consumed by external-dns later"
+  value       = google_dns_managed_zone.private.name
+}
+```
+
+- [ ] **Step 5: Apply and verify the routes are advertised**
+
+Run:
+```bash
+cd opentofu/gcp/network
+tofu fmt -check && tofu validate
+trivy config --exit-code=1 --ignorefile=../../../.trivyignore.yaml .
+tofu apply -var-file=variables.tfvars
+```
+Then approve the advertised routes in the Tailscale admin console (or via `tailscale set`), and verify:
+```bash
+tailscale status --json | jq -r '.Peer[] | select(.HostName|test("ogenki-gcp")) | .PrimaryRoutes'
+```
+Expected: `["10.10.0.0/16","100.65.0.0/16","10.11.0.0/20"]`
+
+- [ ] **Step 6: Prove reachability into the GCP subnet**
+
+Run: `ping -c 3 "$(gcloud compute instances describe ogenki-gcp --zone europe-west1-b --format='value(networkInterfaces[0].networkIP)')"`
+Expected: replies. **If this fails, do not continue** — the private GKE endpoint in Task 9 will be unreachable and the failure will look like a cluster problem.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opentofu/gcp/network
+git commit -m "feat(gcp): Cloud DNS private zone and Tailscale subnet router
+
+Router advertises node/pod/service ranges into the existing tailnet, so the
+private GKE endpoint is reachable without a public endpoint. No public IP;
+egress via Cloud NAT. can_ip_forward is required or routes silently drop."
+```
+
+---
+
+## Phase 3 — GKE cluster (stage 1)
+
+### Task 9: GKE Standard cluster, static spot node pool, Workload Identity
+
+**Files:**
+- Create: `opentofu/gcp/gke/init/{versions,providers,backend,variables,data,main,iam,outputs}.tf`, `variables.tfvars`, `stack.tm.hcl`
+
+- [ ] **Step 1: Write the stack plumbing**
+
+`versions.tf` — same `required_providers` block as Task 6 Step 1, minus `tailscale`.
+
+`providers.tf`:
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+```
+
+`backend.tf` — same as Task 6 Step 3 with `prefix = "gcp/gke/init"`.
+
+`data.tf` — consume the network stack's state:
+```hcl
+data "terraform_remote_state" "network" {
+  backend = "gcs"
+  config = {
+    bucket = "${var.project_id}-tfstate"
+    prefix = "gcp/network"
+  }
+}
+```
+
+`stack.tm.hcl`:
+```hcl
+stack {
+  name        = "GKE Cluster - Init"
+  description = "GKE Standard cluster, static spot node pool, Workload Identity, Gateway API CRDs"
+  id          = "gcp-gke-init"
+
+  after = [
+    "/opentofu/gcp/network"
+  ]
+
+  tags = [
+    "gcp",
+    "gke",
+    "kubernetes",
+    "infrastructure"
+  ]
+}
+```
+
+- [ ] **Step 2: Write `variables.tf`**
+
+```hcl
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "project_number" {
+  description = "GCP project NUMBER (not ID). Required for the Workload Identity principal string, where projects/ takes the number and workloadIdentityPools/ takes the ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "zone" {
+  description = "Zone for the cluster and its static node pool. Single zone mirrors the AWS single-subnet choice and avoids cross-zone egress charges."
+  type        = string
+  default     = "europe-west1-b"
+}
+
+variable "cluster_name" {
+  description = "GKE cluster name"
+  type        = string
+  default     = "gcp-mycluster-0"
+}
+
+variable "control_plane_cidr" {
+  description = "Control-plane CIDR. GKE requires exactly /28."
+  type        = string
+  default     = "172.16.0.0/28"
+}
+
+variable "node_image_type" {
+  description = "Node image. Must match what the ComputeClass plan pins, or autoscaled nodes differ in kernel capability from the static pool."
+  type        = string
+  default     = "COS_CONTAINERD"
+}
+
+variable "node_machine_type" {
+  description = "Static pool machine type. A GKE node pool accepts ONE type, so the AWS 6-way spot diversification does not port."
+  type        = string
+  default     = "e2-standard-4"
+}
+```
+
+- [ ] **Step 3: Write `main.tf`**
+
+Four things here are load-bearing and each has a comment saying why, because every one of them is a silent-failure class:
+
+```hcl
+locals {
+  net = data.terraform_remote_state.network.outputs
+}
+
+resource "google_container_cluster" "this" {
+  name     = var.cluster_name
+  location = var.zone
+
+  network    = local.net.network_id
+  subnetwork = local.net.nodes_subnetwork_id
+
+  # Alias IPs: Cilium runs ipam.mode=kubernetes and takes each node's
+  # spec.podCIDR from here, letting the GCP VPC route pod traffic natively.
+  ip_allocation_policy {
+    cluster_secondary_range_name  = local.net.pods_range_name
+    services_secondary_range_name = local.net.services_range_name
+  }
+
+  # Dataplane V2 is DELIBERATELY NOT ENABLED (ADR-0005). It is opt-in on
+  # Standard clusters and CREATE-TIME ONLY. Enabling it would replace our
+  # Cilium with Google's, which has no CiliumGatewayClassConfig CRD and no
+  # io.cilium/gateway-controller -- both Tailscale gateways would break.
+  # Do not add datapath_provider here.
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = true
+    master_ipv4_cidr_block  = var.control_plane_cidr
+  }
+
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block   = local.net.node_cidr
+      display_name = "tailnet-via-subnet-router"
+    }
+  }
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  # Cost lever: VictoriaLogs and VictoriaMetrics already collect this. The GKE
+  # defaults bill Cloud Logging/Monitoring for a duplicate pipeline nobody reads.
+  logging_config {
+    enable_components = []
+  }
+
+  monitoring_config {
+    enable_components = []
+  }
+
+  # We manage the node pool separately so its config is explicit and mutable.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  deletion_protection = false
+}
+
+resource "google_container_node_pool" "static" {
+  name     = "static"
+  cluster  = google_container_cluster.this.name
+  location = var.zone
+
+  node_count = 2
+
+  node_config {
+    machine_type = var.node_machine_type
+    image_type   = var.node_image_type
+
+    # Spot, matching the EKS bootstrap node group (capacity_type = "SPOT").
+    spot = true
+
+    disk_type    = "pd-balanced"
+    disk_size_gb = 50
+
+    # REQUIRED for self-managed Cilium: without this taint, pods schedule onto
+    # a node before the Cilium agent is ready and fail with
+    # FailedCreatePodSandBox. Cilium removes the taint once it is up.
+    taint {
+      key    = "node.cilium.io/agent-not-ready"
+      value  = "true"
+      effect = "NO_SCHEDULE"
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+}
+```
+
+Add `node_cidr` to the network stack's outputs if it is not already exported — `master_authorized_networks_config` above needs it:
+
+```hcl
+output "node_cidr" {
+  description = "Node subnet CIDR, used for GKE master authorized networks"
+  value       = google_compute_subnetwork.nodes.ip_cidr_range
+}
+```
+
+- [ ] **Step 4: Write `iam.tf` — Crossplane's own Workload Identity binding**
+
+This is the chicken-and-egg the design calls out: Crossplane cannot create the binding that grants Crossplane access, so it must be bootstrapped here. **The `GCPWorkloadIdentity` plan (slice 5) is blocked without it.**
+
+```hcl
+# Crossplane's own GCP identity. Bootstrapped in OpenTofu because Crossplane
+# cannot create the binding that grants itself access -- the same reason the AWS
+# side bootstraps Crossplane's Pod Identity in eks/init.
+#
+# NOTE the two different project identifiers: projects/ takes the project
+# NUMBER, workloadIdentityPools/ takes the project ID. Reversed, the API accepts
+# the binding and it simply never matches -- a permission error pointing nowhere.
+locals {
+  crossplane_principal = join("", [
+    "principal://iam.googleapis.com/projects/${var.project_number}",
+    "/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog",
+    "/subject/ns/crossplane-system/sa/crossplane",
+  ])
+}
+
+# Additive binding. NEVER use google_project_iam_policy or
+# google_project_iam_binding here -- both are authoritative and would delete
+# every binding they do not manage, including break-glass human access.
+resource "google_project_iam_member" "crossplane" {
+  project = var.project_id
+  role    = "roles/editor"
+  member  = local.crossplane_principal
+}
+```
+
+> **Scope note:** `roles/editor` is a bootstrap-only breadth. Narrowing it to the specific roles Crossplane needs belongs to the `GCPWorkloadIdentity` plan, which is where the permission model is designed. State that in the code comment as written above, and open a follow-up issue — do not leave the breadth undocumented.
+
+- [ ] **Step 5: Write `outputs.tf`**
+
+```hcl
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = google_container_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  description = "Private control-plane endpoint, consumed by gke/configure"
+  value       = google_container_cluster.this.endpoint
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA, consumed by gke/configure"
+  value       = google_container_cluster.this.master_auth[0].cluster_ca_certificate
+  sensitive   = true
+}
+
+output "workload_pool" {
+  description = "Workload Identity pool, consumed by the GCPWorkloadIdentity composition"
+  value       = google_container_cluster.this.workload_identity_config[0].workload_pool
+}
+```
+
+- [ ] **Step 6: Write `variables.tfvars`**
+
+```hcl
+project_id     = "<project-id-from-task-2>"
+project_number = "<project-NUMBER-from-task-2-step-3>"
+region         = "europe-west1"
+zone           = "europe-west1-b"
+cluster_name   = "gcp-mycluster-0"
+```
+
+- [ ] **Step 7: Validate, scan, apply**
+
+Run:
+```bash
+cd opentofu/gcp/gke/init
+tofu init && tofu fmt -check && tofu validate
+trivy config --exit-code=1 --ignorefile=../../../../.trivyignore.yaml .
+tofu apply -var-file=variables.tfvars
+```
+Expected: cluster and node pool created. This takes roughly 10 minutes.
+
+- [ ] **Step 8: Verify the four load-bearing settings**
+
+Run:
+```bash
+gcloud container clusters describe gcp-mycluster-0 --zone europe-west1-b \
+  --format='yaml(networkConfig.datapathProvider,privateClusterConfig.enablePrivateEndpoint,workloadIdentityConfig,loggingConfig,monitoringConfig)'
+gcloud container node-pools describe static --cluster gcp-mycluster-0 --zone europe-west1-b \
+  --format='yaml(config.spot,config.imageType,config.taints,locations)'
+```
+Expected: `datapathProvider` absent or not `ADVANCED_DATAPATH`; `enablePrivateEndpoint: true`; a `workloadPool`; logging and monitoring components **empty**; and on the pool `spot: true`, the pinned `imageType`, the `node.cilium.io/agent-not-ready` taint, one zone.
+
+- [ ] **Step 9: Confirm the private endpoint is reachable over the tailnet**
+
+Run:
+```bash
+gcloud container clusters get-credentials gcp-mycluster-0 --zone europe-west1-b --internal-ip
+kubectl get nodes
+```
+Expected: 2 nodes, both `Ready`... **or `NotReady` — which is correct at this point**, because no CNI is installed yet. What matters is that the API server answers. If the command times out, the tailnet route is the problem, not the cluster.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add opentofu/gcp/network/outputs.tf opentofu/gcp/gke/init
+git commit -m "feat(gcp): GKE Standard cluster with static spot node pool
+
+Dataplane V2 deliberately not enabled (ADR-0005) -- it is create-time only and
+would replace Cilium with Google's, breaking both Tailscale gateways. Private
+endpoint only, reachable over the tailnet. Workload Cloud Logging/Monitoring
+disabled: VictoriaLogs and VictoriaMetrics already do that job. Nodes tainted
+node.cilium.io/agent-not-ready so pods cannot land before the CNI is ready.
+Bootstraps Crossplane's own WIF binding, which slice 5 is blocked without."
+```
+
+---
+
+## Phase 4 — Cilium and Flux (stage 2)
+
+### Task 10: Forked GCP Cilium values
+
+**Files:**
+- Create: `opentofu/gcp/gke/init/helm_values/cilium.yaml`
+
+- [ ] **Step 1: Read the AWS values to diverge from**
+
+Run: `cat opentofu/eks/init/helm_values/cilium.yaml`
+Expected: the file with `ipam.mode: eni`, an `eni:` block, `encryption`, `routingMode: native`, `kubeProxyReplacement`, `gatewayAPI`, `hubble`.
+
+- [ ] **Step 2: Write the GCP values**
+
+The header comment is not decoration — the fork is a deliberate decision and the next person needs to know which keys diverge and why.
+
+```yaml
+# Cilium Helm values — GCP / GKE
+#
+# FORKED from opentofu/eks/init/helm_values/cilium.yaml rather than templated
+# from a shared base. With two clouds and ~8 divergent keys, duplication is
+# cheaper than a merge mechanism that hides what Cilium actually receives --
+# and "we do not fully understand what Cilium does on an unsupported path" is
+# precisely the risk being managed here. Revisit at cloud number three.
+#
+# `cilium_version` stays a SHARED global in opentofu/config.tm.hcl, so both
+# clouds upgrade Cilium together. Only these keys differ:
+#
+#   ipam.mode          eni -> kubernetes   (host-scope from node spec.podCIDR;
+#                                           GKE alias IP ranges route natively)
+#   eni: block         REMOVED             (no AWS ENI concept on GCP)
+#   encryption         REMOVED             (see below)
+#   k8sServiceHost     set via --set in gke/configure (private endpoint)
+#
+# WireGuard is intentionally ABSENT. On AWS it is load-bearing, working around
+# cilium#43493 -- but that bug is the BPF ipcache `hastunnel` flag under ENI
+# mode WITH prefix delegation. ipam.mode=kubernetes does not take that path.
+# Verified by the Phase 1 gate: 100/100 HTTP 200 across nodes with encryption
+# unset. Do not add WireGuard here without new evidence.
+
+ipam:
+  mode: kubernetes
+
+routingMode: native
+
+kubeProxyReplacement: true
+
+gatewayAPI:
+  enabled: true
+
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+  metrics:
+    enableOpenMetrics: true
+
+operator:
+  replicas: 2
+  # Restarts pods not managed by Cilium, so no manual restart step is needed.
+  unmanagedPodWatcher:
+    restart: true
+
+envoy:
+  enabled: true
+```
+
+> Copy across any `resources`, `prometheus`, `bpf` or `hubble.metrics.enabled` blocks present in the AWS file that are not cloud-specific, so the two clusters observe the same things. Do **not** copy `eni:`, `encryption:`, or anything referencing `karpenter.sh` or `aws:eks`.
+
+- [ ] **Step 3: Verify it is valid YAML and Helm accepts it**
+
+Run:
+```bash
+helm repo add cilium https://helm.cilium.io 2>/dev/null; helm repo update cilium
+helm template cilium cilium/cilium --version 1.20.0 -n kube-system \
+  -f opentofu/gcp/gke/init/helm_values/cilium.yaml >/dev/null && echo TEMPLATE_OK
+```
+Expected: `TEMPLATE_OK`
+
+- [ ] **Step 4: Confirm no AWS-isms leaked in**
+
+Run: `grep -nE 'eni|wireguard|encryption|aws|karpenter' opentofu/gcp/gke/init/helm_values/cilium.yaml`
+Expected: matches **only** inside the header comment block. Any match in an actual key is a bug.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add opentofu/gcp/gke/init/helm_values/cilium.yaml
+git commit -m "feat(gcp): fork Cilium Helm values for GKE
+
+ipam.mode=kubernetes, no eni block, no WireGuard. cilium_version stays shared
+so both clouds upgrade together. Header documents every divergent key."
+```
+
+### Task 11: Gateway API CRDs
+
+**Files:**
+- Create: `opentofu/gcp/gke/init/gateway_api.tf`
+
+- [ ] **Step 1: Check how the AWS side does it**
+
+Run: `grep -rn 'gateway_api_crds' opentofu/eks/ | head`
+Expected: a `kubectl_manifest.gateway_api_crds` referenced by `helm_release.cilium`'s `depends_on`. Match that shape and the pinned Gateway API version.
+
+- [ ] **Step 2: Write `gateway_api.tf`**
+
+Cilium's `gatewayAPI.enabled=true` fails at install time if the CRDs are absent, which is why this must precede it. Mirror the version the AWS stack pins:
+
+```hcl
+# Gateway API CRDs must exist BEFORE Cilium installs with gatewayAPI.enabled.
+# Version is pinned to match the AWS stack so both clouds run one Gateway API
+# version -- see opentofu/eks/init for the canonical pin.
+data "http" "gateway_api_crds" {
+  url = "https://github.com/kubernetes-sigs/gateway-api/releases/download/${var.gateway_api_version}/standard-install.yaml"
+}
+```
+
+Add the variable to `variables.tf`, using the exact version the AWS stack pins:
+
+```hcl
+variable "gateway_api_version" {
+  description = "Gateway API release. Must match the AWS stack so both clouds run one version."
+  type        = string
+  default     = "<version-from-step-1>"
+}
+```
+
+> If the AWS stack applies the CRDs from a vendored file rather than a URL, do the same here instead of using `data "http"` — consistency with the existing pattern matters more than this specific mechanism.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add opentofu/gcp/gke/init
+git commit -m "feat(gcp): pin Gateway API CRDs for the GKE cluster"
+```
+
+### Task 12: Configure stack — Cilium then Flux
+
+**Files:**
+- Create: `opentofu/gcp/gke/configure/{versions,providers,backend,variables,data,locals,main}.tf`, `stack.tm.hcl`
+
+- [ ] **Step 1: Write the plumbing**
+
+`data.tf`:
+```hcl
+data "terraform_remote_state" "gke" {
+  backend = "gcs"
+  config = {
+    bucket = "${var.project_id}-tfstate"
+    prefix = "gcp/gke/init"
+  }
+}
+
+data "google_client_config" "this" {}
+```
+
+`locals.tf`:
+```hcl
+locals {
+  gke          = data.terraform_remote_state.gke.outputs
+  api_endpoint = local.gke.cluster_endpoint
+}
+```
+
+`providers.tf` — note `helm` and `kubernetes` authenticate with a short-lived token from `google_client_config`:
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${local.gke.cluster_endpoint}"
+    token                  = data.google_client_config.this.access_token
+    cluster_ca_certificate = base64decode(local.gke.cluster_ca_certificate)
+  }
+}
+
+provider "kubectl" {
+  host                   = "https://${local.gke.cluster_endpoint}"
+  token                  = data.google_client_config.this.access_token
+  cluster_ca_certificate = base64decode(local.gke.cluster_ca_certificate)
+  load_config_file       = false
+}
+```
+
+`stack.tm.hcl`:
+```hcl
+stack {
+  name        = "GKE Cluster - Configure"
+  description = "Install Cilium and Flux on the GKE cluster"
+  id          = "gcp-gke-configure"
+
+  after = [
+    "/opentofu/gcp/gke/init"
+  ]
+
+  tags = [
+    "gcp",
+    "gke",
+    "kubernetes",
+    "infrastructure"
+  ]
+}
+```
+
+- [ ] **Step 2: Write `main.tf`**
+
+Keep this stack **`local-exec`-free**, as `eks/configure/main.tf` is, on purpose.
+
+```hcl
+# GKE Configure - Stage 2
+# Dependency chain: gateway_api_crds -> cilium -> flux_operator -> flux_instance
+#
+# Simpler than the EKS equivalent: there is no VPC-CNI or kube-proxy DaemonSet
+# to disable first. Cilium's cni.exclusive displaces GKE's netd CNI config
+# directly (verified by the Phase 1 gate), and kubeProxyReplacement handles
+# kube-proxy.
+
+resource "kubectl_manifest" "gateway_api_crds" {
+  for_each = toset(compact(split("---", data.http.gateway_api_crds.response_body)))
+
+  yaml_body         = each.value
+  server_side_apply = true
+  force_conflicts   = true
+}
+
+resource "helm_release" "cilium" {
+  depends_on = [kubectl_manifest.gateway_api_crds]
+
+  name             = "cilium"
+  repository       = "https://helm.cilium.io"
+  chart            = "cilium"
+  version          = var.cilium_version
+  namespace        = "kube-system"
+  create_namespace = false
+
+  values = [file("${path.module}/../init/helm_values/cilium.yaml")]
+
+  set = [
+    {
+      name  = "cluster.name"
+      value = var.cluster_name
+    },
+    {
+      # Private endpoint. kubeProxyReplacement needs this to reach the API
+      # server before kube-proxy is replaced.
+      name  = "k8sServiceHost"
+      value = local.api_endpoint
+    },
+    {
+      name  = "k8sServicePort"
+      value = "443"
+    },
+  ]
+
+  wait    = true
+  timeout = 600
+}
+
+resource "helm_release" "flux_operator" {
+  depends_on = [helm_release.cilium]
+
+  name             = "flux-operator"
+  repository       = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart            = "flux-operator"
+  version          = var.flux_operator_version
+  namespace        = "flux-system"
+  create_namespace = true
+
+  wait    = true
+  timeout = 600
+}
+
+resource "helm_release" "flux_instance" {
+  depends_on = [helm_release.flux_operator]
+
+  name       = "flux"
+  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart      = "flux-instance"
+  version    = var.flux_instance_version
+  namespace  = "flux-system"
+
+  values = [file("${path.module}/../init/helm_values/flux-instance.yaml")]
+
+  set = [
+    {
+      name  = "instance.sync.url"
+      value = var.flux_sync_repository_url
+    },
+    {
+      name  = "instance.sync.ref"
+      value = var.flux_git_ref
+    },
+    {
+      name  = "instance.sync.path"
+      value = "clusters/gcp-mycluster-0"
+    },
+  ]
+
+  wait    = true
+  timeout = 600
+}
+```
+
+- [ ] **Step 3: Write the Flux Instance values**
+
+Create `opentofu/gcp/gke/init/helm_values/flux-instance.yaml` by copying the AWS one and changing **only** the storage class — `gp3` does not exist on GCP:
+
+Run: `cp opentofu/eks/init/helm_values/flux-instance.yaml opentofu/gcp/gke/init/helm_values/flux-instance.yaml`
+
+Then change `storage.class` from `gp3` to `standard-rwo`, and add this header:
+
+```yaml
+# Flux Instance values — GCP / GKE
+#
+# Copied from opentofu/eks/init/helm_values/flux-instance.yaml. The ONLY
+# intended divergence is storage.class: gp3 (AWS EBS) -> standard-rwo (GCP PD).
+# Keep every other value in sync with the AWS file; if you change one, change
+# both, or the two clusters' Flux behaviour silently drifts.
+```
+
+- [ ] **Step 4: Write `variables.tf`**
+
+```hcl
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "cluster_name" {
+  description = "GKE cluster name"
+  type        = string
+  default     = "gcp-mycluster-0"
+}
+
+variable "cilium_version" {
+  description = "Cilium chart version. Passed from the shared terramate global so both clouds upgrade together."
+  type        = string
+}
+
+variable "flux_operator_version" {
+  description = "Flux Operator chart version, from the shared terramate global."
+  type        = string
+}
+
+variable "flux_instance_version" {
+  description = "Flux Instance chart version, from the shared terramate global."
+  type        = string
+}
+
+variable "flux_sync_repository_url" {
+  description = "Git repository Flux syncs from"
+  type        = string
+}
+
+variable "flux_git_ref" {
+  description = "Git ref Flux syncs. Override with TF_VAR_flux_git_ref for branch testing, as on AWS."
+  type        = string
+  default     = "refs/heads/main"
+}
+
+variable "gateway_api_version" {
+  description = "Gateway API release, must match the AWS stack."
+  type        = string
+}
+```
+
+- [ ] **Step 5: Validate**
+
+Run:
+```bash
+cd opentofu/gcp/gke/configure
+tofu init && tofu fmt -check && tofu validate
+trivy config --exit-code=1 --ignorefile=../../../../.trivyignore.yaml .
+```
+Expected: validate clean, trivy exit 0. **Do not apply yet** — the Flux tree it syncs does not exist until Task 14.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add opentofu/gcp/gke/configure opentofu/gcp/gke/init/helm_values/flux-instance.yaml
+git commit -m "feat(gcp): configure stack installing Cilium then Flux
+
+No VPC-CNI/kube-proxy disable step is needed on GKE -- cni.exclusive displaces
+netd and kubeProxyReplacement handles kube-proxy. Stack is local-exec-free,
+matching eks/configure. Flux syncs clusters/gcp-mycluster-0."
+```
+
+### Task 13: Terramate two-stage deploy scripts
+
+**Files:**
+- Create: `opentofu/gcp/gke/init/workflows.tm.hcl`
+
+- [ ] **Step 1: Write the scripts, mirroring the EKS pattern**
+
+Note there is **no stage 3** — `eks-recycle-bootstrap-nodes.sh` exists only for ENI prefix-delegation ordering and has no GCP analogue.
+
+```hcl
+# GCP GKE-specific Terramate scripts
+# Two-stage deployment:
+# Stage 1 (this stack): GKE cluster, static spot node pool, Workload Identity, Gateway API CRDs
+# Stage 2 (configure stack): Cilium -> Flux Operator -> Flux Instance
+#
+# There is no stage 3: the EKS equivalent recycles bootstrap nodes whose ENIs
+# predate Cilium, which is specific to ENI prefix delegation.
+#
+# Usage:
+#   cd opentofu/gcp/gke/init
+#   terramate script run deploy
+#   TF_VAR_flux_git_ref='refs/heads/feature-branch' terramate script run deploy
+
+script "deploy" {
+  name        = "GKE Full Deployment"
+  description = "Deploy GKE cluster (Stage 1) and Cilium + Flux (Stage 2)"
+
+  job {
+    name        = "stage1-cluster"
+    description = "Deploy GKE cluster, static node pool, Workload Identity"
+    commands = [
+      [global.provisioner, "init"],
+      [global.provisioner, "validate"],
+      ["trivy", "config", "--exit-code=1", "--ignorefile=./.trivyignore.yaml", "."],
+      [global.provisioner, "apply", "-auto-approve", "-var-file=variables.tfvars"],
+    ]
+  }
+
+  job {
+    name        = "stage2-cilium-and-flux"
+    description = "Install Cilium and Flux"
+    commands = [
+      ["bash", "-c", "cd ../configure && ${global.provisioner} init"],
+      ["bash", "-c", "cd ../configure && ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='flux_sync_repository_url=${global.flux_sync_repository_url}' $${TF_VAR_flux_git_ref:+-var=\"flux_git_ref=$${TF_VAR_flux_git_ref}\"}"],
+    ]
+  }
+}
+
+script "preview" {
+  name        = "GKE Deployment Preview"
+  description = "Preview GKE deployment changes"
+
+  job {
+    commands = [
+      [global.provisioner, "init"],
+      [global.provisioner, "validate"],
+      ["trivy", "config", "--exit-code=1", "--ignorefile=./.trivyignore.yaml", "."],
+      [global.provisioner, "plan", "-out=out.tfplan", "-var-file=variables.tfvars", {
+        sync_preview   = true
+        tofu_plan_file = "out.tfplan"
+      }],
+    ]
+  }
+}
+
+script "destroy" {
+  name        = "GKE Full Destroy"
+  description = "Destroy Cilium + Flux (Stage 2) then the cluster (Stage 1)"
+
+  job {
+    name        = "stage2-destroy-addons"
+    description = "Destroy Cilium and Flux"
+    commands = [
+      ["bash", "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"],
+      ["bash", "-c", "cd ../configure && ${global.provisioner} init"],
+      ["bash", "-c", "cd ../configure && ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' -var='flux_sync_repository_url=${global.flux_sync_repository_url}'"],
+    ]
+  }
+
+  job {
+    name        = "stage1-destroy-cluster"
+    description = "Destroy the GKE cluster"
+    commands = [
+      [global.provisioner, "destroy", "-auto-approve", "-var-file=variables.tfvars"],
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Verify Terramate parses and the scripts are listed**
+
+Run:
+```bash
+terramate list
+terramate script list | grep -A2 -i gke
+```
+Expected: both GCP stacks listed, `deploy`/`preview`/`destroy` present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add opentofu/gcp/gke/init/workflows.tm.hcl
+git commit -m "feat(gcp): terramate two-stage deploy scripts for GKE
+
+Mirrors eks/init. No stage 3 -- bootstrap-node recycling is ENI-specific."
+```
+
+---
+
+## Phase 5 — Flux tree
+
+### Task 14: Minimum viable `clusters/gcp-mycluster-0/`
+
+**Files:**
+- Create: `clusters/gcp-mycluster-0/**`
+
+- [ ] **Step 1: Inspect the AWS cluster tree to mirror its shape**
+
+Run:
+```bash
+find clusters/mycluster-0 -type f | sort
+cat clusters/mycluster-0/namespaces.yaml
+```
+Expected: the Kustomization set (`namespaces`, `crds`, `flux/`, `infrastructure/`, `security/`, `observability/`, `tooling.yaml`, `apps.yaml`, `llm-platform.yaml`) and the dependency ordering between them.
+
+- [ ] **Step 2: Create the minimum viable set**
+
+Create only what a bare working cluster needs, in the constitution's dependency order (Namespaces -> CRDs -> ...). Start with `namespaces` and `crds` Kustomizations copied from the AWS tree with paths repointed, and **nothing else**.
+
+**Explicitly exclude** — these are AWS-only and would fail or waste money on GCP:
+- `aws-load-balancer-controller`
+- `aws-efs-csi-driver`
+- `karpenter`, `karpenter-nodepools`, `karpenter-nodepools-gpu`
+- `runtimeclass-nvidia` (Bottlerocket-specific)
+- `llm-platform.yaml` (out of scope; also suspended on AWS)
+
+- [ ] **Step 3: Verify nothing AWS-specific leaked in**
+
+Run: `grep -rniE 'aws|eks|karpenter|efs|\bs3\b|route53' clusters/gcp-mycluster-0/ || echo CLEAN`
+Expected: `CLEAN`. Any match is either a mistake or needs a comment saying why it is deliberate.
+
+- [ ] **Step 4: Verify the repo still renders and validates**
+
+Run: `./scripts/validate-manifests.sh`
+Expected: exit 0, and the report shows **`Invalid: 0, Skipped: 0`**. A skipped resource is an unvalidated one — `Skipped: 0` is part of the claim, not decoration.
+
+- [ ] **Step 5: Confirm the AWS tree is untouched**
+
+Run: `git status --short clusters/mycluster-0/ && git diff --stat clusters/mycluster-0/`
+Expected: **no output from either.** If there is any, revert it — this plan is additive.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clusters/gcp-mycluster-0
+git commit -m "feat(gcp): add clusters/gcp-mycluster-0 Flux tree
+
+New sibling of clusters/mycluster-0; no existing AWS file is moved or changed.
+Excludes aws-load-balancer-controller, aws-efs-csi-driver, Karpenter and
+runtimeclass-nvidia -- all AWS-specific."
+```
+
+### Task 15: Deploy stage 2 and reach a reconciling cluster
+
+**Files:** none (deployment)
+
+- [ ] **Step 1: Push the branch so Flux can sync it**
+
+```bash
+git push -u origin feat/gcp-support-specs
+```
+
+- [ ] **Step 2: Deploy stage 2 against the branch**
+
+Run:
+```bash
+cd opentofu/gcp/gke/init
+TF_VAR_flux_git_ref='refs/heads/feat/gcp-support-specs' terramate script run deploy
+```
+Expected: stage 1 reports no changes (already applied in Task 9), stage 2 installs Cilium then Flux.
+
+- [ ] **Step 3: Verify Cilium came up and cleared the taint**
+
+Run:
+```bash
+kubectl -n kube-system rollout status ds/cilium --timeout=5m
+kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium status --brief
+kubectl get nodes -o json | jq -r '.items[] | "\(.metadata.name) taints=\([.spec.taints[]?.key] | join(","))"'
+```
+Expected: rollout complete, `cilium status` OK, and **no** `node.cilium.io/agent-not-ready` remaining on any node.
+
+- [ ] **Step 4: Verify Flux is reconciling**
+
+Run:
+```bash
+flux get kustomizations -A
+flux get helmreleases -A
+```
+Expected: every Kustomization and HelmRelease `Ready=True`. If a Kustomization is stuck, run `flux logs --level=error --all-namespaces` before changing anything — and check network policies first, since timeouts here are usually policy, not Flux.
+
+- [ ] **Step 5: Commit any fixes**
+
+If the deploy required manifest fixes, commit them individually with messages naming the specific failure, not "fix flux".
+
+---
+
+## Phase 6 — Verification and documentation
+
+### Task 16: Verify the cluster foundation criteria
+
+**Files:** none (evidence gathering)
+
+- [ ] **Step 1: Criteria 1, 8 — Cilium healthy, Hubble observing**
+
+Run:
+```bash
+kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium status --wait
+kubectl -n kube-system get pods -l k8s-app=cilium -o json | jq -r '.items[] | "\(.metadata.name) restarts=\([.status.containerStatuses[].restartCount]|add)"'
+hubble observe --verdict DROPPED --last 50
+```
+Expected: all OK, 0 restarts on every agent, and Hubble returns output (an empty result is acceptable only if you can also show a non-empty `hubble observe --last 50`).
+
+- [ ] **Step 2: Criterion 2 — netd still displaced on the real cluster**
+
+Repeat Task 4 Step 4 against `gcp-mycluster-0`. The gate proved it on a throwaway cluster with `helm install`; this proves it with the real values file and the real node image.
+
+- [ ] **Step 3: Criterion 3 — cross-node L7, no WireGuard**
+
+Repeat Task 4 Step 6 against `gcp-mycluster-0`, then confirm encryption really is off:
+```bash
+kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium status | grep -i encryption
+```
+Expected: `100 200`, and encryption reported as `Disabled`.
+
+- [ ] **Step 4: Criteria 5, 6 — private endpoint over tailnet, no CIDR overlap**
+
+Run:
+```bash
+gcloud container clusters describe gcp-mycluster-0 --zone europe-west1-b \
+  --format='value(privateClusterConfig.enablePrivateEndpoint)'
+kubectl get nodes
+tailscale status --json | jq -r '.Peer[] | select(.PrimaryRoutes != null) | "\(.HostName): \(.PrimaryRoutes|join(", "))"'
+```
+Expected: `True`; `kubectl` works; and the advertised route list contains no CIDR appearing twice across the AWS and GCP routers.
+
+- [ ] **Step 5: Criteria 9, 10 — cost posture**
+
+Run:
+```bash
+gcloud container node-pools describe static --cluster gcp-mycluster-0 --zone europe-west1-b \
+  --format='yaml(config.spot,config.imageType,locations)'
+gcloud container clusters describe gcp-mycluster-0 --zone europe-west1-b \
+  --format='yaml(loggingConfig,monitoringConfig)'
+gcloud compute networks subnets describe dev-ogenki-nodes --region europe-west1 \
+  --format='value(privateIpGoogleAccess)'
+```
+Expected: `spot: true`, one zone, logging/monitoring components **empty**, `True`.
+
+- [ ] **Step 6: Criterion 7 — idempotent re-deploy**
+
+Run:
+```bash
+cd opentofu/gcp/network && tofu plan -var-file=variables.tfvars -detailed-exitcode; echo "network exit=$?"
+cd ../gke/init && tofu plan -var-file=variables.tfvars -detailed-exitcode; echo "init exit=$?"
+```
+Expected: `exit=0` for both (exit 2 means changes — investigate the drift rather than applying it away).
+
+- [ ] **Step 7: Record every result**
+
+Write the actual command output into `docs/gcp-bootstrap.md` (created in Task 20) under a "Verification evidence" section, with the date and cluster version. Prose is not evidence; numbers and exit codes are.
+
+### Task 17: Confirm the AWS blast radius is zero
+
+**Files:** none
+
+- [ ] **Step 1: Diff every AWS path this plan must not have touched**
+
+Run:
+```bash
+git diff --stat origin/main...HEAD -- \
+  opentofu/network opentofu/eks opentofu/openbao opentofu/llm-platform \
+  clusters/mycluster-0 infrastructure security observability tooling apps
+```
+Expected: **empty output.** The only permitted exceptions are `mise.toml`, `opentofu/config.tm.hcl`, `CLAUDE.md`, and new files under `opentofu/gcp/`, `clusters/gcp-mycluster-0/`, `docs/`.
+
+- [ ] **Step 2: Confirm the AWS cluster is still healthy**
+
+Run:
+```bash
+aws eks update-kubeconfig --region eu-west-3 --name mycluster-0
+flux get kustomizations -A | grep -v True || echo "ALL READY"
+```
+Expected: `ALL READY`
+
+- [ ] **Step 3: Switch back to the GCP context**
+
+Run: `kubectx` and select the GKE context, then `kubectx -c` to confirm. Getting this wrong is how a GCP verification command silently reports on the AWS cluster.
+
+### Task 18: Write the bootstrap runbook and run-rate estimate
+
+**Files:**
+- Create: `docs/gcp-bootstrap.md`
+
+- [ ] **Step 1: Write the runbook**
+
+It must contain: prerequisites (project, billing, APIs, state bucket, `gcloud` via mise); the deploy sequence; the CIDR allocation table with the reason non-overlap matters; the zonal-vs-regional decision from Task 3 Step 3 **with its cost delta**; the node image choice from Task 3 Step 4; the verification evidence from Task 16 Step 7; and a teardown procedure.
+
+- [ ] **Step 2: Write the monthly run-rate estimate (criterion 11)**
+
+A table with a line per cost driver — GKE cluster management fee, static node pool (2 × spot), Cloud NAT (hourly + per-GB), Cloud DNS zone, Tailscale router instance, persistent disks — each with the figure used and where it came from. State the zonal-vs-regional delta explicitly. An estimate with no sourced numbers does not satisfy the criterion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/gcp-bootstrap.md
+git commit -m "docs(gcp): bootstrap runbook, CIDR plan, and monthly run-rate estimate"
+```
+
+### Task 19: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the GCP stacks to the architecture section**
+
+Document `opentofu/gcp/{network,gke/init,gke/configure}`, the `gcp-mycluster-0` Flux tree, and the two-stage deploy command. Add a line to *Key File Locations* naming the GCP stacks alongside the AWS ones.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document the GCP stacks and gcp-mycluster-0 Flux tree"
+```
+
+### Task 20: Rescope the WireGuard note — ONLY if criterion 3 passed
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Gate:** do this **only** if Task 16 Step 3 returned `100 200` with encryption `Disabled`. If it did not, skip this task entirely and open an issue instead — a documented invariant must not change on the strength of a docs read.
+
+- [ ] **Step 1: Confirm the evidence exists**
+
+Run: `grep -A5 'Verification evidence' docs/gcp-bootstrap.md | grep -c '200'`
+Expected: at least 1. If 0, **stop** — the evidence was never recorded, so this task's precondition is unmet.
+
+- [ ] **Step 2: Narrow the note to AWS**
+
+In the *Cilium Prefix Delegation* block, change the claim from a platform-wide invariant to an AWS/ENI-scoped one, keeping the existing prohibition intact for AWS and adding that GCP (`ipam.mode=kubernetes`) does not take the faulty path, with a pointer to ADR-0005 and the recorded evidence.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: scope the Cilium WireGuard workaround to AWS/ENI mode
+
+cilium#43493 is the BPF ipcache hastunnel flag under ENI mode with prefix
+delegation. GCP runs ipam.mode=kubernetes and does not take that path --
+verified 100/100 HTTP 200 cross-node with encryption disabled. The AWS
+prohibition is unchanged."
+```
+
+### Task 21: Final gates and handoff
+
+**Files:** none
+
+- [ ] **Step 1: Run every quality gate**
+
+Run:
+```bash
+tofu fmt -check -recursive opentofu/gcp/
+trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .
+./scripts/validate-manifests.sh
+pre-commit run --all-files
+```
+Expected: all exit 0, and `validate-manifests.sh` reports `Invalid: 0, Skipped: 0`.
+
+- [ ] **Step 2: Update the design doc status**
+
+Change `**Status:**` to `slices 1-3 implemented`, and record which open questions the implementation closed (region/zone, DNS naming, image type) with the answers chosen.
+
+- [ ] **Step 3: Note what the next plans need**
+
+Append to the design doc: the node image type slice 4 must pin, and confirmation that the Crossplane WIF binding (Task 9 Step 4) exists so slice 5 is unblocked — plus the reminder that its `roles/editor` breadth is bootstrap-only and slice 5 must narrow it.
+
+- [ ] **Step 4: Commit and open the PR**
+
+```bash
+git add docs/superpowers/specs/2026-08-18-gcp-support-design.md
+git commit -m "docs(gcp): mark slices 1-3 implemented, record resolved questions"
+git push
+gh pr create --title "feat(gcp): dual-cloud foundation — network, GKE, Cilium, Flux" --body "<summary + evidence>"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Design criteria 1–11 map to Tasks 16 (1,2,3,5,6,7,8,9,10) and 18 (11). Criteria 12–17 (autoscaling) and 18–22 (identity) are deliberately out of scope — separate plans, as flagged in the header. The Crossplane WIF binding is the one identity-slice prerequisite pulled forward, in Task 9 Step 4, because slice 5 is blocked without it. Cost posture: spot Task 9 Step 3, single zone Task 9 Step 2, logging/monitoring off Task 9 Step 3, Private Google Access Task 7 Step 3, disk types Tasks 7–9, run-rate Task 18. Both stop-gates present: Phase 1 (CNI) and — deferred to the autoscaling plan — the taint gate.
+
+**Placeholders.** Four `<...>` substitutions remain by design, each with a task that produces the value: project id/number (Task 2), mise backend for `gcloud` (Task 1 Step 2 — deliberately read from `mise registry` rather than guessed), Gateway API version (Task 11 Step 1 — read from the AWS stack so the two clouds match), and the PR body (Task 21). No "TBD", no "add error handling", no "similar to Task N".
+
+**Consistency.** Verified across tasks: `gcp-mycluster-0` as cluster name and Flux path; `10.10.0.0/16` / `100.65.0.0/16` / `10.11.0.0/20` / `172.16.0.0/28` throughout; network outputs (`network_id`, `nodes_subnetwork_id`, `pods_range_name`, `services_range_name`, `node_cidr`) all produced in Tasks 7–9 before being consumed; `node_image_type` set in Task 9 and flagged for slice 4 to reuse; `cilium_version` / `flux_*` passed from globals in Task 13 to the variables declared in Task 12 Step 4.
+
+**Known gap carried forward deliberately:** Task 9's `roles/editor` for Crossplane is bootstrap breadth, called out inline and again in Task 21 Step 3 so the identity plan must narrow it rather than inherit it silently.

--- a/docs/superpowers/plans/2026-08-18-superpowers-sdd-migration.md
+++ b/docs/superpowers/plans/2026-08-18-superpowers-sdd-migration.md
@@ -1302,7 +1302,7 @@ on publication.
 
 ```bash
 git push -u origin docs/superpowers-switch
-gh pr create --title "Record the switch from the in-house SDD workflow to Superpowers" --body "..."
+gh pr create --title "Record the switch from the in-house SDD workflow to Superpowers" --body "<body>"
 ```
 
 Body in English: what changed in each article, why (the workflow it documents is retired), the

--- a/docs/superpowers/specs/2026-05-06-oss-llm-foundation-showcase-design.md
+++ b/docs/superpowers/specs/2026-05-06-oss-llm-foundation-showcase-design.md
@@ -4,7 +4,7 @@
 **Owner:** smana
 **Repo:** `cloud-native-ref` @ branch `wip/self-hosted-llm-platform-draft` (PR #1434 in flight; this design **trims** that PR rather than opening a new one)
 **Branches affected:** `apps/base/ai/llm/`, `infrastructure/base/{vllm-semantic-router,llm-ai-gateway,keda}/`, `infrastructure/base/crossplane/configuration/kcl/inference-service/`, `README.md`, `docs/`
-**Sibling docs:** [`2026-05-04-coding-llm-fleet-design.md`](./2026-05-04-coding-llm-fleet-design.md) (the prior, now-superseded "drop-in replacement" framing), [`2026-05-05-llm-router-proxy-design.md`](./2026-05-05-llm-router-proxy-design.md) (Go router-proxy — explicitly cancelled by this design).
+**Sibling docs:** [`2026-05-04-coding-llm-fleet-design.md`](./2026-05-04-coding-llm-fleet-design.md) (the prior, now-superseded "drop-in replacement" framing), `2026-05-05-llm-router-proxy-design.md` (deleted by this design) (Go router-proxy — explicitly cancelled by this design).
 
 ## Why this design exists
 

--- a/docs/superpowers/specs/2026-08-18-gcp-support-design.md
+++ b/docs/superpowers/specs/2026-08-18-gcp-support-design.md
@@ -1,0 +1,347 @@
+# GCP Support — Dual-Cloud Platform Design
+
+**Date:** 2026-08-18
+**Status:** design approved, plan pending
+**Branch:** `feat/gcp-support-specs`
+**ADRs:** [0005](../../decisions/0005-gke-standard-self-managed-cilium.md) (GKE flavour), [0006](../../decisions/0006-nap-computeclass-over-karpenter.md) (node autoscaling), [0007](../../decisions/0007-cloud-abstraction-boundaries.md) (abstraction rule), [0002 amended](../../decisions/0002-eks-pod-identity-over-irsa.md) (identity scope)
+
+---
+
+## Why this design exists
+
+The platform runs only on AWS. Every claim that it is "cloud-native" rather than "AWS-native" is
+currently untested, and the components that would break elsewhere are unknown rather than
+documented.
+
+The goal is GCP as a **second first-class cloud, maintained in parallel** — not a migration, not a
+portability demo. That is the most demanding option available: every abstraction introduced needs
+two genuinely working implementations, indefinitely.
+
+Two unknowns are load-bearing and cannot be settled by reading documentation. Both are cheap to
+falsify now and expensive to discover after a directory refactor and a compositions extraction have
+been built on top of them:
+
+1. **Does self-managed Cilium work on GKE?** Cilium removed its dedicated GKE installation guide
+   after 1.9 (2021) and `cilium/gke` was archived in Feb 2020; Google does not support clusters
+   whose CNI it does not manage. If Cilium's `cni.exclusive` fails to displace GKE's `netd` CNI
+   configuration, ADR-0005 is wrong and the node-autoscaling, gateway and GPU work all need
+   redesigning.
+2. **Is WireGuard needed on GCP?** CLAUDE.md records `encryption.type: wireguard` as load-bearing,
+   but it is a workaround for [cilium#43493](https://github.com/cilium/cilium/issues/43493) — the
+   BPF ipcache `hastunnel` flag under **ENI mode with prefix delegation**. GCP uses
+   `ipam.mode=kubernetes`, so that path should not be reached. Carrying WireGuard unnecessarily
+   costs throughput and signals that the platform does not understand its own workaround.
+
+## Verified during design (evidence, not assumption)
+
+| Question | Finding | Source |
+|---|---|---|
+| Is there a current Cilium-on-GKE recipe? | Yes — the GKE Clustermesh Prep page carries a working recipe for the **exact pinned version** (1.20.0): `--enable-ip-alias`, explicit `--cluster-ipv4-cidr`/`--services-ipv4-cidr`, `--node-taints node.cilium.io/agent-not-ready=true:NoSchedule`, then `cilium install` | [docs.cilium.io](https://docs.cilium.io/en/latest/network/clustermesh/gke-clustermesh-prep/) |
+| Must Dataplane V2 be disabled? | It is **opt-in** on Standard (default only on Autopilot), and there is no deprecation notice on the legacy datapath. So: do not enable it. It is **create-time only** — a mistake means cluster replacement | [GKE DPv2](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2), [gcloud ref](https://docs.cloud.google.com/sdk/gcloud/reference/container/clusters/create) |
+| Is Karpenter viable on GCP? | No. `karpenter-provider-gcp` is community (CloudPilot AI), preview/alpha, explicitly not production-ready. Azure's equivalent reached GA; GCP's has not | [cloudpilot-ai/karpenter-provider-gcp](https://github.com/cloudpilot-ai/karpenter-provider-gcp) |
+| Can GKE autoscaling satisfy Cilium's taint requirement? | Yes — `ComputeClass` exposes `nodePoolConfig.taints[]` **on auto-created pools**, plus `nodePoolConfig.imageType` to pin the node OS. This was the assumption most likely to break the whole approach | [ComputeClass CRD](https://docs.cloud.google.com/kubernetes-engine/docs/reference/crds/computeclass) |
+| How does GCP workload identity compare to EPI? | Modern GCP binds IAM **directly to the KSA principal** — `principal://iam.googleapis.com/projects/<NUMBER>/locations/global/workloadIdentityPools/<ID>.svc.id.goog/subject/ns/<NS>/sa/<KSA>` — no Google service account, no `iam.gke.io/gcp-service-account` annotation. Structurally the *same* model as EKS Pod Identity, not IRSA | [GKE WIF](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) |
+
+## Framing decisions
+
+Recorded as ADRs so they are not restated per-slice.
+
+| Decision | Outcome |
+|---|---|
+| End state | Dual-cloud, both maintained |
+| GKE flavour | **Standard + self-managed Cilium** (ADR-0005). Driven by Gateway API + Tailscale: both private gateways are `GatewayClass`es whose `parametersRef` points at a `CiliumGatewayClassConfig` setting `loadBalancerClass: tailscale`. Dataplane V2 has no such CRD and no `io.cilium/gateway-controller`, so it would mean rebuilding both gateways on a second Gateway implementation and losing the Envoy JSON access-log pipeline into VictoriaLogs |
+| Node autoscaling | **GKE NAP via `ComputeClass`** (ADR-0006), not Karpenter |
+| Abstraction rule | **Cloud-shaped platform APIs, neutral developer APIs** (ADR-0007). Platform-facing gets sibling per-cloud APIs; developer-facing gets a neutral surface with provider knobs quarantined in optional `aws {}` / `gcp {}` blocks |
+| Workload identity | Sibling XRDs — `EPI` untouched, new `GCPWorkloadIdentity`. Avoids delete-and-create against live IAM roles, and `spec.policyDocument` (IAM JSON) has no honest neutral form |
+| Object storage API | `spec.s3Bucket` → `spec.objectStore` with a per-cloud escape hatch. Developer-facing, so portability is worth the breaking change |
+| Repo topology | Monorepo, cloud-partitioned, **plus** extraction of Crossplane XRDs/KCL modules to a dedicated OCI-released repo |
+| Cost posture | Match the AWS intent, which is aggressive (see below) |
+
+### Cost posture
+
+The AWS side is more cost-optimised than it first appears, and GCP must match the *intent*, not just
+work. `opentofu/eks/init/main.tf` runs even the **bootstrap** node group on `capacity_type = "SPOT"`
+(min 2 / max 3) across 6 diversified instance types, pinned to one subnet with the comment *"Use a
+single subnet for costs reasons"*. All three Karpenter pools are spot-first, `default` is
+spot-**only**, and each carries a hard ceiling (`cpu 60/mem 192Gi`, `cpu 20/mem 64Gi`,
+`nvidia.com/gpu: 4`).
+
+Four mechanisms, and their GCP fate:
+
+| AWS mechanism | GCP equivalent |
+|---|---|
+| Spot-first / spot-only capacity | `priorities[].spot` ✅ |
+| Instance-size bounding (blast radius + cost) | `priorities[].machineFamily`/`machineType` ✅ |
+| Hard **per-pool** resource ceiling | ⚠️ cluster-scoped `resourceLimits` only — three ceilings collapse into one, losing per-profile isolation |
+| Consolidation (`WhenEmptyOrUnderutilized`) | ❌ **no equivalent** — document, do not emulate |
+
+Two GCP-only levers with no AWS analogue, both **create-time** and awkward to retrofit:
+
+- **Disable workload Cloud Logging/Monitoring.** VictoriaLogs and VictoriaMetrics already do this
+  job; the GKE defaults bill for a duplicate pipeline nobody reads.
+- **Private Google Access** on the node subnet, so Cloud NAT does not bill for Google API traffic.
+
+One free win: private services use `loadBalancerClass: tailscale`, which creates a Tailscale device
+rather than a GCP forwarding rule — no cloud load-balancer charges for the private gateways.
+
+One AWS technique does **not** port: a GKE node pool takes a single machine type, so the 6-way
+instance diversification that blunts spot interruption is unavailable. Spot risk concentrates on one
+shape, which argues for keeping the static pool small and letting `ComputeClass` supply breadth.
+
+---
+
+## Scope split
+
+Value-first: a **working GCP cluster** before enabling refactors. The directory refactor and
+compositions extraction are deliberately not first — the first slice is purely additive (it moves no
+existing AWS file), so those refactors are unblocked either way and are cheaper once the GCP shape is
+known rather than predicted.
+
+### In scope for the first plan
+
+| # | Slice | Why first |
+|---|---|---|
+| 1 | GCP network — VPC, subnets + secondary ranges, Cloud DNS, Tailscale subnet router on GCE | Nothing is reachable without it; private control plane needs the tailnet |
+| 2 | GKE Standard cluster + **static** tainted node pool + `--workload-pool` | Mirrors AWS: `eks/init` creates managed node groups before Karpenter arrives |
+| 3 | Cilium (`ipam.mode=kubernetes`) + Flux bootstrap | Settles unknown #1 and #2 |
+| 4 | Node autoscaling — three `ComputeClass` objects | Settles the taint-propagation risk; gates GPU/LLM work |
+| 5 | `GCPWorkloadIdentity` XRD + Crossplane GCP provider plumbing | Gates every remaining workstream |
+
+### Deferred (later plans)
+
+| # | Workstream | Depends on |
+|---|---|---|
+| 6 | Directory refactor to cloud-partitioned layout | 3 |
+| 7 | Extract `ogenki-compositions` repo, OCI-released | 6 |
+| 8 | `objectStore` API migration + `App`/`SQLInstance` branching | 5, 7 |
+| 9 | Object-storage call sites: Harbor (GCS driver), `openbao-snapshot` (GCS + Cloud KMS), CNPG barman (GCS) | 5, 8 |
+| 10 | DNS + PKI: `external-dns` google provider, cert-manager clouddns DNS-01 | 5 |
+| 11 | OpenBao on GCP: MIG + internal LB + Cloud KMS auto-unseal | 1 |
+| 12 | Gateway/LB: GCP public-LB annotations, drop `aws-load-balancer-controller` | 3 |
+| 13 | Storage: `gp3` → `pd-balanced`/hyperdisk, EFS CSI → Filestore CSI | 3 |
+| 14 | GPU + LLM platform: GPU `ComputeClass`, GCS Fuse weights, no `runtimeclass-nvidia` | 4, 9 |
+| 15 | CI: `validate-manifests.sh` renders both clouds; Renovate; per-cloud schema catalogs | 6 |
+
+### Already cloud-agnostic (verified — do not touch)
+
+OpenBao itself (`openbao/management` uses only the `bao` provider), External Secrets, Envoy Gateway,
+Envoy AI Gateway, VictoriaMetrics/Logs/Traces, Grafana Operator, KEDA, Zitadel, Harbor-the-app,
+CloudNativePG-the-operator, Atlas Operator, Tailscale operator, Headlamp, Homepage, Dagger engine,
+GHA runners, vLLM/`InferenceService`, and Cilium itself modulo the values divergence below.
+
+---
+
+## Architecture
+
+### OpenTofu layout (additive — no existing file moves)
+
+```
+opentofu/gcp/
+├── network/     VPC, node subnet, pod+service secondary ranges, Cloud DNS private zone,
+│                Tailscale subnet router, Cloud NAT + Private Google Access
+└── gke/
+    ├── init/      GKE Standard (DPv2 not enabled), static tainted pool, --workload-pool,
+    │              Crossplane WIF binding, Gateway API CRDs, helm_values/cilium.yaml
+    └── configure/ Cilium then Flux Operator + Flux Instance
+
+clusters/gcp-mycluster-0/   new sibling of clusters/mycluster-0/
+```
+
+Two-stage deploy mirrors EKS, for the same reason: the Helm provider needs a cluster endpoint at
+plan time. `cd opentofu/gcp/gke/init && terramate script run deploy` runs both stages.
+
+### Cilium values divergence
+
+`cilium_version` stays a **shared** global in `opentofu/config.tm.hcl` so both clouds upgrade
+together. The values **file is forked**, not templated: with two clouds and ~8 divergent keys,
+duplicating ~130 lines is cheaper than a merge mechanism that hides what Cilium actually receives —
+and "we don't understand what Cilium is doing on an unsupported path" is precisely the risk being
+managed. Revisit at cloud three.
+
+| Key | AWS | GCP |
+|---|---|---|
+| `ipam.mode` | `eni` | `kubernetes` (host-scope from `spec.podCIDR`; GKE alias IP ranges route natively) |
+| `eni:` block, `cilium-cni-config.tf` | prefix-delegation ConfigMap | **deleted — no counterpart** |
+| `routingMode` | `native` | `native` |
+| `encryption.type` | `wireguard` (cilium#43493) | **expected unnecessary** — verify before removing the CLAUDE.md note |
+| `kubeProxyReplacement`, `gatewayAPI`, `hubble` | — | port unchanged |
+
+### Node autoscaling
+
+Three `ComputeClass` objects replace six Karpenter manifests (`{default,io,gpu-l4}` ×
+`NodePool`+`EC2NodeClass`). Each sets `nodePoolConfig.taints[]` carrying
+`node.cilium.io/agent-not-ready=true:NoSchedule` and pins `imageType`. `priorities[]` is ordered
+spot-first, with `default` spot-**only** to match AWS. A small static pool is retained because
+`ComputeClass` cannot express `min > 0`.
+
+`infrastructure/base/runtimeclass-nvidia/` is **not ported** — it is Bottlerocket-specific (that AMI
+pre-configures an `nvidia` containerd handler and advertises `nvidia.com/gpu` natively). GKE installs
+drivers via its own managed installer and advertises the resource with no `RuntimeClass`.
+
+### GCPWorkloadIdentity
+
+```yaml
+apiVersion: cloud.ogenki.io/v1alpha1
+kind: GCPWorkloadIdentity
+metadata: { name: external-dns, namespace: infrastructure }
+spec:
+  serviceAccount: { name: external-dns, namespace: infrastructure }
+  roles: [roles/dns.admin]              # predefined roles, named as GCP names them
+  customRole:                            # optional — creates + binds a custom role
+    permissions: [dns.resourceRecordSets.create]
+```
+
+Renders one **`ProjectIAMMember`** per role, member = the `principal://` KSA string, plus a
+`ProjectIAMCustomRole` when `customRole.permissions` is set. No Google service account, no
+annotation. `xplane-*` prefix owned by the composition.
+
+**Two hard constraints, both silent-failure classes:**
+
+- **Additive IAM only.** `ProjectIAMPolicy` and `ProjectIAMBinding` are *authoritative* — they
+  overwrite the policy for the roles they manage. In a composition that renders once per workload,
+  either would delete other workloads' and humans' bindings. `external-dns` and `cert-manager` both
+  need Cloud DNS access, so this breaks immediately, and silently, until something unrelated loses
+  permissions.
+- **`PROJECT_NUMBER` and `PROJECT_ID` sit in different segments** of the principal string:
+  `projects/` takes the **number**, `workloadIdentityPools/` takes the **ID**. Reversed, the API
+  accepts the binding and it simply never matches — a permission error pointing nowhere. Must be
+  asserted as an exact string in `main_test.k`.
+
+**Chicken-and-egg:** Crossplane cannot create the binding that grants Crossplane access. The GKE
+`init` stage must bootstrap Crossplane's own WIF binding in OpenTofu, exactly as the AWS side
+bootstraps its Pod Identity. Slice 5 is blocked without it.
+
+---
+
+## Goal & success criteria
+
+Falsifiable, verified against a live cluster.
+
+**Slices 1–3 (cluster foundation)**
+
+1. `cilium status --wait` all OK; `cilium`/`cilium-envoy` pods `Running`, 0 restarts, ≥2 nodes.
+2. **Only Cilium's CNI config is active in `/etc/cni/net.d/`** — GKE's `netd` displaced. *If this
+   fails, stop and revisit ADR-0005 before any further GCP work.*
+3. With `encryption` unset, an `HTTPRoute` through a Cilium Gateway to a backend pod **on another
+   node** returns 200 across 100 consecutive requests, 0 failures (the cilium#43493 check).
+4. `flux get kustomizations -A` and `helmreleases -A` all `Ready=True`.
+5. `kubectl get nodes` works against the **private** endpoint from a tailnet device, no public
+   endpoint.
+6. No GCP CIDR (node/pod/service/control-plane) overlaps any AWS range advertised into the tailnet —
+   both clusters share one tailnet, so an overlap breaks subnet routing in a way that looks like a
+   Cilium bug.
+7. Second `terramate script run deploy` produces a 0-change plan.
+8. `hubble observe --verdict DROPPED --last 50` returns results.
+9. All static-pool nodes report `cloud.google.com/gke-spot=true`, in a single zone.
+10. Workload Cloud Logging **and** Monitoring disabled; Private Google Access enabled on the node
+    subnet.
+11. A written monthly run-rate estimate exists (cluster fee, static pool, Cloud NAT, Cloud DNS,
+    Tailscale instance) stating the zonal-vs-regional choice and its price delta.
+
+**Slice 4 (autoscaling)**
+
+12. A **freshly auto-created** node carries `node.cilium.io/agent-not-ready` at registration, and
+    Cilium clears it. *This is the criterion the slice exists to test.*
+13. Across 5 scale-up cycles, 0 pods record `FailedCreatePodSandBox` referencing a missing CNI.
+14. `imageType` on every auto-created pool matches the pinned value; general-purpose nodes are
+    spot with **zero** on-demand fallback.
+15. A GPU pod with **no** `runtimeClassName` sees the device via `nvidia-smi`.
+16. Cluster `resourceLimits` set; an oversized workload stays `Unschedulable` at the ceiling.
+17. Empty auto-created pools are removed on scale-down.
+
+**Slice 5 (identity)**
+
+18. A pod calls its granted Google API with **no** key mounted and no `iam.gke.io` annotation.
+19. `gcloud projects get-iam-policy` shows the member in exact `principal://.../ns/<NS>/sa/<KSA>`
+    form.
+20. `grep -rE 'ProjectIAMPolicy|ProjectIAMBinding'` finds no match in the composition; two claims
+    coexist; a manually-created binding survives a full reconcile.
+21. `external-dns` creates a Cloud DNS record and `cert-manager` completes a DNS-01 challenge using
+    only the binding.
+22. `git diff --stat` shows **zero** changes under `security/base/epis/` or to the `EPI`
+    XRD/composition/module.
+
+---
+
+## Non-goals
+
+- Migrating any AWS workload, or removing Karpenter from AWS.
+- Generalising `EPI` into a neutral `WorkloadIdentity` XRD (ADR-0007).
+- Any cloud-neutral façade over `NodePool`/`ComputeClass` — the two differ in *behaviour*, not
+  syntax, and a shared surface would hide exactly the divergence that needs documenting.
+- Replicating Karpenter consolidation. Documented as a gap; **not** emulated with a custom drain
+  controller, which would put a bespoke component in the scheduling path to imitate a managed
+  feature.
+- Cross-project or cross-organisation identity federation.
+- GCP Secret Manager for External Secrets — OpenBao-backed and already agnostic.
+- Rescoping CLAUDE.md's WireGuard note *as a requirement*. It is a task gated on criterion 3; a
+  documented invariant should not change on the strength of a docs read.
+
+---
+
+## Implementation outline (sketch — full plan from `superpowers:writing-plans`)
+
+1. **Gate first.** Throwaway GKE Standard cluster: prove criteria 2 and 3 before writing any
+   OpenTofu. If either fails, stop and reopen ADR-0005.
+2. CIDR plan against the AWS ranges already in the tailnet; resolve region/zone, DNS zone naming and
+   node image type.
+3. `opentofu/gcp/network/`, then `gke/init/` (including the Crossplane WIF binding), then
+   `gke/configure/`.
+4. `clusters/gcp-mycluster-0/` minimum viable Flux tree — excluding `aws-load-balancer-controller`,
+   `aws-efs-csi-driver`, Karpenter, `runtimeclass-nvidia`.
+5. **Gate again.** One `ComputeClass` proving criterion 12 before writing the other two; fallback is
+   static pools + cluster autoscaler (ADR-0006 option 3).
+6. `GCPWorkloadIdentity` — confirm the API group from installed CRDs *first*, then XRD, KCL module
+   (TDD, principal string asserted), then convert `external-dns` and `cert-manager` as proof.
+
+---
+
+## Risks & open questions
+
+**Risks**
+
+| Risk | Mitigation |
+|---|---|
+| `cni.exclusive` does not displace GKE's `netd` | Gate task on a throwaway cluster before any OpenTofu is written. Fallback: Dataplane V2, which costs a second Gateway implementation |
+| DPv2 is create-time only | The gate cluster is disposable; the real cluster is created once the datapath choice is proven |
+| Taint not propagated to auto-created nodes | Prove on one `ComputeClass` before writing three. Fallback: static pools + cluster autoscaler |
+| Authoritative IAM kinds used by mistake | Forbidden in the design; enforced by a grep plus positive coexistence tests |
+| Reversed `PROJECT_NUMBER`/`PROJECT_ID` | Exact-string assertion in `main_test.k` |
+| Spot preemption concentrated on one machine type | Keep the static pool small; breadth from `ComputeClass`, not on-demand fallback |
+| Crossplane informer stalls after CRD activation | Known trap — `kubectl auth can-i` first, then restart the controller |
+
+**Open questions**
+
+- GCP region and zone topology; zonal vs regional control plane (material cost difference).
+- Private DNS zone naming — `priv.gcp.cloud.ogenki.io` sibling, or one zone shared across clouds?
+- Node image type: `cos_containerd` (GKE default) or `ubuntu_containerd` (more familiar kernel for
+  debugging an unsupported path)?
+- GCP machine families for the `default`/`io` equivalents; retained static pool size; cluster
+  `resourceLimits` values. Three of these need a measurement off the **AWS** cluster first — the
+  always-on controller footprint and what the `io` pool actually serves. No GCP access required.
+- **Exact namespaced API group for Crossplane GCP v2.** AWS uses `iam.aws.m.upbound.io/v1beta1`;
+  GCP is *expected* to be `cloudplatform.gcp.m.upbound.io/v1beta1`, but `provider-gcp-cloudplatform`
+  v2.6.0 reference pages still document the cluster-scoped `cloudplatform.gcp.upbound.io`. Must be
+  confirmed against installed CRDs, never inferred.
+- One Crossplane control plane per cluster, or one managing both clouds?
+- Where do Flux's GitHub App credentials come from on GCP? They live in AWS Secrets Manager today;
+  reading them from GCP would create a hard AWS dependency in the GCP bootstrap. Likely a GCP Secret
+  Manager copy first, OpenBao once workstream 11 lands.
+- Does the `ogenki-compositions` split absorb the App Wizard split already designed elsewhere?
+
+**External prerequisite:** a GCP project with billing and APIs enabled, plus a Tailscale auth path
+for a second cloud. Nothing past the gate task can be verified without it.
+
+---
+
+## Quality gates the PR must pass before merge
+
+- `tofu validate` and `tofu fmt -check -recursive opentofu/gcp/`
+- `trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml .`
+- `./scripts/validate-manifests.sh` → exit 0 with **`Invalid: 0, Skipped: 0`** (a skipped resource is
+  an unvalidated one)
+- `./scripts/validate-kcl-compositions.sh` → exit 0, and `kcl test` (needs `-Y settings-example.yaml`)
+- `crossplane render` succeeds for the basic and complete `GCPWorkloadIdentity` examples
+- `pre-commit run --all-files`
+- Live-cluster evidence cited for every success criterion above, per
+  [`.claude/rules/process.md`](../../../.claude/rules/process.md)

--- a/docs/superpowers/specs/2026-08-18-superpowers-sdd-migration-design.md
+++ b/docs/superpowers/specs/2026-08-18-superpowers-sdd-migration-design.md
@@ -129,10 +129,10 @@ Three classes, all mechanical:
 2. **Constitution links inside archived docs** (~40 occurrences) — two forms exist today:
    `](../constitution.md)` in the directories being moved, and `](../../../constitution.md)` in
    the two already-archived ones. Both are rewritten to
-   `[docs/platform-constitution.md](../../../../platform-constitution.md)`, matching the uniform
+   ``[docs/platform-constitution.md](../../../../platform-constitution.md)``, matching the uniform
    post-move depth `docs/specs/done/<quarter>/<slug>/`.
 
-3. **PHASED.md links inside archived docs** (~10 `- Phased specs: [...](../PHASED.md)` lines) —
+3. **PHASED.md links inside archived docs** (~10 `- Phased specs: ...(../PHASED.md)` lines) —
    deleted, since the target is deleted.
 
 The `runbook_url` in `vmrule-llm-slo.yaml` is a live alert annotation pointing at a

--- a/infrastructure/base/crossplane/configuration/kcl/README.md
+++ b/infrastructure/base/crossplane/configuration/kcl/README.md
@@ -82,7 +82,7 @@ The CI/CD pipeline automatically:
 
 ## CI/CD Pipeline
 
-The workflow is defined in [`.github/workflows/crossplane-modules.yml`](../../../../../../.github/workflows/crossplane-modules.yml).
+The workflow is defined in [`.github/workflows/crossplane-modules.yml`](../../../../../.github/workflows/crossplane-modules.yml).
 
 ### Triggers
 

--- a/opentofu/openbao/management/docs/cert-manager.md
+++ b/opentofu/openbao/management/docs/cert-manager.md
@@ -8,7 +8,7 @@ Before integrating `cert-manager` with OpenBao, ensure these prerequisites are m
 
 - **OpenBao Setup**: A OpenBao instance with permissions to manage [approles](https://developer.hashicorp.com/vault/docs/auth/approle). Use our guide for [building a OpenBao cluster](../../cluster/README.md).
 - **TLS Configuration**: Ensure a proper TLS setup, including the CA chain. If you've followed the [PKI requirements procedure](../../cluster/docs/pki_requirements.md), you should have `.tls/ca-chain.pem` locally.
-- **Kubernetes Cluster**: A Kubernetes cluster capable of reaching the OpenBao. You can set one up using our [EKS cluster guide](../../../eks/README.md).
+- **Kubernetes Cluster**: A Kubernetes cluster capable of reaching the OpenBao. You can set one up using our [EKS cluster guide](../../../eks/init/README.md).
 
 Once these requirements are met, you're ready to proceed with the `cert-manager` integration.
 
@@ -50,7 +50,7 @@ In the context of cert-manager, a `ClusterIssuer` is a Kubernetes resource used 
 
 As stated in the requirements, OpenBao should be reachable from the Kubernetes cluster but also from the CLI in order to run the following commands that make use of the `bao` CLI.
 
-⚠️ During this procedure we'll use the `root` token but this is strongly recommended to configure an Identity provider as soon as the cluster is up and running. More about that [here](root_token.md).
+⚠️ During this procedure we'll use the `root` token but this is strongly recommended to configure an Identity provider as soon as the cluster is up and running. More about that here.
 
 1. Check that you can effectively access to OpenBao.
 

--- a/scripts/validate-links.sh
+++ b/scripts/validate-links.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# validate-links.sh — resolve every relative Markdown link in the repo.
+#
+# A string match on a path (`git grep 'docs/specs/'`) cannot catch link rot from a
+# directory move: relative targets like `../../decisions/` change meaning when the
+# file holding them moves, and the string never appears in the file at all. This
+# resolves link *targets* instead.
+#
+# Usage:
+#   ./scripts/validate-links.sh            # fail on any broken link not in the allowlist
+#   ./scripts/validate-links.sh --list     # print every broken link, exit 0 (for refreshing the allowlist)
+#
+# Allowlist: .linkcheck-allow — one `<file><TAB><target>` per line, `#` comments allowed.
+# It exists so pre-existing breakage does not block unrelated work; entries should be
+# deleted as they are fixed, never added to route around a new break.
+#
+# Skipped by design: absolute URLs, anchors, absolute paths, template placeholders, and
+# anything inside a fenced code block or an inline code span (documentation samples are
+# not navigation).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:-check}"
+ALLOW=".linkcheck-allow"
+
+mapfile -t BROKEN < <(python3 - <<'PY'
+import os, re, subprocess
+
+files = subprocess.run(['git', 'ls-files', '*.md'],
+                       capture_output=True, text=True).stdout.split()
+link = re.compile(r'\[[^\]]*\]\(([^)#\s]+)(?:#[^)\s]*)?\)')
+fence = re.compile(r'^\s*(```|~~~)')
+# inline code spans hold illustrative links, not navigation — strip before matching
+code_span = re.compile(r'(`+)(?:(?!\1).)*\1')
+
+for f in files:
+    d = os.path.dirname(f)
+    try:
+        lines = open(f, encoding='utf-8', errors='replace').read().split('\n')
+    except OSError:
+        continue
+    in_fence = False
+    for line in lines:
+        if fence.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for m in link.finditer(code_span.sub('', line)):
+            t = m.group(1)
+            if t.startswith(('http://', 'https://', 'mailto:', 'tel:', '<', '/')):
+                continue
+            # template placeholders, not real paths
+            if any(c in t for c in '<>*\\') or 'NNN' in t or 'YYYY' in t:
+                continue
+            if not os.path.exists(os.path.normpath(os.path.join(d, t))):
+                print(f"{f}\t{t}")
+PY
+)
+
+if [ "$MODE" = "--list" ]; then
+    printf '%s\n' "${BROKEN[@]}"
+    exit 0
+fi
+
+allowed() {
+    [ -f "$ALLOW" ] || return 1
+    grep -qxF "$1" <(grep -v '^\s*#' "$ALLOW" | grep -v '^\s*$')
+}
+
+fail=0
+for entry in "${BROKEN[@]}"; do
+    [ -n "$entry" ] || continue
+    if ! allowed "$entry"; then
+        printf 'BROKEN  %s\n' "$entry"
+        fail=1
+    fi
+done
+
+total=${#BROKEN[@]}
+[ "$total" -eq 1 ] && [ -z "${BROKEN[0]}" ] && total=0
+if [ "$fail" -eq 0 ]; then
+    echo "==> All relative Markdown links resolve (${total} allowlisted)."
+else
+    echo
+    echo "Broken relative links found. Fix the target, or — only for pre-existing"
+    echo "breakage unrelated to your change — add the line to ${ALLOW}."
+    exit 1
+fi


### PR DESCRIPTION
## 📝 Summary

Follow-up to #1764. That PR archived `docs/specs/NNN-slug/` into `docs/specs/done/<quarter>/NNN-slug/` and verified the result with `git grep 'docs/specs/'`. The grep reported clean — and **22 links were broken anyway**, because moving a file two levels deeper silently changes what every `../`-relative link inside it points at, and the moved path never appears in the link text.

This adds a gate that resolves link *targets*, and fixes everything it found.

## 🎯 Changes

**`scripts/validate-links.sh`** — walks `git ls-files '*.md'` and `os.path.exists` every `](target)` relative to the file holding it. Skips absolute URLs, anchors, absolute paths, template placeholders (`NNN`, `YYYY`), fenced code blocks and inline code spans; documentation samples are not navigation, and treating them as such produced 39 false positives on the first pass.

**`ci.yaml` → `links` job**, next to `shellcheck`.

**`.linkcheck-allow`** — known-broken links that do not block unrelated work. Currently five entries: the App Wizard screenshot placeholders, which need capturing from the running wizard (`docs/assets/app-wizard/README.md` already specifies each one).

**30 broken links fixed:**

| Count | What | Cause |
|---|---|---|
| 24 | `../../decisions/` and `../../../.claude/rules/process.md` across every archived 2026-Q3 spec | 22 from the #1764 archive move; 2 pre-dated it in `012-kvstore`, which was archived at the wrong depth originally |
| 2 | `docs/ingress.md` → OpenBao PKI docs | wrong subdirectory — `getting_started.md` lives under `cluster/docs/`, not `management/docs/` |
| 1 | `kcl/README.md` → `crossplane-modules.yml` | one `../` too many |
| 1 | `openbao/.../cert-manager.md` → EKS README | moved under `eks/init/` |
| 2 | ADR-0003 → `docs/plans/self-hosted-ai/`, `cert-manager.md` → `root_token.md` | de-linked; neither target exists in any commit |

## ✅ Validation

| Gate | Result |
|---|---|
| `./scripts/validate-links.sh` | exit 0 — `All relative Markdown links resolve (5 allowlisted)` |
| Negative test | appending one bad link → `BROKEN`, exit 1 |
| `shellcheck -x -S warning scripts/validate-links.sh` | clean |
| `./scripts/validate-manifests.sh` | exit 0 — `Valid: 1193, Invalid: 0, Skipped: 0` |

## 📌 Note on #1764

Its PR body claims "0 newly broken links". That was wrong. The verification deduped pre-existing breakage by `(basename, target)`, and `012-kvstore/clarifications.md → ../../decisions/` was already broken on `main` — so that one pair masked the identical pair in eleven sibling directories. The repair loop and the check shared the filter, so it confirmed itself. Corrected here.