### PR TITLE
fix(terramate): init before destroy so a root-level sweep survives a stale lock

### DIFF
--- a/opentofu/eks/configure/workflows.tm.hcl
+++ b/opentofu/eks/configure/workflows.tm.hcl
@@ -47,6 +47,10 @@ script "destroy" {
       # Single y/n prompt; cached for 10 min so `--reverse destroy` asks once.
       # Bypass with TM_DESTROY_CONFIRMED=true for CI.
       ["bash", "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"],
+      # `destroy` is a standalone entrypoint: unlike `deploy` it can be the first
+      # tofu command run in a stack, so it has to init itself. Without this a lock
+      # file predating a new provider fails the whole `--reverse destroy` sweep.
+      [global.provisioner, "init", "-lock-timeout=5m"],
       # `-auto-approve`: confirmation already handled by the helper above.
       [global.provisioner, "destroy", "-auto-approve", "-var-file=variables.tfvars"],
     ]

--- a/opentofu/eks/init/workflows.tm.hcl
+++ b/opentofu/eks/init/workflows.tm.hcl
@@ -28,7 +28,7 @@ script "deploy" {
     name        = "stage2-cilium-and-flux"
     description = "Disable VPC CNI/kube-proxy, install Cilium and Flux"
     commands = [
-      ["bash", "-c", "cd ../configure && ${global.provisioner} init"],
+      ["bash", "-c", "cd ../configure && ${global.provisioner} init -lock-timeout=5m"],
       ["bash", "-c", "cd ../configure && ${global.provisioner} apply -auto-approve -var-file=variables.tfvars -var='cilium_version=${global.cilium_version}' -var='flux_operator_version=${global.flux_operator_version}' -var='flux_instance_version=${global.flux_instance_version}' $${TF_VAR_flux_git_ref:+-var=\"flux_git_ref=$${TF_VAR_flux_git_ref}\"}"],
     ]
   }
@@ -106,6 +106,10 @@ script "destroy" {
       # Single y/n prompt; cached for 10 min so `--reverse destroy` asks once.
       # Bypass with TM_DESTROY_CONFIRMED=true for CI.
       ["bash", "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"],
+      # Init before anything is torn down: a lock file predating a new provider
+      # must fail here, not after Flux has been suspended. Same stack dir as the
+      # stage1-destroy-cluster job below, so that job inherits this init.
+      [global.provisioner, "init", "-lock-timeout=5m"],
       [
         "bash",
         "../../../scripts/eks-prepare-destroy.sh",
@@ -123,7 +127,7 @@ script "destroy" {
     name        = "stage2-destroy-addons"
     description = "Destroy Cilium and Flux (configure stack)"
     commands = [
-      ["bash", "-c", "cd ../configure && ${global.provisioner} init"],
+      ["bash", "-c", "cd ../configure && ${global.provisioner} init -lock-timeout=5m"],
       ["bash", "-c", "cd ../configure && ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars"],
     ]
   }

--- a/opentofu/llm-platform/workflows.tm.hcl
+++ b/opentofu/llm-platform/workflows.tm.hcl
@@ -129,6 +129,7 @@ script "destroy" {
         fi
         set -euo pipefail
         bash "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"
+        ${global.provisioner} init -lock-timeout=5m
         ${global.provisioner} destroy -auto-approve -var-file=variables.tfvars
       SCRIPT
       ],

--- a/opentofu/openbao/management/workflows.tm.hcl
+++ b/opentofu/openbao/management/workflows.tm.hcl
@@ -84,6 +84,10 @@ script "destroy" {
     description = "Opentofu destroy"
     commands = [
       ["bash", "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"],
+      # `destroy` is a standalone entrypoint: unlike `deploy` it can be the first
+      # tofu command run in a stack, so it has to init itself. Without this a lock
+      # file predating a new provider fails the whole `--reverse destroy` sweep.
+      [global.provisioner, "init", "-lock-timeout=5m"],
       # Needed even to tear down: the provider still has to configure before it
       # can plan the destroy.
       global.openbao_ca_cmd.args,

--- a/opentofu/workflows.tm.hcl
+++ b/opentofu/workflows.tm.hcl
@@ -99,6 +99,10 @@ script "destroy" {
       # Single y/n prompt; cached for 10 min so `--reverse destroy` asks once.
       # Bypass with TM_DESTROY_CONFIRMED=true for CI.
       ["bash", "${terramate.root.path.fs.absolute}/scripts/terramate-destroy-confirm.sh"],
+      # `destroy` is a standalone entrypoint: unlike `deploy` it can be the first
+      # tofu command run in a stack, so it has to init itself. Without this a lock
+      # file predating a new provider fails the whole `--reverse destroy` sweep.
+      [global.provisioner, "init", "-lock-timeout=5m"],
       # `-auto-approve`: confirmation already handled by the helper above —
       # without this flag tofu would prompt a second time.
       [global.provisioner, "destroy", "-auto-approve", "-var-file=variables.tfvars"],


### PR DESCRIPTION
A root-level `terramate script run --reverse destroy` aborts before destroying anything:

```
Error: Inconsistent dependency lock file
  - provider registry.opentofu.org/hashicorp/random: required by this
    configuration but no version is selected
```

## Root cause

`deploy` runs `tofu init` as its first command. `destroy` never did. That asymmetry
is invisible until destroy is the **first** tofu command run in a stack — which is
exactly the root-level sweep.

The trigger was #1771 adding `random_password` to `openbao/management`. Because
**lock files are gitignored here** (`.gitignore:16 **.terraform.lock.hcl`), the new
provider requirement never reaches an existing checkout until someone inits, so
every developer machine and every fresh clone carries a lock without it. Nothing in
CI catches this — CI runs the `init` script as a separate step.

## Change

Adds `tofu init -lock-timeout=5m` to all five destroy scripts.

Two placement details worth reviewing:

- **`eks/init`** — init goes in the `prepare-destroy` job, *ahead of*
  `eks-prepare-destroy.sh`, so a bad lock fails while the cluster is still intact
  rather than after Flux has been suspended. `stage1-destroy-cluster` shares the
  stack directory and inherits it.
- **`llm-platform`** — inside the opt-in heredoc, *after* the gate, so an opt-out
  invocation still no-ops without downloading providers.

Also aligns the two pre-existing `cd ../configure && tofu init` calls with the same
lock timeout.

## Verification

Reproduced the failure and confirmed the fix on `openbao/management`:

```
=== destroy WITHOUT init (old behaviour) ===
Error: Inconsistent dependency lock file
  - provider registry.opentofu.org/hashicorp/random: ... no version is selected

=== new behaviour: init -lock-timeout=5m, then destroy ===
- Installing hashicorp/random v3.9.0...
OpenTofu has been successfully initialized!
Plan: 0 to add, 0 to change, 31 to destroy.
```

`terramate script run --reverse --dry-run destroy` now shows `tofu init -lock-timeout=5m`
as job 0.1 in every stack (network, openbao/cluster, openbao/management, eks/init,
eks/configure), with llm-platform still gated.

`terramate fmt --check` flags only `opentofu/config.tm.hcl`, which it flagged before
this change too.