### PR TITLE
feat(openbao): reap dead raft voters, and alert on the first one not the last

### DIFF
--- a/observability/base/victoria-metrics-k8s-stack/vmrules/openbao.yaml
+++ b/observability/base/victoria-metrics-k8s-stack/vmrules/openbao.yaml
@@ -66,20 +66,60 @@ spec:
             runbook_url: "https://openbao.org/docs/internals/integrated-storage/"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
 
-        # Only meaningful in ha mode; absent metrics simply never fire.
-        - alert: OpenBaoRaftQuorumAtRisk
-          expr: vault_autopilot_failure_tolerance{job="openbao"} < 1
+        # Two thresholds on the same metric, because the interesting moment is
+        # the FIRST lost node, not the last. A five-node cluster with min_quorum
+        # 3 has a failure tolerance of 2 when healthy. At `< 1` the cluster is
+        # already one failure from losing quorum -- by then it is an incident,
+        # not a warning.
+        #
+        # Measured 2026-08-19: raft listed six voters against five live
+        # instances (a replaced spot node left behind as a voter) and
+        # vault_autopilot_failure_tolerance read exactly 1 -- so the old rule
+        # stayed silent through it. Quorum is computed over the voter set, not
+        # over live instances, so a stale voter raises the quorum bar (4 of 6
+        # instead of 3 of 5) and halves the tolerance without anything failing.
+        #
+        # Neither fires in dev mode: file storage has no raft and no autopilot,
+        # so the metric does not exist.
+        - alert: OpenBaoRaftNodeLost
+          expr: vault_autopilot_failure_tolerance{job="openbao"} < 2
           for: 15m
           labels:
             severity: warning
           annotations:
+            message: OpenBao raft cluster has lost redundancy.
+            description: |
+              Failure tolerance has been below 2 for 15 minutes, so a five-node
+              cluster is no longer tolerating the two failures it is sized for.
+              Usually a dead peer: instances replaced without
+              `bao operator raft remove-peer` stay in the voter set, which spot
+              reclamation does routinely.
+
+              Compare the voter list against the running instances:
+                bao operator raft list-peers
+                aws autoscaling describe-auto-scaling-groups --region <region> \
+                  --auto-scaling-group-names <asg> \
+                  --query 'AutoScalingGroups[0].Instances[].InstanceId'
+
+              Autopilot only removes these when dead server cleanup is enabled;
+              that is the vault_raft_autopilot resource in
+              opentofu/openbao/management/autopilot.tf.
+            runbook_url: "https://openbao.org/docs/concepts/integrated-storage/autopilot"
+            dashboard: "https://grafana.${private_domain_name}/dashboards"
+
+        - alert: OpenBaoRaftQuorumAtRisk
+          expr: vault_autopilot_failure_tolerance{job="openbao"} < 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
             message: OpenBao raft cluster cannot tolerate a node failure.
             description: |
               Failure tolerance has been below 1 for 15 minutes: losing one more
-              node loses quorum. Dead peers accumulate when instances are
-              replaced without `bao operator raft remove-peer`, which spot
-              reclamation does routinely.
-            runbook_url: "https://openbao.org/docs/internals/integrated-storage/"
+              node loses quorum, and a cluster without quorum cannot issue a
+              certificate or read a secret. If OpenBaoRaftNodeLost fired first
+              and was not acted on, this is that same dead peer plus a real one.
+            runbook_url: "https://openbao.org/docs/concepts/integrated-storage/autopilot"
             dashboard: "https://grafana.${private_domain_name}/dashboards"
 
         # The backup ran and failed every night with nobody watching. Two

--- a/opentofu/openbao/management/autopilot.tf
+++ b/opentofu/openbao/management/autopilot.tf
@@ -1,0 +1,36 @@
+# Raft autopilot — dead server cleanup
+# ------------------------------------
+# Autopilot runs by default in OpenBao, but dead server cleanup does NOT: it
+# "must be explicitly activated"
+# (openbao.org/docs/concepts/integrated-storage/autopilot). Without it a node
+# that goes away stays in the raft voter set forever.
+#
+# That is not a corner case on this cluster. The ha-mode ASG is 95% spot with
+# instance refresh enabled, and the raft node_id is the EC2 instance id
+# (`node_id = "$INSTANCE_ID"` in cluster/scripts/startup_script.sh), so every
+# replacement joins under a new id and the old one is simply left behind.
+#
+# Measured 2026-08-19: raft listed six voters against five live instances.
+# Quorum is computed over the voter set, not over live nodes, so the bar moved
+# from 3-of-5 to 4-of-6 and vault_autopilot_failure_tolerance halved from 2 to
+# 1 — the cluster silently lost half the redundancy it was sized for, with
+# nothing failing and nothing alerting.
+#
+# min_quorum is the guard on the cleanup itself: autopilot will not remove
+# servers below it, so a burst of reclamations cannot cascade into losing
+# quorum. 3 is the majority of the five-node ha ASG, and OpenBao rejects values
+# below 3 when cleanup is enabled.
+#
+# Note for recovery: a server autopilot removes must be REINITIALISED before it
+# can rejoin. Harmless here — ASG replacements are always fresh instances.
+resource "vault_raft_autopilot" "this" {
+  count = var.mode == "ha" ? 1 : 0
+
+  cleanup_dead_servers = true
+  min_quorum           = 3
+
+  # Long enough that a node being replaced, or a slow boot, is not mistaken for
+  # a dead one; short enough that a reclaimed spot instance does not distort
+  # quorum for a working day.
+  dead_server_last_contact_threshold = "30m"
+}

--- a/opentofu/openbao/management/variables.tf
+++ b/opentofu/openbao/management/variables.tf
@@ -135,3 +135,23 @@ variable "admin_credentials_secret_name" {
   type        = string
   default     = "openbao/cloud-native-ref/users/admin"
 }
+
+# Must match `mode` in opentofu/openbao/cluster/variables.tfvars. It duplicates
+# one fact across two stacks, which is a drift risk, but the alternative is
+# wiring remote state between them for a single flag and this stack has no
+# other cross-stack coupling.
+#
+# Getting it wrong is loud rather than silent in the direction that matters:
+# "ha" against a dev cluster fails the apply on raft endpoints that do not
+# exist on file storage. "dev" against an ha cluster leaves dead server cleanup
+# off, which is what OpenBaoRaftNodeLost exists to catch.
+variable "mode" {
+  description = "Storage mode of the target OpenBao cluster: 'dev' (file, single node) or 'ha' (raft). Must match the cluster stack."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "ha"], var.mode)
+    error_message = "mode must be 'dev' or 'ha'."
+  }
+}


### PR DESCRIPTION
Closes the dead-peer gap found while validating #1771. Two halves: stop them accumulating, and notice the first one rather than the second.

## What was observed

During the HA bring-up on 2026-08-19, raft listed **six voters against five live instances** — a replaced spot node left behind in the voter set:

```
raft peers: 6                        ASG instances: 5
  i-08dd574965968f363  voter=True    ← instance no longer exists
```

Quorum is computed over the **voter set**, not over live nodes. So:

| | voters | quorum | alive | failure tolerance |
|---|---|---|---|---|
| intended | 5 | 3 | 5 | **2** |
| actual | 6 | 4 | 5 | **1** |

`vault_autopilot_failure_tolerance` read exactly **1**, confirming it independently. Nothing had failed and nothing alerted — the cluster had simply stopped being able to survive what it is sized to survive.

## Why it accumulates

Autopilot is enabled by default in OpenBao, but dead server cleanup **"must be explicitly activated"** ([docs](https://openbao.org/docs/concepts/integrated-storage/autopilot)) — and this repo configured autopilot nowhere (`grep` for `autopilot|cleanup_dead_servers|remove-peer` across `opentofu/` and `scripts/` returns nothing).

Meanwhile the ha ASG is 95% spot with instance refresh enabled, and the raft `node_id` is the EC2 instance id (`node_id = "$INSTANCE_ID"` in `startup_script.sh`). Every replacement joins under a new id; the old one is never removed. **Accumulation is the steady state, not an edge case.**

## 1. `vault_raft_autopilot`

`cleanup_dead_servers = true`, `dead_server_last_contact_threshold = "30m"`, `min_quorum = 3`.

`min_quorum` is the guard on the cleanup itself — autopilot will not remove servers below it, so a burst of reclamations cannot cascade into losing quorum. 3 is the majority of the five-node ha ASG.

One recovery caveat from the docs, worth knowing: a server autopilot removes **must be reinitialised before it can rejoin**. Harmless here, since ASG replacements are always fresh instances.

## 2. The alerting missed it entirely

`OpenBaoRaftQuorumAtRisk` fires at `failure_tolerance < 1`. The dead peer put tolerance at **exactly 1**, so the alert stayed silent through the whole thing — and would only have fired after a *second* peer died, at which point one more failure kills the cluster.

- **`OpenBaoRaftNodeLost`** at `< 2`, warning — would have caught this one. Its description includes the `list-peers` vs ASG comparison to identify the stale voter.
- **`OpenBaoRaftQuorumAtRisk`** stays at `< 1`, promoted **warning → critical**, since by then it is an incident rather than a warning.

Neither fires in dev mode: file storage has no raft and no autopilot, so the metric does not exist.

## Gating, and an honest trade-off

The autopilot resource is gated on a new `mode` variable in the management stack, because dev mode has no raft endpoints to configure. That **duplicates one fact across two stacks** and is a genuine drift risk — noted in the variable itself. The alternative was wiring remote state between the stacks for a single flag, and this stack has no other cross-stack coupling.

The failure direction that matters is loud: `ha` against a dev cluster fails the *apply* on endpoints that do not exist. `dev` against an ha cluster leaves cleanup off — which is exactly what `OpenBaoRaftNodeLost` now catches.

## Verification

| Check | Result |
|---|---|
| `tofu plan` against the live dev cluster | **No changes** — demo untouched |
| `tofu plan -var mode=ha` | `vault_raft_autopilot.this[0] will be created` — gate works both ways |
| `tofu validate` | Success (resource is `vault_raft_autopilot`; `vault_raft_autopilot_config` does not exist in hashicorp/vault v5 — confirmed against the provider schema) |
| `./scripts/validate-manifests.sh` | `Valid: 1183, Invalid: 0, Skipped: 0` |
| pre-commit incl. `tflint`, `detect-secrets` | pass |

Not verified live: the alert firing against a real dead peer, since the cluster is back on dev mode and has no raft. The threshold is derived from the measurement above, where tolerance was observed at 1.
