### PR TITLE
Drop the ADR-0002 link allowlist entry now that #1763 has merged

### DIFF
--- a/.linkcheck-allow
+++ b/.linkcheck-allow
@@ -9,9 +9,3 @@ docs/app-wizard.md	assets/app-wizard/02-advanced.png
 docs/app-wizard.md	assets/app-wizard/03-validation.png
 docs/app-wizard.md	assets/app-wizard/04-render-preview.png
 docs/app-wizard.md	assets/app-wizard/05-pull-request.png
-#
-# ADR-0002's Related Spec link predates the 2026-08 spec archive and points at a
-# `specs/completed/` path that never existed. PR #1763 repoints it at
-# ../specs/done/2024-Q1/0000-eks-pod-identity/spec.md as part of the GCP ADR work —
-# delete this entry when that merges.
-docs/decisions/0002-eks-pod-identity-over-irsa.md	../specs/completed/0000-


### PR DESCRIPTION
#1766 allowlisted ADR-0002's `../specs/completed/0000-` link — a path that exists in no commit — so that #1763 could fix it without a conflict on that line. #1763 has merged and repointed it at `../specs/done/2024-Q1/0000-eks-pod-identity/spec.md`, so the entry now excuses nothing.

`./scripts/validate-links.sh` reports `All relative Markdown links resolve (5 allowlisted)` both with and without the entry, which is the proof it is stale rather than load-bearing.

`.linkcheck-allow` is back to just the five App Wizard screenshot placeholders — the only genuinely outstanding breakage, tracked in `docs/assets/app-wizard/README.md`.