### PR TITLE
Require a git worktree for every file-changing task

### DIFF
--- a/.claude/rules/superpowers.md
+++ b/.claude/rules/superpowers.md
@@ -32,12 +32,27 @@ ahead of it. The PR body links the design.
 | Before claiming done | `process.md` in this directory — the evidence table. A fresh command run per claim, output cited inline |
 | After merge | `/verify-spec` for anything with cluster-observable criteria |
 
-## Isolation
+## Isolation — always work in a worktree
 
-Work that touches the running cluster belongs in a worktree
-(`superpowers:using-git-worktrees`); worktrees live in `.claude/worktrees/`, which is gitignored.
-When deploying a feature branch to the cluster, pass
-`TF_VAR_flux_git_ref=refs/heads/<branch>` to the Terramate deploy script.
+**Every task that changes files runs in a git worktree.** Not just cluster-touching work. Use the
+native `EnterWorktree` tool (this instruction is what authorises it), never `git worktree add` —
+manual worktrees create state the harness cannot see or clean up.
+
+Worktrees land in `.claude/worktrees/`, which is gitignored. The default `worktree.baseRef` is
+`fresh`, so a new worktree branches from `origin/main` rather than local `HEAD`.
+
+That last property is the point. On 2026-08-18 a branch was cut with `git checkout -b` while a
+concurrent session had this shared checkout on *its* feature branch; `HEAD` was not `main`, so the
+new branch silently inherited five unrelated commits and two of them were merged under the wrong
+PR (see #1765 / #1766). Branching from `origin/main` makes that failure impossible, and a worktree
+means two sessions never share a working directory in the first place.
+
+`ExitWorktree` with `keep` to come back to the work later, `remove` when it is done or abandoned.
+Long-lived worktrees the user manages by hand live outside the repo in
+`~/Sources/cnref-worktrees/` — leave those alone.
+
+When deploying a feature branch to the cluster, pass `TF_VAR_flux_git_ref=refs/heads/<branch>`
+to the Terramate deploy script.
 
 ## Historical note
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,11 @@ superpowers:brainstorming        -> docs/superpowers/specs/YYYY-MM-DD-<topic>-de
         /commit -> /create-pr
 ```
 
+> **Always work in a git worktree.** Use the `EnterWorktree` tool at the start of any task that
+> changes files — worktrees land in the gitignored `.claude/worktrees/` and branch from
+> `origin/main`, so concurrent sessions never share a working directory or inherit each other's
+> `HEAD`. Details in [`.claude/rules/superpowers.md`](.claude/rules/superpowers.md).
+
 **Key documents**:
 - [Platform Constitution](docs/platform-constitution.md) — non-negotiable principles (auto-loaded via `.claude/rules/platform-constitution.md`)
 - [Architecture Decision Records](docs/decisions/) — cross-cutting technology choices


### PR DESCRIPTION
Records the working agreement set on 2026-08-18: all work happens in a git worktree, not just cluster-touching changes.

## Why

`/home/smana/Sources/cloud-native-ref` is a shared checkout — a second interactive session works in it concurrently. Earlier today `git checkout -b` was run there while the peer session had `HEAD` on its own feature branch. The new branch silently inherited five unrelated commits, two of which were merged into `main` under an unrelated PR and had to be reverted (#1765, then #1766).

A worktree makes that failure impossible on two counts: sessions no longer share a working directory, and the default `worktree.baseRef: fresh` branches from `origin/main` rather than local `HEAD`.

## Changes

- `CLAUDE.md` — a short directive above *Key documents*, which is what authorises the `EnterWorktree` tool (it only fires on an explicit user or project instruction).
- `.claude/rules/superpowers.md` — the *Isolation* section widened from cluster-touching work to all work, with the incident recorded as the rationale, plus the rule to use the native tool rather than `git worktree add` (manual worktrees leave state the harness cannot see — four stale registrations from past sessions were pruned today).

## Validation

This PR was itself produced from a worktree at `.claude/worktrees/docs-worktree-policy`, branched from `e1a8bf80` = `origin/main`, verified via `git rev-parse --git-dir` resolving to `.git/worktrees/docs-worktree-policy`.

`./scripts/validate-links.sh` → exit 0, `All relative Markdown links resolve (5 allowlisted)`.