### PR TITLE
fix(eks): make a failed Flux helm install self-healing

### DIFF
--- a/opentofu/eks/configure/main.tf
+++ b/opentofu/eks/configure/main.tf
@@ -139,6 +139,18 @@ resource "helm_release" "flux_operator" {
 
   wait    = true
   timeout = 300
+
+  # Purge the release if the install fails, instead of leaving a `failed`
+  # revision behind. OpenTofu does not record a failed create in state, so the
+  # orphan makes every later apply fail with "cannot re-use a name that is still
+  # in use" — hit on 2026-08-19, when a transient 401 during the post-install
+  # wait wedged the deploy until the release was uninstalled by hand.
+  # `atomic` covers a failed install, `cleanup_on_fail` a failed upgrade (the
+  # version-bump path). `atomic` forces wait=true, which this release already
+  # sets — do NOT copy it to helm_release.cilium, which sets wait=false on
+  # purpose (see the comment there).
+  atomic          = true
+  cleanup_on_fail = true
 }
 
 # =============================================================================
@@ -180,4 +192,8 @@ resource "helm_release" "flux_instance" {
 
   wait    = true
   timeout = 300
+
+  # Same rationale as helm_release.flux_operator above.
+  atomic          = true
+  cleanup_on_fail = true
 }


### PR DESCRIPTION
## Problem

A transient 401 during `flux-operator`'s post-install wait on 2026-08-19 left the release in the cluster with status `failed`:

```
$ helm history flux-operator -n flux-system
REVISION  STATUS  CHART                 DESCRIPTION
1         failed  flux-operator-0.55.0  Release "flux-operator" failed: Unauthorized
```

OpenTofu does not record a failed *create* in state, so `helm_release.flux_operator` was absent from `tofu state list` while the release object was very much present in the cluster. Every subsequent apply then died on:

```
Error: installation failed
  with helm_release.flux_operator,
  on main.tf line 127:
cannot re-use a name that is still in use
```

The deploy stayed wedged until the orphan was uninstalled by hand. Note the install itself had actually succeeded — the Deployment was `1/1 Available` the whole time; only Helm's post-install wait failed.

## Change

| Attribute | Covers |
|---|---|
| `atomic = true` | a failed **install** — purges the release so the next apply starts clean |
| `cleanup_on_fail = true` | a failed **upgrade** — deletes the resources that upgrade created (the version-bump path) |

Both are needed: `cleanup_on_fail` alone is documented as *"Allow deletion of new resources created in this upgrade when upgrade fails"* and would not have prevented this wedge, because ours was an install.

Applied to `flux_operator` and `flux_instance` only. **Not** to `helm_release.cilium` — `atomic` implicitly forces `wait = true`, which would silently undo 4410b05e (*"helm_release.cilium wait=false — decouple apply from Cilium DaemonSet roll"*). Both Flux releases already set `wait = true`, so this adds no new blocking behaviour.

## Verification

Against live `mycluster-0` state:

| Check | Result |
|---|---|
| `tofu fmt -check -diff` | clean |
| `tofu validate` | `Success! The configuration is valid.` |
| `tofu plan` | `0 to add, 2 to change, 0 to destroy` — in-place, no replacement |
| `trivy config --exit-code=1 --ignorefile=./.trivyignore.yaml opentofu/eks/configure` | 0 misconfigurations |

## Heads-up before merging

`tofu plan` also shows `~ version = "0.58.1+b93eb18c9dfb" -> "0.55.0"` on `flux_operator`. That is **pre-existing drift, not introduced here**: Flux adopts this same Helm release after bootstrap (`flux/operator/helmrelease.yaml` + an OCIRepository pinned to `semver: ">=0.43.0 <1.0.0"`) and has floated it to 0.58.1 at revision 11. Applying this PR therefore briefly downgrades the operator and strips the Flux-managed values (web UI, Zitadel OIDC) until the next Flux reconcile (≤10m).

It would fire on the next `terramate script run deploy` either way. Tracked separately — `lifecycle.ignore_changes` is **not** a workable fix (it makes the plan fail outright on the `+buildmeta` version string).
