### PR TITLE
docs: mirror the KCL authoring guidance for the docs site

### DIFF
--- a/.claude/rules/crossplane-validation.md
+++ b/.claude/rules/crossplane-validation.md
@@ -10,7 +10,7 @@ globs:
 [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration) and ship as a
 Configuration package; this repo pins a version in
 `infrastructure/base/crossplane/configuration/configuration-packages.yaml`. Change a composition
-there, run `make check` there, cut a release, then bump the pin here.
+there, run `task check` there, cut a release, then bump the pin here.
 
 Two things in this repo still gate on that pin:
 

--- a/.claude/rules/platform-constitution.md
+++ b/.claude/rules/platform-constitution.md
@@ -15,7 +15,7 @@ All Crossplane-managed resources use the **`xplane-*`** prefix (e.g., `xplane-ha
 - **Never mutate a dict after creation** — causes duplicate resources (function-kcl issue #285). Use inline conditionals: `obj = { spec.X = ... if cond else default }`.
 - **List comprehensions** must be single-line.
 - Run **`kcl fmt`** before every commit; CI is strict.
-- Validate with `make check` in `Smana/crossplane-configuration` (generate-sync, `kcl fmt`/`kcl test`, XRD schema, render equivalence against golden fixtures).
+- Validate with `task check` in `Smana/crossplane-configuration` (generate-sync, `kcl fmt`/`kcl test`, XRD schema, render equivalence against golden fixtures).
 - Native Kubernetes readiness via `option("params").ocds`:
   - Deployment: `status.conditions[type=Available, status=True]`
   - Service: `spec.clusterIP` assigned

--- a/.claude/rules/process.md
+++ b/.claude/rules/process.md
@@ -13,7 +13,7 @@ Before claiming status: identify the command, run it fresh, cite the output inli
 | Claim | Evidence (fresh, this message) |
 |-------|--------------------------------|
 | Manifests valid | `./scripts/validate-manifests.sh` → exit 0, and the report shows `Invalid: 0, Skipped: 0` |
-| KCL composition valid | `make check` in `Smana/crossplane-configuration` → exit 0 (compositions are not in this repo) |
+| KCL composition valid | `task check` in `Smana/crossplane-configuration` → exit 0 (compositions are not in this repo) |
 | Docs links resolve | `./scripts/validate-links.sh` → exit 0 (run after ANY file move — a path grep cannot see relative-link rot) |
 | Design ready | Design doc committed under `docs/superpowers/specs/`, no `[NEEDS CLARIFICATION]` markers left |
 | Success criteria met (post-merge) | `/verify-spec <design-doc>` against live cluster |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Both use `loadBalancerClass: tailscale` via CiliumGatewayClassConfig. ExternalDN
 ### Scripts
 - EKS cleanup: `scripts/eks-prepare-destroy.sh`
 - OpenBao config: `scripts/openbao-config.sh`
-- KCL/composition validation: `make check` in [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration) (moved with the compositions)
+- KCL/composition validation: `task check` in [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration) (moved with the compositions)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Security is built-in, not bolted-on:
 - 📖 [OpenTofu Deployment](docs/opentofu.md) - Infrastructure deployment guide
 - 🔄 [GitOps with Flux](docs/gitops.md) - How continuous delivery works
 - 🏗️ [Crossplane](docs/crossplane.md) - Infrastructure compositions
+- 🧩 [Authoring KCL compositions](docs/crossplane-kcl-authoring.md) - composition authoring rules and gotchas
 
 ### Platform Services
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -233,7 +233,7 @@ Self-hosted runner scale sets run in-cluster (`tooling/base/gha-runners/`), enab
 
 ### KCL formatting failure
 
-Now a `Smana/crossplane-configuration` concern — `make test` there formats in place and fails if the
+Now a `Smana/crossplane-configuration` concern — `task test` there formats in place and fails if the
 tree changes. Nothing in this repo runs `kcl`.
 
 ### Manifest validation failure (`Invalid` > 0 or `Skipped` > 0)

--- a/docs/crossplane-kcl-authoring.md
+++ b/docs/crossplane-kcl-authoring.md
@@ -1,0 +1,150 @@
+<!-- MIRROR of Smana/crossplane-configuration:docs/kcl-authoring.md @ 9292741
+     Upstream is authoritative. Kept here so the platform docs site can publish it.
+     Update by re-copying from upstream; see the note at the foot of this page. -->
+
+> **This page is mirrored.** The compositions it describes live in
+> [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration), and so does
+> the authoritative copy of this page — [`docs/kcl-authoring.md`](https://github.com/Smana/crossplane-configuration/blob/main/docs/kcl-authoring.md).
+> Edit it there. This copy exists so the platform documentation site can publish composition
+> authoring guidance alongside everything else.
+
+# Authoring KCL compositions
+
+The Compositions in `crossplane-configuration` are generated: `apis/<api>/kcl/main.k` is the source of truth and
+`make generate` inlines it into `apis/<api>/composition.yaml` as a block scalar. **Never edit the
+inlined copy** — CI regenerates and fails if the two disagree.
+
+Inlining is why a published package pulls nothing at render time. It also means the KCL modules are
+no longer published as OCI artifacts; the `version` field surviving in each `kcl.mod` is vestigial
+metadata that nothing reads.
+
+## The five rules
+
+**1. Always `kcl fmt`.** CI formats in place and fails if the tree changes. `kcl fmt` has no
+`--check` flag (0.11.3), which is why `make test` formats then diffs.
+
+**2. Never mutate a dict after creation.** This is the one that silently doubles your output.
+function-kcl hashes each resource at creation; mutating it produces a second hash, so *both*
+versions appear in the rendered result ([function-kcl#285]). Use inline conditionals instead:
+
+```kcl
+# WRONG — yields two Deployments in the rendered output
+_deployment = {metadata.annotations = {}}
+if _ready:
+    _deployment.metadata.annotations["krm.kcl.dev/ready"] = "True"
+
+# RIGHT — decided at creation
+_deployment = {
+    metadata.annotations = {
+        if _ready:
+            "krm.kcl.dev/ready" = "True"
+    }
+}
+```
+
+The same trap in other shapes: conditional field assignment (`if c: r.field = v`), dictionary update
+(`r.metadata.labels["k"] = "v"`), and accumulating into a resource inside a loop. Compute values
+*first*, then build the resource once.
+
+**3. List comprehensions must be single-line.** Multi-line ones fail CI.
+
+**4. Don't shadow the loop variable in a dict comprehension.** `[{name = name} for name in xs]`
+writes the *value* as both key and value — you get `{<value>: <value>}`, not `{name: <value>}`.
+Rename the loop variable: `for n in xs`. The symptom is remote and confusing: Kubernetes rejects the
+rendered manifest with `field not declared in schema`.
+
+**5. Validate with `make check`.** Runs generate-sync, `kcl fmt` + `kcl test`, XRD schema validation
+of the example claims, and render equivalence against the golden fixtures in `tests/golden/`.
+
+[function-kcl#285]: https://github.com/crossplane-contrib/function-kcl/issues/285
+
+## Catching a mutation bug
+
+The failure is duplicate resources in the rendered output, so look there rather than at the source:
+
+```bash
+make render                      # diffs every example against tests/golden/
+crossplane render examples/app-basic.yaml apis/app/composition.yaml functions.yaml \
+  | grep -c "^kind: Deployment"  # >1 for a single-Deployment claim means duplicates
+```
+
+Grepping the source finds candidates but not proof — a post-creation assignment is only a bug if the
+resource is one function-kcl emits:
+
+```bash
+grep -rn '^\s*_[a-zA-Z]*\.[a-zA-Z]' apis/*/kcl/main.k     # field assignment after creation
+grep -rn '\["[^"]*"\] = ' apis/*/kcl/main.k               # dictionary update
+```
+
+## Readiness
+
+Native Kubernetes resources are marked ready by inspecting observed cluster state through
+`option("params").ocds`, then setting `krm.kcl.dev/ready` conditionally:
+
+| Kind | Ready when |
+|---|---|
+| `Deployment` | `status.conditions[type=Available, status=True]` |
+| `Service` | `spec.clusterIP` assigned |
+| `HTTPRoute` | `status.parents[].conditions[type=Accepted, status=True]` |
+| `AIGatewayRoute` | top-level `status.conditions[type=Accepted, status=True]`; rendering additionally latched on Deployment readiness |
+
+```kcl
+_observed = ocds.get(_name + "-deployment", {})?.Resource
+_ready = any_true([c.get("type") == "Available" and c.get("status") == "True" for c in _observed?.status?.conditions or []])
+```
+
+**Always ready when created** (no observed state to wait on): HPA, PDB, Gateway,
+CiliumNetworkPolicy, HelmRelease, Backend, AIServiceBackend.
+
+**Report real conditions** (they are XRs with their own status): SQLInstance, EKSPodIdentity,
+S3 Bucket.
+
+## Crossplane v2 traps
+
+These describe how the *cluster* behaves, so they bite when a composition is deployed rather than
+when it renders.
+
+1. **Managed resources are namespaced** in provider-aws v2.x (`m.upbound.io`), where v1's
+   `upbound.io` was cluster-scoped. Every direct MR needs `metadata.namespace`. Symptom:
+   `<Kind>/<name> namespace not specified` on a Flux dry-run.
+2. **`ManagedResourceActivationPolicy` gates which CRDs install.** Provider packages ship dozens;
+   only those listed in the consuming cluster's activation policy exist. Adding a new MR Kind to a
+   composition usually means adding its plural CRD name there too. Symptom: `no matches for kind`.
+3. **Compositions writing third-party Kinds need an aggregate ClusterRole.** The Crossplane SA only
+   gets RBAC for what its providers manage; `keda.sh/scaledobjects`, `batch/jobs` and friends need
+   an explicit grant labelled `rbac.crossplane.io/aggregate-to-crossplane: "true"`. Symptom:
+   the XR reconcile loops on `Timeout: failed waiting for ... Informer to sync`.
+4. **A fresh CRD's informer can stall even with RBAC in place.** Check the cheap deterministic thing
+   first — `kubectl auth can-i --as=system:serviceaccount:crossplane-system:crossplane list <plural> -A`
+   — and if that says `yes` while the timeout persists, restart the controller.
+
+## Security and policy checks — a known gap
+
+**Nothing automatically audits the workloads these Compositions produce.** Worth stating plainly,
+because the platform constitution implies otherwise.
+
+`cloud-native-ref`'s `./scripts/validate-manifests.sh` runs Polaris over its rendered bundle, but
+that bundle contains the *claims* (`kind: App`), not the Deployments Crossplane expands them into at
+runtime — those objects only ever exist in-cluster, so Polaris never sees them. The retired
+`validate-kcl-compositions.sh` had three stages (`kcl fmt`, `kcl run`, `crossplane render`); the
+Polaris ≥85 / kube-linter / Datree row in the constitution's validation table described an agent
+workflow, never a script.
+
+So a composition that drops `readOnlyRootFilesystem` or `seccompProfile` from its pod spec passes
+every gate in both repos. Review pod specs by hand until this is closed.
+
+The fix is cheap and belongs in `crossplane-configuration`: `make render` already writes rendered
+output for all 12 examples, which is exactly the input a Polaris audit wants.
+
+---
+
+## Keeping this page in sync
+
+Upstream (`crossplane-configuration`) is the source of truth: it holds the code, the CI that
+enforces these rules, and the release the platform pins.
+
+There is **no automated check** that this mirror matches upstream — the two can drift silently
+today. When the documentation site is built, prefer fetching this file from the tag pinned in
+`infrastructure/base/crossplane/configuration/configuration-packages.yaml` at build time over
+keeping a copy in git. That removes the duplication rather than policing it, and guarantees the
+published page describes the API version the cluster actually serves.

--- a/docs/crossplane-kcl-authoring.md
+++ b/docs/crossplane-kcl-authoring.md
@@ -1,4 +1,4 @@
-<!-- MIRROR of Smana/crossplane-configuration:docs/kcl-authoring.md @ 9292741
+<!-- MIRROR of Smana/crossplane-configuration:docs/kcl-authoring.md @ ddc6717
      Upstream is authoritative. Kept here so the platform docs site can publish it.
      Update by re-copying from upstream; see the note at the foot of this page. -->
 
@@ -11,7 +11,7 @@
 # Authoring KCL compositions
 
 The Compositions in `crossplane-configuration` are generated: `apis/<api>/kcl/main.k` is the source of truth and
-`make generate` inlines it into `apis/<api>/composition.yaml` as a block scalar. **Never edit the
+`task generate` inlines it into `apis/<api>/composition.yaml` as a block scalar. **Never edit the
 inlined copy** — CI regenerates and fails if the two disagree.
 
 Inlining is why a published package pulls nothing at render time. It also means the KCL modules are
@@ -21,7 +21,7 @@ metadata that nothing reads.
 ## The five rules
 
 **1. Always `kcl fmt`.** CI formats in place and fails if the tree changes. `kcl fmt` has no
-`--check` flag (0.11.3), which is why `make test` formats then diffs.
+`--check` flag (0.11.3), which is why `task test` formats then diffs.
 
 **2. Never mutate a dict after creation.** This is the one that silently doubles your output.
 function-kcl hashes each resource at creation; mutating it produces a second hash, so *both*
@@ -53,7 +53,7 @@ writes the *value* as both key and value — you get `{<value>: <value>}`, not `
 Rename the loop variable: `for n in xs`. The symptom is remote and confusing: Kubernetes rejects the
 rendered manifest with `field not declared in schema`.
 
-**5. Validate with `make check`.** Runs generate-sync, `kcl fmt` + `kcl test`, XRD schema validation
+**5. Validate with `task check`.** Runs generate-sync, `kcl fmt` + `kcl test`, XRD schema validation
 of the example claims, and render equivalence against the golden fixtures in `tests/golden/`.
 
 [function-kcl#285]: https://github.com/crossplane-contrib/function-kcl/issues/285
@@ -63,7 +63,7 @@ of the example claims, and render equivalence against the golden fixtures in `te
 The failure is duplicate resources in the rendered output, so look there rather than at the source:
 
 ```bash
-make render                      # diffs every example against tests/golden/
+task render                      # diffs every example against tests/golden/
 crossplane render examples/app-basic.yaml apis/app/composition.yaml functions.yaml \
   | grep -c "^kind: Deployment"  # >1 for a single-Deployment claim means duplicates
 ```
@@ -133,7 +133,7 @@ workflow, never a script.
 So a composition that drops `readOnlyRootFilesystem` or `seccompProfile` from its pod spec passes
 every gate in both repos. Review pod specs by hand until this is closed.
 
-The fix is cheap and belongs in `crossplane-configuration`: `make render` already writes rendered
+The fix is cheap and belongs in `crossplane-configuration`: `task render` already writes rendered
 output for all 12 examples, which is exactly the input a Polaris audit wants.
 
 ---

--- a/docs/crossplane.md
+++ b/docs/crossplane.md
@@ -372,7 +372,7 @@ spec:
 
 ```bash
 # From repository root - validates ALL compositions
-make check   # in https://github.com/Smana/crossplane-configuration
+task check   # in https://github.com/Smana/crossplane-configuration
 ```
 
 This script performs three stages:
@@ -565,7 +565,7 @@ _deployment = {
 
    # Validate full composition
    cd ../..
-   make check   # in https://github.com/Smana/crossplane-configuration
+   task check   # in https://github.com/Smana/crossplane-configuration
    ```
 
 5. **Publish Module** (via CI)
@@ -638,7 +638,7 @@ kubectl logs -n crossplane-system deployment/function-kcl
 1. **Start Simple**: Begin with minimal configuration, add complexity as needed
 2. **Use Compositions**: Don't create managed resources directly
 3. **Follow Naming Convention**: Always prefix with `xplane-`
-4. **Validate Before Commit**: Run `make check` in https://github.com/Smana/crossplane-configuration
+4. **Validate Before Commit**: Run `task check` in https://github.com/Smana/crossplane-configuration
 5. **Format KCL Code**: Always run `kcl fmt` before committing
 6. **Avoid Mutations**: Use inline conditionals, not post-creation assignment
 7. **Monitor Resources**: Use `crossplane beta trace` for debugging

--- a/docs/crossplane.md
+++ b/docs/crossplane.md
@@ -440,7 +440,7 @@ datree test /tmp/rendered.yaml --ignore-missing-schemas
 - **Target**: No policy violations
 - **Action**: Fix failures, document accepted warnings
 
-**Related**: [CI Workflows - Crossplane Modules Pipeline](./ci-workflows.md#crossplane-modules-pipeline-githubworkflowscrossplane-modulesyml)
+**Related**: [CI Workflows](./ci-workflows.md)
 
 ## Known Limitations and Considerations
 
@@ -572,7 +572,7 @@ _deployment = {
    - Commit changes
    - CI publishes to GHCR with version tag
 
-**Related**: [KCL Development Guide](https://github.com/Smana/crossplane-configuration)
+**Related**: [Authoring KCL compositions](./crossplane-kcl-authoring.md) — the mutation trap, readiness patterns and Crossplane v2 traps
 
 ## Using Compositions
 

--- a/docs/platform-constitution.md
+++ b/docs/platform-constitution.md
@@ -147,7 +147,7 @@ Before committing composition changes:
 | kube-linter | No errors | Kubernetes best practices |
 | Datree | Pass | Policy enforcement |
 
-**Validation**: `make check` in [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration), which owns the compositions. This repo pins a released version in `infrastructure/base/crossplane/configuration/configuration-packages.yaml`.
+**Validation**: `task check` in [`Smana/crossplane-configuration`](https://github.com/Smana/crossplane-configuration), which owns the compositions. This repo pins a released version in `infrastructure/base/crossplane/configuration/configuration-packages.yaml`.
 
 ### 6.2 Infrastructure Changes
 


### PR DESCRIPTION
Companion to [`crossplane-configuration#7`](https://github.com/Smana/crossplane-configuration/pull/7). Merge that one first.

The composition cutover took the KCL guidance with it — the rules, the function-kcl mutation reference and the readiness patterns lived in `.claude/rules/`, `.claude/agents/` and `.claude/skills/`, and were deleted because their globs pointed at a directory that no longer exists here. That left nothing for a reader, or the planned docs site, to find.

## Why a mirror and not just a link

Two different artifacts were tangled together:

- **Glob-triggered enforcement** (`.claude/rules/*.md`) only fires when you edit the files it names. It can only work in the repo that has the code — a copy here would never load. That lives upstream now.
- **Reference documentation for readers** — this. It legitimately belongs wherever the docs site is built from.

So the rules are upstream and this is the readable page, carrying the upstream commit it was taken from. The prose was made repo-neutral upstream in the same PR so it reads correctly from either side.

## No sync check — deliberately

The two copies can drift and nothing will catch it. I considered a CI check that fetches upstream and diffs, and decided against it for now:

- Pinned to the package tag, it would fail today — `v0.1.0` predates the doc.
- Pointed at upstream `main`, an unrelated edit over there turns this repo red, which is how a gate loses its credibility.

**The better fix is to not duplicate at all.** When the Hugo site is built, have the build fetch this file from the tag pinned in `configuration-packages.yaml`. One copy of the facts, and the published page provably describes the API version the cluster serves. The page ends with that recommendation.

Happy to add the check instead if you'd rather have it now — say the word and I'll cut `v0.2.0` upstream so it can be tag-pinned from day one.

## One correction worth surfacing

Writing this turned up that **nothing audits composition pod specs**. `validate-manifests.sh` runs Polaris over the rendered bundle, but that bundle holds the *claims* (`kind: App`), not the Deployments Crossplane expands them into at runtime. And the retired `validate-kcl-compositions.sh` had three stages (`kcl fmt`, `kcl run`, `crossplane render`) — the Polaris ≥85 / kube-linter / Datree row in the constitution's validation table described an agent workflow, never a script.

A composition that drops `readOnlyRootFilesystem` or `seccompProfile` passes every gate in both repos. Documented as a gap in both places rather than left implied. `make render` upstream already produces exactly the input a Polaris audit needs.

## Changes

- `docs/crossplane-kcl-authoring.md` — the mirrored page
- `docs/crossplane.md` — points its "KCL Development Guide" at the local page; also fixes a link into a `ci-workflows.md` heading anchor that the cutover renamed
- `README.md` — adds it to the documentation list

`./scripts/validate-links.sh` → all relative links resolve.