### PR TITLE
fix(eks): install backendtlspolicies before Cilium so Gateway API survives a rebuild

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,15 @@ Use the FluxCD agent-skills plugin for Flux troubleshooting (`/gitops-cluster-de
 - **Certificates**: Check OpenBao CA chain and cert-manager logs
 - **Network**: Confirm Tailscale subnet router connectivity
 - **Resource Conflicts**: Review Crossplane composition functions and resource references
+- **Gateways stuck `Waiting for controller`**: cilium-operator probes for the Gateway API CRDs
+  **once, at startup**, and permanently disables its Gateway API controller if any are missing —
+  no crash, no alert. Symptoms cascade: `GatewayClass ACCEPTED=Unknown`, Gateways unprogrammed,
+  HTTPRoutes with no `status.parents`, and every `App` claim that owns a route stuck
+  `READY=False`. Confirm with
+  `kubectl logs -n kube-system -l io.cilium/app=operator | grep "Required GatewayAPI resources"`,
+  then `kubectl rollout restart -n kube-system deployment/cilium-operator`. The durable fix is to
+  add the missing CRD to `gateway_api_crds_urls` in `opentofu/eks/configure/locals.tf` — Flux
+  applies the full CRD directory, but only *after* Cilium is already running.
 
 > **VictoriaLogs and Grafana rules** are in `.claude/rules/observability.md` (loaded automatically when editing observability files).
 

--- a/opentofu/eks/configure/locals.tf
+++ b/opentofu/eks/configure/locals.tf
@@ -2,6 +2,26 @@ locals {
   # Gateway API CRDs installed before Cilium (Cilium's Gateway API support
   # requires these CRDs to exist). Version must match
   # flux/sources/gitrepo-gateway-api.yaml ref.
+  #
+  # THIS LIST IS LOAD-BEARING AND MUST COVER EVERYTHING CILIUM LOOKS FOR.
+  # The cilium-operator probes for the Gateway API CRDs exactly once, at startup.
+  # If any are missing it logs "Required GatewayAPI resources are not found",
+  # disables its Gateway API controller and NEVER RETRIES — every GatewayClass
+  # then sits at Accepted=Unknown "Waiting for controller", every Gateway stays
+  # unprogrammed, and HTTPRoutes get no status at all. Nothing crashes and
+  # nothing alerts.
+  #
+  # Flux applies the whole ./config/crd/experimental directory
+  # (crds/base/kustomization-gateway-api.yaml), but that runs well after
+  # eks/configure installs Cilium, so anything only Flux applies loses the race.
+  # That is exactly how backendtlspolicies was missed: Cilium 1.20 requires it,
+  # this list did not have it, and the operator gave up two seconds before Flux
+  # created it.
+  #
+  # Append new entries — the `count` index of the existing ones must not shift,
+  # or tofu destroys and recreates live CRDs, taking every Gateway and HTTPRoute
+  # with them. Recovery if it happens again: restart the operator, which reruns
+  # the probe (`kubectl rollout restart -n kube-system deployment/cilium-operator`).
   gateway_api_crds_urls = [
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml",
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml",
@@ -10,7 +30,15 @@ locals {
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml",
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml",
     "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml",
-    "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml"
+    "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml",
+    # Required by Cilium >= 1.20. Its absence is what broke Gateway API on the
+    # 2026-08-19 rebuild.
+    "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml",
+    # Not required, but detected only at operator startup: "The ListenerSet CRD
+    # must be installed before the Cilium operator starts to ensure detection.
+    # If the CRD is added to an existing installation, the Cilium operator must
+    # be restarted" — docs.cilium.io/en/stable/network/servicemesh/gateway-api/listenerset
+    "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${var.gateway_api_version}/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml"
   ]
 
   cert_manager_approle = jsondecode(data.aws_secretsmanager_secret_version.cert_manager_approle.secret_string)


### PR DESCRIPTION
Gateway API was dead on the cluster rebuilt this morning: both GatewayClasses `ACCEPTED=Unknown`, all four Gateways unprogrammed, all sixteen HTTPRoutes with **no status at all**, and the four `App` claims that own a route stuck `READY=False`.

## Root cause — a two-second race

```
11:26:34  cilium-operator (leader) starts
11:26:44  probes for the Gateway API CRDs — backendtlspolicies missing
          -> "Required GatewayAPI resources are not found"
11:26:46  Flux creates backendtlspolicies
```

Cilium 1.20 requires the `BackendTLSPolicy` CRD. `gateway_api_crds_urls` lists eight CRDs and did not include it. `eks/configure` correctly makes the Cilium `helm_release` `depends_on` that list — the dependency was never the problem, the *list* was incomplete.

Flux applies the whole `config/crd/experimental` directory (`crds/base/kustomization-gateway-api.yaml`), but that runs long after `eks/configure` has installed Cilium. So the CRD lost a race it should never have been in.

**The operator probes exactly once and never retries.** It disabled its Gateway API controller for the life of the pod — no crash, no restart, no alert. The second replica, started at 11:30 after the CRD existed, logs no error at all; it just isn't the leader, so its controller never activates. That asymmetry is why the logs look clean unless you check both pods.

## The running cluster is already recovered

`kubectl rollout restart -n kube-system deployment/cilium-operator`, then within 20 seconds:

| | Before | After |
|---|---|---|
| GatewayClasses `ACCEPTED` | 0/2 | **2/2** |
| Gateways `Programmed` | 0/4 | **4/4** |
| HTTPRoutes `Accepted` | 0/16 | **16/16** |
| `App` claims `READY` | 1/5 | **4/5** |

The remaining `App` is `xplane-image-gallery`, failing on `"Failed to connect to storage" / "Access Denied."` — an S3/IAM problem, unrelated to routing. One of its two replicas runs fine.

## This PR is the durable fix

Adds `backendtlspolicies` so a fresh `terramate script run deploy` cannot hit this again, plus `listenersets`, which Cilium detects by the same startup-only rule:

> *"The ListenerSet CRD must be installed before the Cilium operator starts to ensure detection. If the CRD is added to an existing installation, the Cilium operator must be restarted."* — [Cilium docs](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/listenerset)

Also documents the failure mode in `CLAUDE.md`, because the symptom points nowhere near the cause.

### Appended, not reordered — and verified

The list is indexed by `count`. Reordering or inserting would change the resource addresses of existing entries, so tofu would **destroy and recreate live CRDs** — taking every Gateway and HTTPRoute with them. Proven add-only against real state rather than assumed:

```
$ tofu plan -target=kubectl_manifest.gateway_api_crds
  # kubectl_manifest.gateway_api_crds[8] will be created
  # kubectl_manifest.gateway_api_crds[9] will be created
Plan: 2 to add, 0 to change, 0 to destroy.
```

`tofu validate` passes; both new URLs return HTTP 200 at the pinned `v1.6.1`. The version pins are correct and unchanged — Cilium 1.19+ requires Gateway API >= v1.6.1, and `eks/configure` and `flux/sources/gitrepo-gateway-api.yaml` already agree on `v1.6.1`.
