### PR TITLE
fix(openbao): run the latest release and serialise the management stack

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,10 +51,10 @@
   ],
   "packageRules": [
     {
-      "description": "Block 2.6.0 only, not the whole project. 2.6.0 deadlocks on concurrent namespace creation (openbao/openbao#3411): the management stack creates vault_namespace resources in parallel, which wedges the core so every subsequent request hangs. The version now carries a renovate annotation (opentofu/openbao/cluster/variables.tf), so without this rule the first PR raised would reintroduce that deadlock. Drop the exclusion once a release carrying the fix is out, in the same PR that bumps the default.",
+      "description": "Block the whole 2.6 line, not just 2.6.0. openbao/openbao#3411 is inconsistent lock ordering across namespaces, mounts and the router — it is a property of the 2.6 branch, not of one release, and it is still OPEN. The original rule here excluded only ^2.6.0$, so Renovate legally offered 2.6.1 and then 2.6.2 (#1784), which reintroduced the wedge on a from-scratch deploy: the management stack's parallel vault_namespace/vault_auth_backend writes deadlock the core (vault/auth.go:78) and every later request, including a localhost `bao status`, hangs forever. allowedVersions rather than enabled:false so 2.5.x patch and security releases still flow. Lift this bound and the 2.5.5 default in opentofu/openbao/cluster/variables.tf in the same PR, once #3411 closes.",
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["openbao/openbao"],
-      "allowedVersions": "!/^2\\.6\\.0$/"
+      "allowedVersions": "<2.6.0"
     },
     {
       "description": "Block the 0.3.x schema break, not the whole chart. Chart 0.3.0 restructures the values schema (canonical-v0.3 providers/routing/global); our values still speak 0.2, so the chart's own 0.3 component defaults win — including pullPolicy: Never, which breaks the router on any fresh node (ErrImageNeverPull -> every `model: MoM` request 404s). Renovate bumped this past a plain code comment (c00892eb) and it stayed invisible for five weeks, because running clusters kept already-pulled images. allowedVersions rather than enabled:false so 0.2.x patch and security releases still flow. Lift the bound in the same PR that migrates infrastructure/base/vllm-semantic-router/helmrelease.yaml to the 0.3 schema.",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,12 +51,6 @@
   ],
   "packageRules": [
     {
-      "description": "Block the whole 2.6 line, not just 2.6.0. openbao/openbao#3411 is inconsistent lock ordering across namespaces, mounts and the router — it is a property of the 2.6 branch, not of one release, and it is still OPEN. The original rule here excluded only ^2.6.0$, so Renovate legally offered 2.6.1 and then 2.6.2 (#1784), which reintroduced the wedge on a from-scratch deploy: the management stack's parallel vault_namespace/vault_auth_backend writes deadlock the core (vault/auth.go:78) and every later request, including a localhost `bao status`, hangs forever. allowedVersions rather than enabled:false so 2.5.x patch and security releases still flow. Lift this bound and the 2.5.5 default in opentofu/openbao/cluster/variables.tf in the same PR, once #3411 closes.",
-      "matchDatasources": ["github-releases"],
-      "matchPackageNames": ["openbao/openbao"],
-      "allowedVersions": "<2.6.0"
-    },
-    {
       "description": "Block the 0.3.x schema break, not the whole chart. Chart 0.3.0 restructures the values schema (canonical-v0.3 providers/routing/global); our values still speak 0.2, so the chart's own 0.3 component defaults win — including pullPolicy: Never, which breaks the router on any fresh node (ErrImageNeverPull -> every `model: MoM` request 404s). Renovate bumped this past a plain code comment (c00892eb) and it stayed invisible for five weeks, because running clusters kept already-pulled images. allowedVersions rather than enabled:false so 0.2.x patch and security releases still flow. Lift the bound in the same PR that migrates infrastructure/base/vllm-semantic-router/helmrelease.yaml to the 0.3 schema.",
       "matchPackageNames": [
         "ghcr.io/vllm-project/charts/semantic-router"

--- a/opentofu/openbao/cluster/variables.tf
+++ b/opentofu/openbao/cluster/variables.tf
@@ -22,11 +22,18 @@ variable "mode" {
 variable "openbao_version" {
   description = "OpenBao version to install"
   type        = string
-  # 2.6.0 deadlocks on concurrent namespace creation (openbao/openbao#3411):
-  # the management stack's parallel vault_namespace resources wedge the core
-  # and every subsequent request hangs. Stay on 2.5.5 until a fixed release.
+  # The whole 2.6 line deadlocks under the management stack's parallel writes
+  # (openbao/openbao#3411, still OPEN): namespace/mount/auth paths take the core
+  # RWMutex in inconsistent order, so a nested acquire wedges the core and every
+  # subsequent request hangs. Seen on 2.6.0 (namespace_store.go) and again on
+  # 2.6.2 (vault/auth.go:78 enableCredentialInternal, 2026-08-20). 2.5.5 is the
+  # last release predating it.
+  #
+  # The bound that actually enforces this is allowedVersions "<2.6.0" in
+  # .github/renovate.json — a comment does not gate a bot, and #1784 bumped
+  # straight past this one. Lift both in the same PR, once #3411 closes.
   # renovate: datasource=github-releases depName=openbao/openbao
-  default = "2.6.2"
+  default = "2.5.5"
 }
 
 variable "openbao_data_path" {

--- a/opentofu/openbao/cluster/variables.tf
+++ b/opentofu/openbao/cluster/variables.tf
@@ -22,18 +22,15 @@ variable "mode" {
 variable "openbao_version" {
   description = "OpenBao version to install"
   type        = string
-  # The whole 2.6 line deadlocks under the management stack's parallel writes
-  # (openbao/openbao#3411, still OPEN): namespace/mount/auth paths take the core
-  # RWMutex in inconsistent order, so a nested acquire wedges the core and every
-  # subsequent request hangs. Seen on 2.6.0 (namespace_store.go) and again on
-  # 2.6.2 (vault/auth.go:78 enableCredentialInternal, 2026-08-20). 2.5.5 is the
-  # last release predating it.
-  #
-  # The bound that actually enforces this is allowedVersions "<2.6.0" in
-  # .github/renovate.json — a comment does not gate a bot, and #1784 bumped
-  # straight past this one. Lift both in the same PR, once #3411 closes.
+  # Kept at the latest release. 2.6.x carries openbao/openbao#3411 (inconsistent
+  # lock ordering across namespaces, mounts and the router, still OPEN), which
+  # deadlocks the core when the management stack writes concurrently — but the
+  # concurrency is ours, not OpenBao's. The management stack now applies with
+  # -parallelism=1 (opentofu/openbao/management/workflows.tm.hcl), which clears
+  # it; see the reproduction recorded there. Do not raise that parallelism while
+  # #3411 is open.
   # renovate: datasource=github-releases depName=openbao/openbao
-  default = "2.5.5"
+  default = "2.6.2"
 }
 
 variable "openbao_data_path" {

--- a/opentofu/openbao/management/pki.tf
+++ b/opentofu/openbao/management/pki.tf
@@ -32,6 +32,14 @@ resource "vault_pki_secret_backend_intermediate_cert_request" "this" {
 
 # Sign our CSR
 resource "vault_pki_secret_backend_root_sign_intermediate" "this" {
+  # Ordering here was previously luck. Nothing tied this to config_ca, so the
+  # graph was free to call root/sign-intermediate before the root CA bundle had
+  # been imported into the mount. At the old default parallelism the two raced
+  # and config_ca happened to win; serialising the stack (-parallelism=1, see
+  # workflows.tm.hcl) made Terraform pick the other order and it failed with
+  # `no default issuer currently configured` (HTTP 500).
+  depends_on = [vault_pki_secret_backend_config_ca.pki]
+
   backend              = vault_mount.pki.path
   csr                  = vault_pki_secret_backend_intermediate_cert_request.this.csr
   common_name          = var.pki_common_name

--- a/opentofu/openbao/management/workflows.tm.hcl
+++ b/opentofu/openbao/management/workflows.tm.hcl
@@ -91,7 +91,9 @@ script "destroy" {
       # Needed even to tear down: the provider still has to configure before it
       # can plan the destroy.
       global.openbao_ca_cmd.args,
-      [global.provisioner, "destroy", "-auto-approve", "-var-file=variables.tfvars"],
+      # Same #3411 race on the way down — mounts and namespaces are deleted
+      # concurrently otherwise. See the apply job below.
+      [global.provisioner, "destroy", "-auto-approve", "-parallelism=1", "-var-file=variables.tfvars"],
     ]
   }
 }
@@ -146,7 +148,26 @@ script "deploy" {
       [global.provisioner, "validate"],
       [global.provisioner, "plan", "-out=out.tfplan", "-lock=false", "-var-file=variables.tfvars"],
       ["trivy", "config", "--exit-code=1", "--ignorefile=./.trivyignore.yaml", "."],
-      [global.provisioner, "apply", "-auto-approve", "-var-file=variables.tfvars",
+      # -parallelism=1 is load-bearing, not caution.
+      #
+      # OpenBao 2.6.x carries openbao/openbao#3411 — inconsistent lock ordering
+      # between the core mounts lock and the namespace lock. When this stack
+      # writes namespaces, auth backends and mounts concurrently, a nested
+      # acquire wedges the core: every write hangs, `bao status` times out even
+      # on 127.0.0.1, and the apply dies with `context deadline exceeded`.
+      #
+      # It needs BOTH concurrency and a small node, which is why it looks
+      # intermittent — reproduced locally against 2.6.2 on file storage, and the
+      # deciding variable is CPU:
+      #
+      #   unconstrained, -parallelism=10  -> applies clean, 0 deadlocks
+      #   1 core + GOMAXPROCS=2, -p=10    -> 3 deadlock markers, core wedged
+      #   1 core + GOMAXPROCS=2, -p=1     -> applies clean, 0 deadlocks
+      #
+      # The dev cluster is a t3.micro, which is exactly the second row. Serialising
+      # this stack removes the race without pinning OpenBao to an old release.
+      # Raise this only after #3411 closes, and re-run the repro before you do.
+      [global.provisioner, "apply", "-auto-approve", "-parallelism=1", "-var-file=variables.tfvars",
         {
           sync_deployment = true
           tofu_plan_file  = "out.tfplan"


### PR DESCRIPTION
A from-scratch platform deploy fails. `opentofu/openbao/management` hangs and errors
with `context deadline exceeded` on `vault_auth_backend.approle` and
`vault_auth_backend.userpass`; the core is wedged and `bao status` times out **even on
127.0.0.1**, which rules out anything network-shaped.

```
OpenBao v2.6.2, committed 2026-08-18
POTENTIAL DEADLOCK:
  go-deadlock.(*RWMutex).Lock  <<<<<
  vault.(*Core).enableCredentialInternal   (vault/auth.go:78)
  vault.(*SystemBackend).handleEnableAuth  (logical_system.go:2344)
```

That is openbao/openbao#3411 — inconsistent lock ordering across namespaces, mounts and
the router — still open, zero comments, no fix release.

## The concurrency is ours, so the fix is ours

The obvious move was to pin back to 2.5.5 (the 2.6 line has bitten us twice: 2.6.0 in
`namespace_store.go`, 2.6.2 on the auth-mount path). This PR does **not** do that,
because the trigger turned out to be something we control.

Reproduced locally against 2.6.2 on `file` storage with a cut-down copy of this stack
(namespace + 3 auth backends + 2 mounts + 5 policies + the full PKI intermediate chain).
It takes **two** conditions, and CPU is the one that was never obvious:

| server | terraform | result |
|---|---|---|
| unconstrained | `-parallelism=10` | applies clean, 0 deadlock markers |
| 1 core, `GOMAXPROCS=2` | `-parallelism=10` | 3 deadlock markers, core wedged, `bao status` exit 124 |
| 1 core, `GOMAXPROCS=2` | `-parallelism=1` | applies clean, 0 deadlock markers |

On a normal machine 2.6.2 handles this workload fine — including applying immediately
after unseal, and with the PKI chain in the mix. The dev cluster is a `t3.micro`, which
is row 2 exactly. That is also why it reads as intermittent.

So: **stay on the latest release, serialise this one stack.**

- `opentofu/openbao/cluster/variables.tf` — 2.6.2, the current latest.
- `.github/renovate.json` — the openbao `allowedVersions` rule is **removed**; upgrades
  flow normally again.
- `opentofu/openbao/management/workflows.tm.hcl` — `-parallelism=1` on both apply and
  destroy (mounts and namespaces are deleted concurrently on the way down too), with the
  reproduction recorded inline so nobody raises it back without re-testing.

Only this stack is serialised; it is ~26 resources and mostly instant writes.

## Note on the guard that failed

#1667 pinned 2.5.5 but expressed the intent as a **comment** in `variables.tf` plus a
Renovate bound of `!/^2\.6\.0$/` — "block 2.6.0 only". #3411 is a branch-level bug, so
2.6.1 and 2.6.2 (#1784) were legal bumps, the comment gated nothing, and the pin expired
silently. Worth remembering the next time we block a version: bound the branch you
distrust, not the one release you happened to observe, and put the bound where the bot
reads it. (The semantic-router rule below it has the same history — bumped past a plain
code comment in c00892eb, invisible for five weeks.)

## Verification

Ran end to end against the real cluster: brand-new `t3.micro` node on 2.6.2, empty
state, full `terramate script run deploy`.

```
$ bao version
OpenBao v2.6.2 (dd9c19c37a878cf4a81b18efb8d6f0599c7da923), committed 2026-08-18

$ journalctl -u openbao | grep -c 'POTENTIAL DEADLOCK'
0                                     # the wedged 2.6.2 node had 2

$ bao status                          # on 127.0.0.1
Seal Type       awskms
Initialized     true
Sealed          false
exit=0                                # the wedged node timed out here (124)

$ tofu apply -parallelism=1
Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

$ tofu plan
No changes. Your infrastructure matches the configuration.
```

24 Vault resources in state, including `vault_namespace.app`, `vault_mount.{pki,app_secret}`,
`vault_auth_backend.{approle,approle_app,userpass}` and the full PKI chain — i.e. every
resource that previously hung with `context deadline exceeded`.

### Honest note on the run

It took three attempts, and the first two failures were **my** doing, not the change:
I replaced the node underneath a live state, which left `vault_*` entries pointing at a
server that no longer existed (`namespace not found` on a policy delete, then `path is
already in use` after I cleared state but the server kept its mounts). A normal
destroy-then-deploy does not hit either, because destroy empties state. The third run
— fresh node, empty state — is the one quoted above.

Neither of those failures was `context deadline exceeded`, and no deadlock markers
appeared in any of the three runs.


## Commits

- `2ddde87c` — 2.6.2, Renovate bound removed, `-parallelism=1` on apply and destroy
- `647e2b2e` — `depends_on` ordering the CA import before `root/sign-intermediate`
