### PR TITLE
fix(openbao): pin raft quorum to on-demand, document the inline-rule migration

### DIFF
--- a/opentofu/openbao/cluster/autoscaling_group.tf
+++ b/opentofu/openbao/cluster/autoscaling_group.tf
@@ -195,9 +195,24 @@ module "openbao_asg" {
         { instance_type = "t3.medium" },
       ]
     }
+    # Quorum must not depend on spot capacity. With base 0 all five nodes were
+    # spot, so a single unavailable pool could leave raft short of the three
+    # voters it needs to elect a leader — and an OpenBao that cannot elect is an
+    # OpenBao that cannot issue a certificate or read a secret.
+    #
+    # Not theoretical: the 2026-08-19 HA bring-up failed with
+    # "InsufficientInstanceCapacity - We currently do not have sufficient
+    # t3.small capacity in eu-west-3b". It self-healed on retry, but nothing
+    # guaranteed that.
+    #
+    # base 3 pins the quorum majority to on-demand and leaves the two nodes
+    # above it 95% spot, so the fault tolerance a five-node cluster is supposed
+    # to provide is what actually survives a pool outage. The extra cost applies
+    # only in ha mode — dev mode uses one instance from the dev launch template
+    # and no mixed-instances policy at all.
     instances_distribution = {
       on_demand_allocation_strategy            = "lowest-price"
-      on_demand_base_capacity                  = 0
+      on_demand_base_capacity                  = 3
       on_demand_percentage_above_base_capacity = 5
       spot_allocation_strategy                 = "lowest-price"
       spot_instance_pools                      = 3

--- a/opentofu/openbao/cluster/security_group.tf
+++ b/opentofu/openbao/cluster/security_group.tf
@@ -28,6 +28,39 @@
 # Two classes of client:
 #   - operators, arriving over Tailscale via the subnet router
 #   - in-cluster workloads (cert-manager, the snapshot CronJob)
+#
+# MIGRATING AN EXISTING DEPLOYMENT: revoke the legacy inline rule first.
+# ---------------------------------------------------------------------
+# The Tailscale ingress used to be an inline `ingress` block on the security
+# group below; it is now the standalone `nlb_from_tailscale` resource. A fresh
+# deploy is unaffected. Re-applying over a deployment created by the older code
+# fails, once, with:
+#
+#   Error: InvalidPermission.Duplicate: the specified rule
+#   "peer: sg-…, TCP, from port: 8200, to port: 8200, ALLOW" already exists
+#     with aws_security_group_rule.nlb_from_tailscale
+#
+# No `moved` block fixes this and no dependency ordering avoids it. An inline
+# block has no state address to move *from*, and with the block simply deleted
+# from the config the provider plans no rule change on the group at all — the
+# plan shows `aws_security_group.nlb will be updated in-place` for tags only —
+# so it never revokes what it created inline. The old rule and the new resource
+# then describe the same AWS rule, and the create collides.
+#
+# `ingress = []` would revoke it, but the provider forbids mixing inline blocks
+# with aws_security_group_rule and the two would fight on every subsequent
+# apply. So the one-time remedy is out of band, before the apply:
+#
+#   aws ec2 describe-security-group-rules --region <region> \
+#     --filters Name=group-id,Values=<nlb-sg-id> \
+#     --query "SecurityGroupRules[?!IsEgress && FromPort==\`8200\`].[SecurityGroupRuleId,Description]" \
+#     --output text
+#   aws ec2 revoke-security-group-ingress --region <region> \
+#     --group-id <nlb-sg-id> --security-group-rule-ids <the legacy rule id>
+#
+# Access is not interrupted: `nlb_from_vpc` below admits the whole VPC CIDR,
+# and the Tailscale subnet router is an EC2 instance inside it. Verified during
+# the 2026-08-19 migration — the API answered 200 throughout the revoke.
 
 resource "aws_security_group" "nlb" {
   name        = format("%s-nlb", local.name)


### PR DESCRIPTION
The two loose ends from validating #1771 against a real OpenBao rebuild.

## 1. Raft quorum no longer depends on spot

`on_demand_base_capacity` **0 → 3**.

All five ha-mode nodes were spot. One unavailable pool could leave raft short of the three voters it needs to elect a leader — and an OpenBao that cannot elect cannot issue a certificate or read a secret. That is the opposite of what a five-node cluster is for.

Not theoretical. The HA bring-up on 2026-08-19 failed with:

```
InsufficientInstanceCapacity - We currently do not have sufficient
t3.small capacity in the Availability Zone you requested (eu-west-3b)
```

It self-healed on retry, but nothing guaranteed that. Pinning the quorum majority to on-demand leaves the two nodes above it 95% spot, so the fault tolerance actually survives a pool outage.

**No cost change for the demo.** `mixed_instances_policy` only exists when `mode == "ha"`; dev mode runs one instance from the dev launch template. Verified inert against the running cluster:

```
$ tofu plan -var-file=variables.tfvars
No changes. Your infrastructure matches the configuration.
```

## 2. The inline-rule migration — and a correction

I said earlier this needed a `moved` block. **That was wrong**, and the reason is worth recording rather than quietly substituting a different fix.

The Tailscale ingress used to be an **inline `ingress` block** on `aws_security_group.nlb`; #1771 converts it to the standalone `aws_security_group_rule.nlb_from_tailscale`. Fresh deploys are unaffected. Re-applying over a deployment created by the older code fails once with:

```
Error: InvalidPermission.Duplicate: the specified rule
"peer: sg-…, TCP, from port: 8200, to port: 8200, ALLOW" already exists
  with aws_security_group_rule.nlb_from_tailscale
```

A `moved` block cannot express this — an inline block has no state address to move *from*. And no dependency ordering avoids it either: with the block simply deleted from the config, the provider plans **no rule change on the group at all**. The plan shows `aws_security_group.nlb will be updated in-place` for `~ tags` only, so it never revokes what it created inline. The legacy rule and the new resource then describe the same AWS rule, and the create collides.

`ingress = []` *would* revoke it, but the provider forbids mixing inline blocks with `aws_security_group_rule`, and the two would fight on every subsequent apply.

So the remedy is a one-time out-of-band revoke, now documented next to the rule with the exact commands. Access is not interrupted while it runs: `nlb_from_vpc` admits the VPC CIDR that the Tailscale subnet router sits in — confirmed during the migration, the API answered `200` throughout the revoke.

## Verification

| Check | Result |
|---|---|
| `tofu fmt -check` | clean |
| `tofu validate` | Success |
| `tofu plan` against the live dev cluster | **No changes** |
| pre-commit (incl. `terraform_validate`, `tflint`, `detect-secrets`) | all pass |
