### PR TITLE
Close the endpointpicker validation gap and prepare the XRD schema seam

### DIFF
--- a/docs/superpowers/specs/2026-08-18-gcp-support-design.md
+++ b/docs/superpowers/specs/2026-08-18-gcp-support-design.md
@@ -109,10 +109,33 @@ known rather than predicted.
 
 ### Deferred (later plans)
 
+> **Amendment (2026-08-19) — workstreams 6 and 7 are swapped.**
+>
+> This table originally had **7 depend on 6**: extract the compositions *after* the directory
+> refactor. The Crossplane Configuration Extraction design reverses it, and that reversal stands.
+> (That design lives on branch `feat/crossplane-configuration-extraction` as
+> `docs/superpowers/specs/2026-08-18-crossplane-configuration-extraction-design.md` — not yet
+> merged, so it is named rather than linked here.) Two reasons, both load-bearing:
+>
+> 1. The refactor's job is to partition the repo by cloud. Doing it first means partitioning ~40
+>    files that are about to leave the repository entirely.
+> 2. The extraction is what *forces* the AWS coupling to become explicit — it measured the seam and
+>    found three of five APIs are mixed (`App`, `SQLInstance` cloud-neutral contracts with AWS
+>    slices; `EPI` wholly AWS). That measurement is the input the refactor needs, so producing it
+>    first makes the refactor cheaper and better-informed rather than the other way round.
+>
+> The repository is named **`crossplane-configuration`**, not `ogenki-compositions` as written
+> below — see that design's *Naming* section for the namespace research behind the choice. It ships
+> two packages, `-core` and `-aws`, with XRDs in `-core` and cloud-coupled Compositions in `-aws`.
+>
+> Workstream 15 (`per-cloud schema catalogs`) is also affected: once the XRDs leave, the catalog
+> sources them from a release asset rather than a local glob. That seam exists in
+> `gen-catalog.sh` today via `XRD_CRDS_FILE`, verified to produce byte-identical schemas.
+
 | # | Workstream | Depends on |
 |---|---|---|
-| 6 | Directory refactor to cloud-partitioned layout | 3 |
-| 7 | Extract `ogenki-compositions` repo, OCI-released | 6 |
+| 6 | Directory refactor to cloud-partitioned layout | 3, **7** |
+| 7 | Extract the Crossplane Configuration packages, OCI-released | 3 |
 | 8 | `objectStore` API migration + `App`/`SQLInstance` branching | 5, 7 |
 | 9 | Object-storage call sites: Harbor (GCS driver), `openbao-snapshot` (GCS + Cloud KMS), CNPG barman (GCS) | 5, 8 |
 | 10 | DNS + PKI: `external-dns` google provider, cert-manager clouddns DNS-01 | 5 |

--- a/scripts/flux-schema/gen-catalog.sh
+++ b/scripts/flux-schema/gen-catalog.sh
@@ -101,10 +101,44 @@ trap 'rm -rf "${tmp}"' EXIT
 build_dir="${tmp}/schemas"
 mkdir -p "${build_dir}"
 
-echo "==> Converting Crossplane XRDs to CRDs"
-python3 scripts/flux-schema/xrd-to-crd.py \
-  infrastructure/base/crossplane/configuration/*-definition.yaml \
-  > "${tmp}/xrd-crds.yaml"
+# The cloud.ogenki.io schemas have exactly one requirement: a multi-doc YAML of
+# CustomResourceDefinitions for `flux schema extract crd` to read. Today that is
+# produced locally from the XRDs in this repo. Once the XRDs move to
+# github.com/Smana/crossplane-configuration, the same file arrives as a release
+# asset pinned to the installed Configuration version, and only XRD_CRDS_FILE
+# changes — the extract step below is already file-based and does not care.
+#
+# Verified equivalent (2026-08-19): `flux schema extract crd` over a standalone
+# xrd-crds.yaml produced schemas byte-identical to the local-glob path for all 5
+# APIs (`diff -r` clean), so the cutover cannot silently alter validation.
+#
+# Keep this a single seam. If the fetch ever grows conditional logic, the catalog
+# can drift from the Configuration package that is actually installed — the exact
+# failure the AI Gateway / Karpenter pins above are written to prevent.
+if [[ -n "${XRD_CRDS_FILE:-}" ]]; then
+  echo "==> Using pre-built Crossplane XRD CRDs from ${XRD_CRDS_FILE}"
+  if [[ ! -s "${XRD_CRDS_FILE}" ]]; then
+    echo "error: XRD_CRDS_FILE is set but '${XRD_CRDS_FILE}' is missing or empty" >&2
+    exit 1
+  fi
+  cp "${XRD_CRDS_FILE}" "${tmp}/xrd-crds.yaml"
+else
+  echo "==> Converting Crossplane XRDs to CRDs"
+  python3 scripts/flux-schema/xrd-to-crd.py \
+    infrastructure/base/crossplane/configuration/*-definition.yaml \
+    > "${tmp}/xrd-crds.yaml"
+fi
+
+# Guard the count either way: `flux schema extract crd` exits 0 on an input with
+# no CRDs (see the header note), so an empty or truncated artifact would drop the
+# whole cloud.ogenki.io group while the build still reported success — and every
+# claim in the repo would then fail against `skipMissingSchemas: false`.
+xrd_crd_count="$(grep -c '^kind: CustomResourceDefinition' "${tmp}/xrd-crds.yaml" || true)"
+if [[ "${xrd_crd_count}" -lt 1 ]]; then
+  echo "error: no CustomResourceDefinitions in ${tmp}/xrd-crds.yaml (got ${xrd_crd_count})" >&2
+  exit 1
+fi
+echo "    ${xrd_crd_count} cloud.ogenki.io CRD(s)"
 
 echo "==> Rendering Envoy AI Gateway CRDs (chart ${AI_GATEWAY_VERSION})"
 # --include-crds: Helm skips a chart's crds/ directory by default. Without

--- a/scripts/validate-kcl-compositions.sh
+++ b/scripts/validate-kcl-compositions.sh
@@ -56,7 +56,7 @@ declare -a COMPOSITIONS=(
     "app:app-composition.yaml:app-basic.yaml,app-complete.yaml,app-worker.yaml,app-cron.yaml"
     "cloudnativepg:sql-instance-composition.yaml:sqlinstance-basic.yaml,sqlinstance-complete.yaml"
     "eks-pod-identity:epi-composition.yaml:epi.yaml"
-    "inference-service:inference-service-composition.yaml:inferenceservice-basic.yaml,inferenceservice-complete.yaml"
+    "inference-service:inference-service-composition.yaml:inferenceservice-basic.yaml,inferenceservice-complete.yaml,inferenceservice-endpointpicker.yaml"
     "kvstore:kvstore-composition.yaml:kvstore-basic.yaml,kvstore-complete.yaml"
 )
 
@@ -213,8 +213,36 @@ validate_composition() {
     return $errors
 }
 
+# Coverage guard: every example claim on disk must be listed above.
+#
+# `inferenceservice-endpointpicker.yaml` sat in examples/ for months while absent from
+# COMPOSITIONS, so 11 of 12 examples were rendered and the run still reported SUCCESS. An
+# untested example is not a partial pass, it is an unvalidated API surface — the same failure
+# shape SPEC-007 removed from manifest validation. Fail loudly instead.
+#
+# environmentconfig.yaml is excluded: it is an --extra-resources input, not a claim.
+listed_examples=$(printf '%s\n' "${COMPOSITIONS[@]}" | cut -d: -f3 | tr ',' '\n' | sort -u)
+disk_examples=$(find "$CONFIG_BASE/examples" -maxdepth 1 -name '*.yaml' -printf '%f\n' \
+    | grep -v '^environmentconfig\.yaml$' | sort -u)
+uncovered=$(comm -13 <(echo "$listed_examples") <(echo "$disk_examples"))
+
+if [[ -n "$uncovered" ]]; then
+    echo -e "${RED}❌ Example(s) present in $CONFIG_BASE/examples/ but not listed in COMPOSITIONS:${NC}"
+    echo "$uncovered" | sed 's/^/     /'
+    echo ""
+    echo "   Add each to the matching COMPOSITIONS entry, or delete the example."
+    exit 1
+fi
+
+missing=$(comm -23 <(echo "$listed_examples") <(echo "$disk_examples"))
+if [[ -n "$missing" ]]; then
+    echo -e "${RED}❌ Example(s) listed in COMPOSITIONS but missing from disk:${NC}"
+    echo "$missing" | sed 's/^/     /'
+    exit 1
+fi
+
 # Main validation loop
-echo "Starting validation for ${#COMPOSITIONS[@]} compositions..."
+echo "Validating ${#COMPOSITIONS[@]} compositions across $(echo "$disk_examples" | wc -l) examples..."
 
 for composition_spec in "${COMPOSITIONS[@]}"; do
     IFS=':' read -r module composition examples <<< "$composition_spec"


### PR DESCRIPTION
Three items from the Crossplane Configuration extraction review.

## 1. `inferenceservice-endpointpicker.yaml` was never validated

The example has existed for months but was absent from the `COMPOSITIONS` array in `validate-kcl-compositions.sh`, so 11 of 12 examples rendered and the run still reported SUCCESS. It renders fine — it was simply never wired in.

Added it, and added a **coverage guard**: every `.yaml` in `configuration/examples/` must appear in `COMPOSITIONS` (minus `environmentconfig.yaml`, which is an `--extra-resources` input, not a claim), and vice versa. An untested example is not a partial pass, it is an unvalidated API surface — the same failure shape SPEC-007 removed from manifest validation.

Evidence: with the entry removed again, the guard prints the exact missing filename and exits 1. With it present, `./scripts/validate-kcl-compositions.sh` renders **12** examples (was 11) and exits 0.

## 2. XRD schema seam for the extraction blocker

The extraction design's blocker #1: `gen-catalog.sh` globs `configuration/*-definition.yaml`, and with `skipMissingSchemas: false` moving the XRDs makes ~37 `cloud.ogenki.io` claims *fail* rather than skip.

**Verified the proposed fix works** rather than assuming it: generated a standalone `xrd-crds.yaml` via `xrd-to-crd.py`, ran `flux schema extract crd` over it, and `diff -r` against `.schemas/cloud.ogenki.io/` — **byte-identical for all 5 APIs**. A release asset is therefore a drop-in source.

`gen-catalog.sh` now accepts `XRD_CRDS_FILE`. Unset (the default, and what CI does today) it globs the local XRDs exactly as before. Set, it uses the pre-built artifact. That is the whole seam Stage 2 needs — no fetch logic is added before the release it would fetch from exists.

Also added a count guard on both paths: `flux schema extract crd` exits 0 on an input containing no CRDs, so a truncated artifact would silently drop the entire `cloud.ogenki.io` group while the build reported success.

Tested: default path → `5 cloud.ogenki.io CRD(s)`; `XRD_CRDS_FILE` set → same 5 from the artifact; empty artifact → exits 1 with a named error.

## 3. GCP design: workstreams 6 and 7 were swapped

The merged GCP design has workstream 7 (extraction) depending on 6 (directory refactor). The extraction design reverses it. Since the extraction is proceeding, the merged document was the stale one — it now carries an amendment recording the swap, the reasoning, the corrected dependency column, and the actual repository name (`crossplane-configuration`, not `ogenki-compositions`).

## Validation

| Gate | Result |
|---|---|
| `./scripts/validate-kcl-compositions.sh` | exit 0, **12** examples rendered |
| `./scripts/validate-manifests.sh` | exit 0, `Valid: 1193, Invalid: 0, Skipped: 0` |
| `./scripts/validate-links.sh` | exit 0, 5 allowlisted |
| `shellcheck -x -S warning` on both scripts | clean |

The link gate caught one break I introduced myself — a link to the not-yet-merged extraction design — so it is named in text rather than linked, and not allowlisted.