### PR TITLE
chore(eks): use response_body instead of the deprecated http body attribute

### DIFF
--- a/opentofu/eks/configure/kubernetes.tf
+++ b/opentofu/eks/configure/kubernetes.tf
@@ -18,7 +18,7 @@
 # identical (same upstream URL) so there's no flap.
 resource "kubectl_manifest" "gateway_api_crds" {
   count             = length(local.gateway_api_crds_urls)
-  yaml_body         = data.http.gateway_api_crds[count.index].body
+  yaml_body         = data.http.gateway_api_crds[count.index].response_body
   server_side_apply = true
   force_conflicts   = true
   wait              = true


### PR DESCRIPTION
## What

The `hashicorp/http` provider deprecated the `body` attribute in favour of `response_body`. `opentofu/eks/configure/kubernetes.tf` still read `data.http.gateway_api_crds[count.index].body`.

```diff
-  yaml_body         = data.http.gateway_api_crds[count.index].body
+  yaml_body         = data.http.gateway_api_crds[count.index].response_body
```

## Why

Every `tofu plan` / `apply` on the `eks/configure` stack emitted a *"Value derived from a deprecated source"* warning for each of the 8 Gateway API CRDs. It is harmless, but it buries real diagnostics in the deploy output — it showed up alongside a genuine `helm_release.flux_operator` failure during a deploy today and added noise to the triage.

This was the only remaining reference in the repo (`grep -rn 'data\.http\..*\.body\b' --include=*.tf .` → none left).

## Verification

Run against the live `mycluster-0` state:

| Check | Result |
|---|---|
| `tofu fmt -check -diff` | clean |
| `tofu validate` | `Success! The configuration is valid.` |
| `tofu plan` (live state) | **`No changes. Your infrastructure matches the configuration.`** — deprecation warning gone |
| `trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml opentofu/eks/configure` | 0 misconfigurations, exit 0 |

The clean plan is the load-bearing check: both attributes return the identical string, so the 8 `kubectl_manifest.gateway_api_crds` resources are **not** replaced.